### PR TITLE
docs: add product roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Pull requests and pushes to `main` are checked by the Floorp iOS GitHub Actions 
 
 The release and TestFlight foundation, current signing blockers, and Apple account setup checklist are documented in [docs/ci-cd.md](docs/ci-cd.md). Inherited Mozilla/Focus automation was removed from the active workflow directory; it remains recoverable from Git history if a Floorp-owned replacement is needed.
 
+## Development Roadmap
+
+Product work proceeds through small, testable milestones beginning with
+Floorp Notes Local v1. See [docs/roadmap.md](docs/roadmap.md) for scope,
+ordering, and exit criteria.
+
 ## Upstream Sync
 
 This repository tracks [mozilla-mobile/firefox-ios](https://github.com/mozilla-mobile/firefox-ios) as upstream. After merging upstream changes, the Floorp branding must be re-applied using the automated rebrand script.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,6 +1,6 @@
 # Floorp for iOS CI/CD
 
-This document defines the delivery foundation for Floorp for iOS. The repository now has a reproducible pull-request gate and a dedicated unsigned release-archive path. Signed delivery still requires Apple account setup, retained main-app capabilities, and service ownership to be finalized.
+This document defines the delivery foundation for Floorp for iOS. The repository has a reproducible pull-request gate, a dedicated release configuration, and a validated signed Internal TestFlight baseline. Repeatable cloud delivery, retained main-app capabilities, and service ownership still need to be finalized before public distribution.
 
 ## Architecture
 
@@ -8,11 +8,18 @@ This document defines the delivery foundation for Floorp for iOS. The repository
 | --- | --- | --- |
 | Pull-request build and unit tests | GitHub Actions | Implemented in `.github/workflows/ci.yml` |
 | Upstream Firefox synchronization | GitHub Actions | Weekly PR workflow with a workflow allowlist and explicit CI dispatch |
-| Signed archive and internal TestFlight | Xcode Cloud | Release scaffold implemented; workflow and signing not yet configured or validated |
+| Signed archive and internal TestFlight | Manual Xcode upload | `0.1.0 (1)` signed, uploaded, and verified by the internal group |
+| Repeatable signed delivery | Xcode Cloud | Scaffold implemented; workflow not yet configured |
 | App Store release | App Store Connect | Manual approval initially |
 | Mozilla/Focus maintenance automation | Git history | Removed pending a Floorp-owned replacement |
 
-GitHub Actions never receives an Apple certificate or private key in this first stage. Xcode Cloud is the preferred first CD system because it supports cloud-managed signing and direct TestFlight distribution.
+GitHub Actions does not receive an Apple certificate or private key. The first build was uploaded manually from a locally signed archive. Xcode Cloud remains the preferred repeatable CD system because it supports cloud-managed signing and direct TestFlight distribution.
+
+### Validated Internal TestFlight baseline
+
+On August 1, 2026, Floorp `0.1.0 (1)` was signed by Team `DV2U35YBHT`, uploaded to App Store Connect app `6796708699`, processed successfully, assigned to the `Floorp Internal` group, and installed by an internal tester. App Store Connect read `ITSAppUsesNonExemptEncryption=false` as “Uses non-exempt encryption: No.”
+
+The upload reported a non-blocking missing dSYM warning for `Glean.framework`. Resolve that warning before relying on production crash symbolication.
 
 ## CI contract
 
@@ -111,11 +118,11 @@ The primary classic and Liquid Glass icon sources already render the Floorp logo
 
 ## Apple account checklist
 
-Complete these steps before enabling Xcode Cloud distribution:
+Complete the remaining unchecked steps before enabling repeatable Xcode Cloud distribution or public beta delivery:
 
 - [ ] Decide whether the Apple Developer account is permanently owned by a Floorp organization or an individual; avoid a later transfer if possible.
 - [x] Confirm the Apple Developer Team ID: `DV2U35YBHT`.
-- [ ] Confirm an App Store Connect Account Holder, Admin, App Manager, or Developer with Create Apps permission can perform setup.
+- [x] Confirm an App Store Connect Account Holder, Admin, App Manager, or Developer with Create Apps permission can perform setup.
 - [ ] Confirm a GitHub organization owner can authorize the initial Xcode Cloud connection.
 - [ ] Accept all current Apple Developer and App Store Connect agreements.
 - [x] Create or confirm the `app.floorp.Floorp` App ID.
@@ -128,12 +135,12 @@ Complete these steps before enabling Xcode Cloud distribution:
 - [ ] Request the default-browser managed entitlement.
 - [x] Omit the browser app-installation entitlement from the initial release configuration.
 - [ ] Choose the Floorp marketing-version policy and initial version.
-- [ ] Create the Floorp app record in App Store Connect.
+- [x] Create the Floorp app record in App Store Connect (`6796708699`).
 - [ ] Set `FLOORP_APP_STORE_ID` after App Store Connect assigns Floorp's numeric Apple ID.
 - [ ] Replace remaining inherited main-app branding; review extension branding before any extension is restored.
-- [ ] Create an internal TestFlight group.
+- [x] Create the `Floorp Internal` TestFlight group and add the initial tester.
 - [ ] Assign an owner and safe client-side value for each external service setting used by the release configuration.
-- [ ] Produce a signed `Floorp` archive and pass Organizer validation.
+- [x] Produce a signed `Floorp` archive, upload it, and install the processed build through Internal TestFlight.
 
 Do not commit certificates, provisioning profiles, `.p8` API keys, `.p12` files, or passwords.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,118 @@
+# Floorp for iOS Roadmap
+
+This roadmap turns the validated `0.1.0 (1)` internal TestFlight baseline into
+small, reviewable product milestones. Work should proceed in order unless a
+release-blocking regression requires reprioritization.
+
+## Current baseline
+
+- The main Floorp app builds, signs, uploads, installs, and runs through
+  Internal TestFlight.
+- GitHub Actions builds the inherited browser and runs the `FloorpCI` test
+  plan on pull requests and pushes to `main`.
+- Floorp Notes supports local create, edit, search, delete, persistence,
+  corruption recovery, and safe read-only projection of unsupported desktop
+  rich-text content.
+- Notes are local to one device. Push, hosted summarization, and all app
+  extensions remain disabled in `FloorpRelease`.
+
+## Milestone 0.2.0 — Floorp Notes Local v1
+
+Goal: make local Notes safe and predictable enough for daily internal use
+before adding cloud synchronization.
+
+Tracking: [GitHub milestone](https://github.com/Floorp-Projects/floorp-ios/milestone/1)
+
+- [#20 Prevent untouched Floorp Notes drafts from persisting](https://github.com/Floorp-Projects/floorp-ios/issues/20)
+- [#21 Extract testable Floorp Notes editor save state and coordination](https://github.com/Floorp-Projects/floorp-ios/issues/21)
+- [#22 Add recovery UI for Floorp Notes conflicts and save failures](https://github.com/Floorp-Projects/floorp-ios/issues/22)
+- [#23 Add validated JSON export and import for Floorp Notes](https://github.com/Floorp-Projects/floorp-ios/issues/23)
+- [#24 Add Floorp Notes unit and UI regression coverage](https://github.com/Floorp-Projects/floorp-ios/issues/24)
+- [#25 Prepare and verify Floorp 0.2.0 in Internal TestFlight](https://github.com/Floorp-Projects/floorp-ios/issues/25)
+
+### Work items
+
+1. Prevent an untouched new-note draft from leaving an empty persisted note.
+2. Extract the editor save state and Notes-specific drawer coordination behind
+   testable boundaries without rewriting the whole drawer.
+3. Replace generic save failures with actionable handling for edit conflicts,
+   deleted notes, oversized archives, and persistence errors.
+4. Offer conflict recovery actions such as reload, save as a copy, and keep
+   editing without silently overwriting another window's changes.
+5. Expose validated JSON export and import, including a way to retrieve a
+   preserved corruption backup.
+6. Add unit coverage for editor autosave, lifecycle saves, conversion,
+   failure, conflict, and currently unused store operations.
+7. Add a Floorp Notes UI smoke test covering create, edit, search, delete, and
+   relaunch persistence.
+8. Verify the flow in English and Japanese on iPhone and iPad, including basic
+   Dynamic Type, VoiceOver, and multiple-window checks.
+
+### Exit criteria
+
+- Backgrounding, closing, relaunching, and concurrent windows do not cause
+  silent data loss.
+- TipTap and Lexical source content stays byte-for-byte unchanged until the
+  user explicitly approves conversion to plain text.
+- Core Notes behavior is covered by deterministic unit tests and one stable UI
+  smoke path in CI or a dedicated scheduled workflow.
+- `0.2.0` passes Internal TestFlight verification.
+
+## Milestone 0.3.0 — Desktop interoperability and sync design
+
+Goal: define a safe cross-device contract before implementing remote sync.
+
+### Work items
+
+1. Record an ADR covering service ownership, authentication, transport,
+   retention, encryption assumptions, and operational responsibility.
+2. Define a versioned Notes schema with stable identifiers, tombstones for
+   deletions, deterministic conflict rules, and clock-skew handling.
+3. Round-trip the desktop parallel-array payload through export and import
+   without losing unknown rich-text nodes.
+4. Prototype offline create, update, and delete conflicts before selecting a
+   production backend.
+5. Decide how the feature relates to Firefox Accounts; the inherited iOS Sync
+   manager does not currently expose a Notes or preferences engine.
+
+### Exit criteria
+
+- Desktop and iOS fixtures round-trip without destructive conversion.
+- Concurrent offline updates and deletions have documented, tested outcomes.
+- No production network path is enabled until its owner and privacy contract
+  are explicit.
+
+## Milestone 0.4.0 — Floorp browser differentiation
+
+Goal: make the product visibly useful beyond the inherited Firefox baseline.
+
+Candidate work, ordered after Notes stability:
+
+1. Save the current page title, URL, or selected text into Floorp Notes.
+2. Implement custom web panels and a panel-management UI.
+3. Finish Floorp-specific onboarding, settings, branding, and localization.
+4. Restore app extensions one at a time, beginning with the Share extension,
+   after capability, branding, signing, and test review.
+
+## External beta and App Store gates
+
+These are release gates rather than prerequisites for Notes development:
+
+- Make signed delivery repeatable through Xcode Cloud or another explicitly
+  owned CD path.
+- Resolve missing third-party dSYMs needed for useful crash symbolication.
+- Complete the retained endpoint, privacy manifest, App Privacy, and branding
+  review.
+- Confirm the default-browser entitlement and remaining export-compliance
+  obligations.
+- Validate external TestFlight metadata and Beta App Review before inviting
+  external testers.
+
+## Working agreement
+
+- Keep Floorp-specific code concentrated under `firefox-ios/Floorp` and use
+  narrow upstream hook points.
+- Deliver each work item as a small pull request with tests and explicit
+  acceptance criteria.
+- Do not remove a passing test from `FloorpCI` to hide a regression.
+- Re-run Internal TestFlight at the end of each product milestone.


### PR DESCRIPTION
## Summary

- add a milestone-based product roadmap beginning with Floorp Notes Local v1
- link the roadmap from the repository README
- update the CI/CD document with the validated 0.1.0 Internal TestFlight baseline
- link the 0.2.0 milestone and tracking issues #20–#25

## Why

The build and internal delivery foundation is now validated. This change records the next product-development sequence and gives each Notes Local v1 work item explicit acceptance criteria before feature implementation starts.

## Impact

Documentation only. No application, build configuration, signing, or workflow behavior changes.

## Verification

- `git diff main...HEAD --check`
- confirmed milestone 1 contains six open tracking issues
- confirmed the commit contains only `README.md`, `docs/ci-cd.md`, and `docs/roadmap.md`
