### PR TITLE
fix: defer persistence for untouched Notes drafts

### DIFF
--- a/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
+++ b/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
@@ -89,6 +89,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     private var didApprovePlainTextConversion: Bool
     private var changeVersion = 0
     private var savedVersion = 0
+    private var hasPersistedNote: Bool
     private var isSaving = false
     private var saveWaiters = [CheckedContinuation<Void, Never>]()
     private var autosaveTask: Task<Void, Never>?
@@ -141,6 +142,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
         windowUUID: WindowUUID,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         notificationCenter: NotificationProtocol = NotificationCenter.default,
+        isPersisted: Bool = true,
         onSave: @escaping @MainActor (FloorpNote) async throws -> FloorpNote
     ) {
         let contentAnalysis = FloorpNoteContent.analyze(note.content)
@@ -150,6 +152,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.hasPersistedNote = isPersisted
         self.onSave = onSave
         super.init(nibName: nil, bundle: nil)
     }
@@ -274,9 +277,23 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
 
     @objc private func saveTapped() {
         Task { @MainActor in
-            autosaveTask?.cancel()
-            _ = await saveLatestDraft()
+            _ = await saveForExplicitRequest()
         }
+    }
+
+    /// Saves in response to an explicit user request.
+    ///
+    /// An untouched new draft has no content change to autosave, but choosing
+    /// Save is still an instruction to create it. Advancing the version also
+    /// keeps a failed first save pending so it can be retried before dismissal.
+    @discardableResult
+    func saveForExplicitRequest() async -> Bool {
+        autosaveTask?.cancel()
+        if !hasPersistedNote && savedVersion == changeVersion {
+            changeVersion += 1
+            setInteractiveDismissalBlocked(true)
+        }
+        return await saveLatestDraft()
     }
 
     @objc private func closeTapped() {
@@ -340,6 +357,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
             do {
                 let persistedNote = try await onSave(noteToSave)
                 savedVersion = versionToSave
+                hasPersistedNote = true
                 // Keep edits made while this save was in flight, but adopt the
                 // real identity assigned when a new draft is first persisted.
                 draft = FloorpNote(

--- a/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
+++ b/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
@@ -6,6 +6,58 @@ import UIKit
 import Common
 import Shared
 
+/// Owns the persistence identity for one editor session.
+///
+/// New drafts stay in memory until the editor reports its first change. Once
+/// created, every later save uses the last persisted revision so concurrent
+/// edits continue to be rejected by `FloorpNotesStore`.
+@MainActor
+final class FloorpNotePersistenceSession {
+    private let notesStore: FloorpNotesStore
+    private var persistedNote: FloorpNote?
+    private var isSaving = false
+    private var saveWaiters = [CheckedContinuation<Void, Never>]()
+
+    init(notesStore: FloorpNotesStore, persistedNote: FloorpNote?) {
+        self.notesStore = notesStore
+        self.persistedNote = persistedNote
+    }
+
+    func save(_ draft: FloorpNote) async throws -> FloorpNote {
+        if isSaving {
+            await withCheckedContinuation { continuation in
+                saveWaiters.append(continuation)
+            }
+            return try await save(draft)
+        }
+
+        isSaving = true
+        defer {
+            isSaving = false
+            let waiters = saveWaiters
+            saveWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        let savedNote: FloorpNote
+        if let persistedNote {
+            savedNote = try await notesStore.updateNote(
+                id: persistedNote.id,
+                title: draft.title,
+                content: draft.content,
+                expectedUpdatedAt: persistedNote.updatedAt
+            )
+        } else {
+            savedNote = try await notesStore.createNote(
+                title: draft.title,
+                content: draft.content
+            )
+        }
+        persistedNote = savedNote
+        return savedNote
+    }
+}
+
 /// Native, local-first editor for a single Floorp note.
 ///
 /// Plain text is fully editable. Rich TipTap/Lexical content remains byte-for-
@@ -288,7 +340,15 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
             do {
                 let persistedNote = try await onSave(noteToSave)
                 savedVersion = versionToSave
-                draft.updatedAt = persistedNote.updatedAt
+                // Keep edits made while this save was in flight, but adopt the
+                // real identity assigned when a new draft is first persisted.
+                draft = FloorpNote(
+                    id: persistedNote.id,
+                    title: draft.title,
+                    content: draft.content,
+                    createdAt: persistedNote.createdAt,
+                    updatedAt: persistedNote.updatedAt
+                )
                 lastAttemptSucceeded = true
                 if savedVersion == changeVersion {
                     updateSaveState(.saved)

--- a/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
+++ b/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
@@ -832,7 +832,8 @@ final class FloorpOverlayDrawerViewController: UIViewController, Themeable {
             note: note,
             windowUUID: windowUUID,
             themeManager: themeManager,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            isPersisted: isPersisted
         ) { updatedNote in
             try await persistenceSession.save(updatedNote)
         }

--- a/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
+++ b/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
@@ -786,19 +786,20 @@ final class FloorpOverlayDrawerViewController: UIViewController, Themeable {
         guard !isCreatingNote else { return }
         isCreatingNote = true
         addNoteButton.isEnabled = false
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer {
-                isCreatingNote = false
-                addNoteButton.isEnabled = currentPanelType == .notes && !isCreatingNote
-            }
-            do {
-                let note = try await notesStore.createNote(title: FloorpStrings.Notes.newNote)
-                presentNoteEditor(note)
-            } catch {
-                presentOperationError()
-            }
+        defer {
+            isCreatingNote = false
+            addNoteButton.isEnabled = currentPanelType == .notes && !isCreatingNote
         }
+
+        let timestamp = FloorpNotesStore.currentTimeInMilliseconds()
+        let draft = FloorpNote(
+            id: UUID().uuidString,
+            title: FloorpStrings.Notes.newNote,
+            content: "",
+            createdAt: timestamp,
+            updatedAt: timestamp
+        )
+        presentNoteEditor(draft, isPersisted: false)
     }
 
     @objc private func notesDidChange() {
@@ -821,21 +822,19 @@ final class FloorpOverlayDrawerViewController: UIViewController, Themeable {
         }
     }
 
-    private func presentNoteEditor(_ note: FloorpNote) {
+    private func presentNoteEditor(_ note: FloorpNote, isPersisted: Bool = true) {
         guard presentedViewController == nil else { return }
-        let notesStore = notesStore
+        let persistenceSession = FloorpNotePersistenceSession(
+            notesStore: notesStore,
+            persistedNote: isPersisted ? note : nil
+        )
         let editor = FloorpNoteEditorViewController(
             note: note,
             windowUUID: windowUUID,
             themeManager: themeManager,
             notificationCenter: notificationCenter
         ) { updatedNote in
-            try await notesStore.updateNote(
-                id: updatedNote.id,
-                title: updatedNote.title,
-                content: updatedNote.content,
-                expectedUpdatedAt: updatedNote.updatedAt
-            )
+            try await persistenceSession.save(updatedNote)
         }
         editor.navigationItem.prompt = FloorpStrings.Notes.localOnly
         let navigationController = UINavigationController(rootViewController: editor)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -358,9 +358,19 @@ final class FloorpNotePersistenceSessionTests: XCTestCase {
         let firstDraft = makeDraft(title: "First", content: "A")
         let secondDraft = makeDraft(title: "Second", content: "B")
 
-        async let firstSave = session.save(firstDraft)
-        async let secondSave = session.save(secondDraft)
-        let (firstSaved, secondSaved) = try await (firstSave, secondSave)
+        let firstSave = Task { @MainActor in
+            try await session.save(firstDraft)
+        }
+        let secondSave = Task { @MainActor in
+            try await session.save(secondDraft)
+        }
+        defer {
+            firstSave.cancel()
+            secondSave.cancel()
+        }
+
+        let firstSaved = try await firstSave.value
+        let secondSaved = try await secondSave.value
         let notes = try await store.loadNotes()
 
         XCTAssertEqual(firstSaved.id, secondSaved.id)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -311,6 +311,95 @@ final class FloorpNotesStoreTests: XCTestCase, @unchecked Sendable {
 }
 
 @MainActor
+final class FloorpNoteEditorViewControllerTests: XCTestCase {
+    func testExplicitSavePersistsUntouchedNewDraftOnlyOnce() async {
+        let draft = makeDraft()
+        var savedDrafts = [FloorpNote]()
+        let editor = makeEditor(note: draft, isPersisted: false) { note in
+            savedDrafts.append(note)
+            return FloorpNote(
+                id: "persisted-id",
+                title: note.title,
+                content: note.content,
+                createdAt: 1_000,
+                updatedAt: 1_000
+            )
+        }
+
+        let firstSaveSucceeded = await editor.saveForExplicitRequest()
+        let secondSaveSucceeded = await editor.saveForExplicitRequest()
+
+        XCTAssertTrue(firstSaveSucceeded)
+        XCTAssertTrue(secondSaveSucceeded)
+        XCTAssertEqual(savedDrafts, [draft])
+    }
+
+    func testExplicitSaveDoesNotRewriteUntouchedExistingNote() async {
+        var saveCount = 0
+        let editor = makeEditor(note: makeDraft(), isPersisted: true) { note in
+            saveCount += 1
+            return note
+        }
+
+        let saveSucceeded = await editor.saveForExplicitRequest()
+
+        XCTAssertTrue(saveSucceeded)
+        XCTAssertEqual(saveCount, 0)
+    }
+
+    func testFailedExplicitSaveOfUntouchedDraftCanRetry() async {
+        var saveCount = 0
+        let editor = makeEditor(note: makeDraft(), isPersisted: false) { note in
+            saveCount += 1
+            guard saveCount > 1 else { throw SaveError.expected }
+            return FloorpNote(
+                id: "persisted-id",
+                title: note.title,
+                content: note.content,
+                createdAt: 1_000,
+                updatedAt: 1_000
+            )
+        }
+
+        let firstSaveSucceeded = await editor.saveForExplicitRequest()
+        let retrySucceeded = await editor.saveForExplicitRequest()
+
+        XCTAssertFalse(firstSaveSucceeded)
+        XCTAssertTrue(retrySucceeded)
+        XCTAssertEqual(saveCount, 2)
+    }
+
+    private func makeEditor(
+        note: FloorpNote,
+        isPersisted: Bool,
+        onSave: @escaping @MainActor (FloorpNote) async throws -> FloorpNote
+    ) -> FloorpNoteEditorViewController {
+        FloorpNoteEditorViewController(
+            note: note,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: MockThemeManager(),
+            notificationCenter: MockNotificationCenter(),
+            isPersisted: isPersisted,
+            onSave: onSave
+        )
+    }
+
+    private func makeDraft() -> FloorpNote {
+        FloorpNote(
+            id: "draft-id",
+            title: "New Note",
+            content: "",
+            createdAt: 500,
+            updatedAt: 500
+        )
+    }
+
+    private enum SaveError: Error {
+        case expected
+    }
+}
+
+@MainActor
 final class FloorpNotePersistenceSessionTests: XCTestCase {
     func testNewDraftDoesNotPersistBeforeFirstSave() async throws {
         let location = makeTemporaryArchiveLocation()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -311,6 +311,145 @@ final class FloorpNotesStoreTests: XCTestCase, @unchecked Sendable {
 }
 
 @MainActor
+final class FloorpNotePersistenceSessionTests: XCTestCase {
+    func testNewDraftDoesNotPersistBeforeFirstSave() async throws {
+        let location = makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        _ = FloorpNotePersistenceSession(notesStore: store, persistedNote: nil)
+
+        let notes = try await store.loadNotes()
+        XCTAssertTrue(notes.isEmpty)
+    }
+
+    func testFirstSaveCreatesAndSubsequentSaveUpdatesSameNote() async throws {
+        let location = makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(
+            fileURL: location.archive,
+            now: { 1_000 },
+            makeID: { "persisted-id" }
+        )
+        let session = FloorpNotePersistenceSession(notesStore: store, persistedNote: nil)
+        var draft = makeDraft(title: "First", content: "Body")
+
+        let created = try await session.save(draft)
+        XCTAssertEqual(created.id, "persisted-id")
+
+        draft.title = "Updated"
+        draft.content = "New body"
+        let updated = try await session.save(draft)
+        let restartedStore = FloorpNotesStore(fileURL: location.archive)
+        let notes = try await restartedStore.loadNotes()
+
+        XCTAssertEqual(updated.id, created.id)
+        XCTAssertGreaterThan(updated.updatedAt, created.updatedAt)
+        XCTAssertEqual(notes, [updated])
+    }
+
+    func testConcurrentFirstSavesCreateOneNote() async throws {
+        let location = makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive, now: { 1_000 })
+        let session = FloorpNotePersistenceSession(notesStore: store, persistedNote: nil)
+        let firstDraft = makeDraft(title: "First", content: "A")
+        let secondDraft = makeDraft(title: "Second", content: "B")
+
+        async let firstSave = session.save(firstDraft)
+        async let secondSave = session.save(secondDraft)
+        let (firstSaved, secondSaved) = try await (firstSave, secondSave)
+        let notes = try await store.loadNotes()
+
+        XCTAssertEqual(firstSaved.id, secondSaved.id)
+        XCTAssertEqual(notes.count, 1)
+        let finalNote = try XCTUnwrap(notes.first)
+        XCTAssertTrue(finalNote == firstSaved || finalNote == secondSaved)
+    }
+
+    func testFailedFirstSaveCanRetryWithoutDuplicate() async throws {
+        let location = makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(
+            fileURL: location.archive,
+            makeID: { "persisted-id" }
+        )
+        let session = FloorpNotePersistenceSession(notesStore: store, persistedNote: nil)
+        var draft = makeDraft(
+            title: "Too large",
+            content: String(repeating: "x", count: FloorpNotesStore.maximumArchiveBytes)
+        )
+
+        do {
+            _ = try await session.save(draft)
+            XCTFail("Expected archiveTooLarge")
+        } catch FloorpNotesStoreError.archiveTooLarge {
+            // Expected.
+        }
+        let notesAfterFailure = try await store.loadNotes()
+        XCTAssertTrue(notesAfterFailure.isEmpty)
+
+        draft.title = "Retry"
+        draft.content = "Saved"
+        let saved = try await session.save(draft)
+        let notesAfterRetry = try await store.loadNotes()
+
+        XCTAssertEqual(saved.id, "persisted-id")
+        XCTAssertEqual(notesAfterRetry, [saved])
+    }
+
+    func testExistingNoteSessionPreservesConflictDetection() async throws {
+        let location = makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(
+            fileURL: location.archive,
+            now: { 1_000 },
+            makeID: { "persisted-id" }
+        )
+        let original = try await store.createNote(title: "Original")
+        let session = FloorpNotePersistenceSession(notesStore: store, persistedNote: original)
+        let otherWindowEdit = try await store.updateNote(
+            id: original.id,
+            title: "Other window",
+            content: "Keep this",
+            expectedUpdatedAt: original.updatedAt
+        )
+        var staleDraft = original
+        staleDraft.title = "Stale editor"
+
+        do {
+            _ = try await session.save(staleDraft)
+            XCTFail("Expected editConflict")
+        } catch FloorpNotesStoreError.editConflict(let id) {
+            XCTAssertEqual(id, original.id)
+        }
+
+        let notes = try await store.loadNotes()
+        XCTAssertEqual(notes, [otherWindowEdit])
+    }
+
+    private func makeDraft(title: String, content: String) -> FloorpNote {
+        FloorpNote(
+            id: "draft-id",
+            title: title,
+            content: content,
+            createdAt: 500,
+            updatedAt: 500
+        )
+    }
+
+    private func makeTemporaryArchiveLocation() -> (directory: URL, archive: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpNoteSessionTests-\(UUID().uuidString)", isDirectory: true)
+        return (directory, directory.appendingPathComponent("notes.json"))
+    }
+}
+
+@MainActor
 final class FloorpPanelNotesMigrationTests: XCTestCase {
     func testLegacyPanelConfigurationReceivesNotesExactlyOnce() throws {
         let suiteName = "FloorpPanelNotesMigrationTests-\(UUID().uuidString)"

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -117,6 +117,11 @@
     },
     {
       "selectedTests" : [
+        "FloorpNotePersistenceSessionTests\/testConcurrentFirstSavesCreateOneNote()",
+        "FloorpNotePersistenceSessionTests\/testExistingNoteSessionPreservesConflictDetection()",
+        "FloorpNotePersistenceSessionTests\/testFailedFirstSaveCanRetryWithoutDuplicate()",
+        "FloorpNotePersistenceSessionTests\/testFirstSaveCreatesAndSubsequentSaveUpdatesSameNote()",
+        "FloorpNotePersistenceSessionTests\/testNewDraftDoesNotPersistBeforeFirstSave()",
         "FloorpNotesStoreTests\/testCRUDPersistsAcrossStoreInstancesIncludingEmptyArchive()",
         "FloorpNotesStoreTests\/testConcurrentUpdatesToDifferentNotesDoNotOverwriteEachOther()",
         "FloorpNotesStoreTests\/testCorruptArchiveIsPreservedAndRequiresExplicitReset()",

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -117,6 +117,9 @@
     },
     {
       "selectedTests" : [
+        "FloorpNoteEditorViewControllerTests\/testExplicitSaveDoesNotRewriteUntouchedExistingNote()",
+        "FloorpNoteEditorViewControllerTests\/testExplicitSavePersistsUntouchedNewDraftOnlyOnce()",
+        "FloorpNoteEditorViewControllerTests\/testFailedExplicitSaveOfUntouchedDraftCanRetry()",
         "FloorpNotePersistenceSessionTests\/testConcurrentFirstSavesCreateOneNote()",
         "FloorpNotePersistenceSessionTests\/testExistingNoteSessionPreservesConflictDetection()",
         "FloorpNotePersistenceSessionTests\/testFailedFirstSaveCanRetryWithoutDuplicate()",


### PR DESCRIPTION
## Summary

- Open a new Floorp Note as an in-memory draft instead of writing it immediately.
- Persist the draft on its first actual edit, then update the same stored note on later autosaves.
- Preserve edits made while the first save is in flight and serialize concurrent first saves.
- Add deterministic coverage for untouched drafts, first-save retry, relaunch persistence, concurrent creation, and stale-edit conflicts.

## Root cause

The Notes add action called `createNote` before presenting the editor. Closing an untouched editor therefore left a stored “New Note” entry even though the user had made no edit.

## Impact

Add → close without editing now leaves the note count unchanged. Once the user edits, existing autosave, background save, and conflict-detection behavior remains active.

## Validation

- `git diff --check`
- `jq empty firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan`
- Floorp Notes tests on iPhone 17 / iOS 26.5: 21 passed, 0 failed

The end-to-end Notes UI smoke paths, including Add → Close and Add → Edit → Relaunch, remain tracked in #24.

Closes #20
