### PR TITLE
Prepare Floorp 0.1.0 (2) internal TestFlight checkpoint

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -103,7 +103,7 @@ The Floorp release entitlement omits `com.apple.developer.browser.app-installati
 
 ### Versioning
 
-The checked-in release baseline is `0.1.0 (1)`. The main app and all extension Info.plists consume the shared marketing version and build number. Approve the independent Floorp marketing-version policy; Xcode Cloud can assign the monotonically increasing distribution build number for the initial TestFlight workflow.
+The last validated Internal TestFlight baseline is `0.1.0 (1)`, and the checked-in post-rebrand release candidate is `0.1.0 (2)`. The main app and all extension Info.plists consume the shared marketing version and build number. Approve the independent Floorp marketing-version policy; Xcode Cloud can assign monotonically increasing distribution build numbers after its TestFlight workflow is configured.
 
 ### Floorp-owned services and App Store ID
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -97,7 +97,7 @@ Adding Push later requires restoring that target where needed, production entitl
 
 ### Managed browser entitlements
 
-The app declares `com.apple.developer.web-browser`, which lets an approved app appear as a default browser. The Apple Account Holder must request and receive this managed capability.
+The private `0.1.0 (2)` Internal TestFlight candidate intentionally omits `com.apple.developer.web-browser`. Apple has not approved that managed capability for the Floorp App ID, so this build will not appear as a default-browser choice. Apple's request form requires an App Store build or a public TestFlight link, so the request is intentionally deferred while distribution remains private. When Floorp adopts external testing or public distribution, first provide an assessment build without the entitlement; after Apple approves the request, enable the capability for `app.floorp.Floorp`, regenerate the distribution profile, re-add the entitlement, and verify it in the signed archive.
 
 The Floorp release entitlement omits `com.apple.developer.browser.app-installation`, which is for installing alternative-distribution apps from a website. Add it only if Floorp deliberately adopts that distribution path and Apple approves the request.
 

--- a/firefox-ios/Client/Configuration/FloorpRelease.xcconfig
+++ b/firefox-ios/Client/Configuration/FloorpRelease.xcconfig
@@ -10,7 +10,7 @@
 // this team; certificates and provisioning profiles are never stored here.
 FLOORP_DEVELOPMENT_TEAM = DV2U35YBHT
 FLOORP_MARKETING_VERSION = 0.1.0
-FLOORP_BUILD_NUMBER = 1
+FLOORP_BUILD_NUMBER = 2
 // Keep empty until the public listing is live; otherwise Settings exposes a dead rating link.
 FLOORP_APP_STORE_ID =
 // Team-scoped because the shorter App Group is owned outside this Apple Developer team.

--- a/firefox-ios/Client/Entitlements/FloorpReleaseApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FloorpReleaseApplication.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>com.apple.developer.networking.multipath</key>
 	<true/>
-	<key>com.apple.developer.web-browser</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(FLOORP_APP_GROUP_IDENTIFIER)</string>

--- a/firefox-ios/TestFlight/WhatToTest.en-US.txt
+++ b/firefox-ios/TestFlight/WhatToTest.en-US.txt
@@ -1,7 +1,9 @@
 Floorp for iOS internal beta
 
+This is the post-rebrand 0.1.0 (2) checkpoint. Test both a clean install and an update from 0.1.0 (1). Confirm the Floorp name and icon on the Home Screen, in the app switcher, and throughout launch, onboarding, Home, Settings, About, and permission prompts. Open the Terms, Privacy, Support, and source/feedback links. Repeat the main paths in English and Japanese.
+
 Please focus on Floorp Notes: create, edit, delete, and search notes; restart the app and confirm notes persist; and check the readability of saved page text and links. Notes are currently stored on this device and are not included in Sync.
 
-Also smoke-test launch, normal and private browsing, tabs, and settings. Do not use production account credentials until Floorp's account-service ownership is confirmed.
+Also smoke-test normal and private browsing, tabs, settings, and the default-browser flow. Do not use production account credentials until Floorp's account-service ownership is confirmed.
 
 Known limitations: Push and cloud-hosted page summarization are disabled, app extensions are not included in this build, and Rate Floorp is hidden until the App Store listing is configured. On supported devices, Apple Intelligence page summarization remains available on-device.

--- a/firefox-ios/TestFlight/WhatToTest.en-US.txt
+++ b/firefox-ios/TestFlight/WhatToTest.en-US.txt
@@ -4,6 +4,6 @@ This is the post-rebrand 0.1.0 (2) checkpoint. Test both a clean install and an 
 
 Please focus on Floorp Notes: create, edit, delete, and search notes; restart the app and confirm notes persist; and check the readability of saved page text and links. Notes are currently stored on this device and are not included in Sync.
 
-Also smoke-test normal and private browsing, tabs, settings, and the default-browser flow. Do not use production account credentials until Floorp's account-service ownership is confirmed.
+Also smoke-test normal and private browsing, tabs, and settings. Do not use production account credentials until Floorp's account-service ownership is confirmed.
 
-Known limitations: Push and cloud-hosted page summarization are disabled, app extensions are not included in this build, and Rate Floorp is hidden until the App Store listing is configured. On supported devices, Apple Intelligence page summarization remains available on-device.
+Known limitations: Floorp cannot yet be selected as the default browser because its managed entitlement is not approved. Push and cloud-hosted page summarization are disabled, app extensions are not included in this build, and Rate Floorp is hidden until the App Store listing is configured. On supported devices, Apple Intelligence page summarization remains available on-device.

--- a/scripts/ci/check-floorp-branding.sh
+++ b/scripts/ci/check-floorp-branding.sh
@@ -815,6 +815,10 @@ require_fixed "$RELEASE_CONFIG" "MOZ_PUBLIC_URL_SCHEME = floorp" "Public URL sch
 require_fixed "$RELEASE_CONFIG" "MOZ_INTERNAL_URL_SCHEME = floorp-internal" "Internal URL scheme is fixed"
 
 require_fixed "$RELEASE_ENTITLEMENTS" "\$(AppIdentifierPrefix)app.floorp.Floorp" "Floorp keychain group is fixed"
+forbid_fixed_in_files \
+    "com.apple.developer.web-browser" \
+    "FloorpRelease omits the unapproved default-browser entitlement" \
+    "$RELEASE_ENTITLEMENTS"
 require_fixed "$RELEASE_PLIST" "\$(FLOORP_APP_GROUP_IDENTIFIER)" "Release plist uses the Floorp App Group setting"
 require_fixed "$RELEASE_PLIST" "app.floorp.sync.part1" "Background sync task 1 is fixed"
 require_fixed "$RELEASE_PLIST" "app.floorp.sync.part2" "Background sync task 2 is fixed"


### PR DESCRIPTION
## Summary

- increment the Floorp distribution build from `0.1.0 (1)` to `0.1.0 (2)`
- expand Internal TestFlight instructions for clean install, build 1 upgrade, rebranding, links, localization, and Floorp Notes coverage
- omit the unapproved `com.apple.developer.web-browser` entitlement from `FloorpRelease` and guard against its accidental reintroduction
- distinguish the last validated build from the checked-in post-rebrand candidate in the CI/CD documentation

## Why

App Store Connect already contains build 1, so the post-rebrand checkpoint needs a monotonically increasing build number. Apple has not approved the managed default-browser capability for `app.floorp.Floorp`, and its request requires an App Store build or public TestFlight link. This release remains private, so the request is deferred and the signing-incompatible entitlement is omitted.

This build is for the `Floorp Internal` group only. It is not an external TestFlight build, the incomplete 0.2.0 milestone, or a public App Store release.

## User and developer impact

Internal testers receive clearer coverage for the newly merged Floorp branding, Floorp Notes, and upgrade behavior from the existing TestFlight build. Floorp will not appear as a default-browser choice in build 2; the TestFlight notes document that limitation.

When public testing is deliberately adopted, an assessment build can be provided without the entitlement. After Apple approves the capability, the entitlement and distribution profile can be restored and verified together.

## Validation

- `plutil -lint firefox-ios/Client/Entitlements/FloorpReleaseApplication.entitlements`
- `./scripts/ci/check-floorp-branding.sh` with both ripgrep and portable grep backends
- `./scripts/ci/test-rebrand-dry-run.sh`
- `git diff --check`
- `xcodebuild -showBuildSettings` confirmed `APP_VERSION=0.1.0`, `CURRENT_PROJECT_VERSION=2`, `PRODUCT_BUNDLE_IDENTIFIER=app.floorp.Floorp`, Team `DV2U35YBHT`, `FloorpReleaseApplication.entitlements`, and fail-closed service settings

## Tracking

- Supports #28
- Precedes the 0.2.0 verification tracked in #25
