### PR TITLE
Add adaptive sidebar UI coverage

### DIFF
--- a/.github/workflows/adaptive-sidebar-ui.yml
+++ b/.github/workflows/adaptive-sidebar-ui.yml
@@ -1,0 +1,169 @@
+name: Floorp adaptive sidebar UI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/adaptive-sidebar-ui.yml
+      - .xcode-version
+      - BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+      - firefox-ios/Client/Application/AccessibilityIdentifiers.swift
+      - firefox-ios/Client/Application/UITestAppDelegate.swift
+      - firefox-ios/Floorp/**
+      - firefox-ios/Client/Frontend/Browser/BrowserViewController/**
+      - firefox-ios/Client/Frontend/Browser/Toolbars/**
+      - firefox-ios/Client.xcodeproj/project.pbxproj
+      - firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+      - firefox-ios/firefox-ios-tests/Tests/FloorpAdaptiveUI.xctestplan
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpAdaptiveSidebarUITests.swift
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: floorp-adaptive-sidebar-ui-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_PATH: firefox-ios/Client.xcodeproj
+  SCHEME: Fennec
+  CONFIGURATION: Fennec_Testing
+  SIMULATOR_OS: "26.2"
+
+jobs:
+  adaptive-sidebar-ui:
+    name: Adaptive sidebar UI (${{ matrix.simulator_name }})
+    runs-on: macos-26
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - simulator_name: iPhone 17
+            test_identifier: XCUITests/FloorpAdaptiveSidebarIPhoneUITests
+            artifact_suffix: iphone-17
+          - simulator_name: iPad (A16)
+            test_identifier: XCUITests/FloorpAdaptiveSidebarIPadUITests
+            artifact_suffix: ipad-a16
+    env:
+      SIMULATOR_NAME: ${{ matrix.simulator_name }}
+      ONLY_TESTING: ${{ matrix.test_identifier }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Select Xcode
+        run: |
+          xcode_version="$(<.xcode-version)"
+          sudo xcode-select --switch "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
+          xcodebuild -version
+          swift --version
+
+      - name: Bootstrap generated sources
+        run: ./bootstrap.sh firefox
+        env:
+          CI: "true"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
+      - name: Prepare iOS Simulator
+        timeout-minutes: 10
+        run: |
+          runtime="com.apple.CoreSimulator.SimRuntime.iOS-${SIMULATOR_OS//./-}"
+          simulator_id="$(
+            xcrun simctl list devices available --json \
+              | jq -er --arg runtime "$runtime" --arg name "$SIMULATOR_NAME" \
+                '.devices[$runtime] | map(select(.name == $name)) | first | .udid'
+          )"
+          simulator_arch="$(uname -m)"
+
+          xcrun simctl bootstatus "$simulator_id" -b
+          printf 'DESTINATION=platform=iOS Simulator,id=%s,arch=%s\n' \
+            "$simulator_id" "$simulator_arch" >> "$GITHUB_ENV"
+          printf 'Using %s (%s, %s)\n' "$SIMULATOR_NAME" "$simulator_id" "$simulator_arch"
+
+      - name: Build adaptive sidebar UI tests
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing -quiet \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -destination "$DESTINATION" \
+            -testPlan FloorpAdaptiveUI \
+            -only-testing:"$ONLY_TESTING" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/adaptive-ui-build.log"
+
+      - name: Run adaptive sidebar UI tests
+        timeout-minutes: 30
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -destination "$DESTINATION" \
+            -testPlan FloorpAdaptiveUI \
+            -only-testing:"$ONLY_TESTING" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 180 \
+            -maximum-test-execution-time-allowance 300 \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            -test-repetition-relaunch-enabled YES \
+            -resultBundlePath "$RUNNER_TEMP/FloorpAdaptiveUI.xcresult" \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/adaptive-ui-test.log"
+
+      - name: Upload adaptive sidebar evidence and diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: floorp-adaptive-ui-${{ matrix.artifact_suffix }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/adaptive-ui-build.log
+            ${{ runner.temp }}/adaptive-ui-test.log
+            ${{ runner.temp }}/FloorpAdaptiveUI.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -28,6 +28,8 @@ public struct LaunchArguments {
     public static let DisableAnimations = "DISABLE_ANIMATIONS"
     public static let ResetMicrosurveyExpirationCount = "RESET_MICROSURVEY_EXPIRATION_COUNT"
     public static let SkipAppleIntelligence = "SKIP_APPLE_INTELLIGENCE"
+    public static let SearchBarTop = "FIREFOX_SEARCH_BAR_TOP"
+    public static let SearchBarBottom = "FIREFOX_SEARCH_BAR_BOTTOM"
 
     // After the colon, put the name of the file to load from test bundle
     public static let LoadDatabasePrefix = "FIREFOX_LOAD_DB_NAMED:"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2803,6 +2804,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpAdaptiveSidebarUITests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13536,6 +13538,7 @@
 			children = (
 				5FE7F18C2E78224100B0AFEC /* PageScreens */,
 				5FE7F1852E781EB300B0AFEC /* Selectors */,
+				F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19570,6 +19573,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -577,6 +577,9 @@
       </CodeCoverageTargets>
       <TestPlans>
          <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FloorpAdaptiveUI.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
             reference = "container:firefox-ios-tests/Tests/FloorpCI.xctestplan">
          </TestPlanReference>
          <TestPlanReference

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -84,8 +84,16 @@ class UITestAppDelegate: AppDelegate {
             profile.prefs.setBool(true, forKey: PrefsKeys.KeyDidShowDefaultBrowserOnboarding)
         }
 
-        if launchArguments.contains(LaunchArguments.SkipTermsOfUse) {
-            profile.prefs.setBool(true, forKey: PrefsKeys.TermsOfUseAccepted)
+        if launchArguments.contains(LaunchArguments.SearchBarTop) {
+            profile.prefs.setString(
+                SearchBarPosition.top.rawValue,
+                forKey: PrefsKeys.FeatureFlags.SearchBarPosition
+            )
+        } else if launchArguments.contains(LaunchArguments.SearchBarBottom) {
+            profile.prefs.setString(
+                SearchBarPosition.bottom.rawValue,
+                forKey: PrefsKeys.FeatureFlags.SearchBarPosition
+            )
         }
 
         // Skip the intro when requested by for example tests or automation
@@ -246,7 +254,18 @@ class UITestAppDelegate: AppDelegate {
 
         Tab.ChangeUserAgent.clear()
 
-        return super.application(application, willFinishLaunchingWithOptions: launchOptions)
+        let didFinishLaunching = super.application(
+            application,
+            willFinishLaunchingWithOptions: launchOptions
+        )
+
+        // Floorp's pre-launch migration intentionally invalidates inherited
+        // Mozilla acceptance. Apply the UI-test override after that migration.
+        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.SkipTermsOfUse) {
+            profile.prefs.setBool(true, forKey: PrefsKeys.TermsOfUseAccepted)
+        }
+
+        return didFinishLaunching
     }
 
     /// Use this to reset the application between tests.

--- a/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
+++ b/firefox-ios/Client/Frontend/Browser/Toolbars/Redux/AddressBarState.swift
@@ -926,6 +926,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
         case .version1, .none:
             actions.append(
                 contentsOf: [
+                    floorpDrawerAction(), // Floorp: keep the drawer reachable when the navigation toolbar is hidden
                     menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge),
                     tabsAction(
                         iconName: iconName,
@@ -946,6 +947,7 @@ struct AddressBarState: StateType, Sendable, Equatable {
                         previousTabScreenshot: previousTabScreenshot,
                         nextTabScreenshot: nextTabScreenshot
                     ),
+                    floorpDrawerAction(), // Floorp: keep the drawer reachable when the navigation toolbar is hidden
                     menuAction(iconName: menuIcon, showWarningBadge: showWarningBadge)
                 ]
             )
@@ -1033,6 +1035,17 @@ struct AddressBarState: StateType, Sendable, Equatable {
             isEnabled: true,
             a11yLabel: .LegacyAppMenu.Toolbar.MenuButtonAccessibilityLabel,
             a11yId: AccessibilityIdentifiers.Toolbar.settingsMenuButton)
+    }
+
+    // Floorp: iPad and compact landscape layouts render browser actions in the address toolbar.
+    private static func floorpDrawerAction() -> ToolbarActionConfiguration {
+        return ToolbarActionConfiguration(
+            actionType: .floorpDrawer,
+            iconName: ImageIdentifiers.floorpDrawer,
+            isEnabled: true,
+            a11yLabel: "Floorp Drawer",
+            a11yId: "floorpDrawerToolbarButton"
+        )
     }
 
     private static func backAction(enabled: Bool) -> ToolbarActionConfiguration {

--- a/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
+++ b/firefox-ios/Floorp/FloorpOverlayDrawerViewController.swift
@@ -2948,7 +2948,7 @@ final class FloorpOverlayDrawerViewController:
         if let presentationHost {
             switch presentationMode {
             case .overlay:
-                isAttachedToPresentationHost = presentingViewController === presentationHost
+                isAttachedToPresentationHost = presentingViewController != nil
             case .pinned:
                 isAttachedToPresentationHost = parent === presentationHost
                     && view.superview === presentationHost.view
@@ -3229,7 +3229,9 @@ final class FloorpOverlayDrawerViewController:
                 self.completePresentation(onPresented: onPresented)
             }
         }
-        return presentingViewController === parentVC
+        // UIKit may promote the effective presenter to an ancestor navigation
+        // controller. A non-nil presenter proves that this drawer was attached.
+        return presentingViewController != nil
     }
 
     private func embedPinned(
@@ -3464,7 +3466,7 @@ final class FloorpOverlayDrawerViewController:
             self.presentationMigrationRetainer = nil
             self.completePresentation(onPresented: nil)
         }
-        guard presentingViewController === presentationHost else {
+        guard presentingViewController != nil else {
             restorePinnedAfterFailedOverlayMigration(in: presentationHost)
             return
         }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -5300,6 +5300,59 @@ final class FloorpOverlayDrawerPresentationTests: XCTestCase {
         XCTAssertNil(presentationState.activeDrawer)
     }
 
+    func testOverlayRemainsDismissibleWhenUIKitPromotesPresenterToNavigationController() async throws {
+        let suiteName = "FloorpOverlayDrawerPromotedPresenterTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let archiveDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpOverlayDrawerPromotedPresenterTests-\(UUID().uuidString)")
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+            try? FileManager.default.removeItem(at: archiveDirectory)
+        }
+
+        let panelManager = FloorpPanelManager(defaults: defaults)
+        let presentationState = FloorpPanelPresentationState(windowUUID: .XCTestDefaultUUID)
+        presentationState.select(try XCTUnwrap(panelManager.panel(for: "floorp//notes")))
+        let drawer = FloorpOverlayDrawerViewController(
+            panelManager: panelManager,
+            notesStore: FloorpNotesStore(fileURL: archiveDirectory.appendingPathComponent("notes.json")),
+            presentationState: presentationState,
+            themeManager: MockThemeManager(),
+            notificationCenter: MockNotificationCenter(),
+            presentationModeProvider: { _, _ in .overlay }
+        )
+        let browser = UIViewController()
+        let navigationController = UINavigationController(rootViewController: browser)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        navigationController.loadViewIfNeeded()
+        browser.loadViewIfNeeded()
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+        let animationsWereEnabled = UIView.areAnimationsEnabled
+        UIView.setAnimationsEnabled(false)
+        defer {
+            UIView.setAnimationsEnabled(animationsWereEnabled)
+            window.isHidden = true
+        }
+
+        let presented = expectation(description: "Promoted overlay presentation completed")
+        XCTAssertTrue(drawer.show(from: browser) { presented.fulfill() })
+        await fulfillment(of: [presented], timeout: 1)
+
+        XCTAssertTrue(drawer.presentingViewController === navigationController)
+        XCTAssertEqual(drawer.presentationMode, .overlay)
+        XCTAssertTrue(presentationState.activeDrawer === drawer)
+
+        let dismissed = expectation(description: "Promoted overlay dismissal completed")
+        drawer.onDismissed = { dismissed.fulfill() }
+        drawer.dismissDrawer()
+        await fulfillment(of: [dismissed], timeout: 1)
+
+        XCTAssertNil(navigationController.presentedViewController)
+        XCTAssertNil(presentationState.activeDrawer)
+    }
+
     func testExternalDismissalFinishesOnceAndAllowsReplacementDrawer() async throws {
         let suiteName = "FloorpOverlayDrawerExternalDismissalTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -167,10 +167,13 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         )
 
         XCTAssertEqual(newState.windowUUID, windowUUID)
-        XCTAssertEqual(newState.browserActions.count, 2)
-        XCTAssertEqual(newState.browserActions[0].actionType, .menu)
-        XCTAssertEqual(newState.browserActions[1].actionType, .tabs)
-        XCTAssertEqual(newState.browserActions[1].numberOfTabs, 2)
+        XCTAssertEqual(newState.browserActions.count, 3)
+        XCTAssertEqual(newState.browserActions[0].actionType, .floorpDrawer)
+        XCTAssertEqual(newState.browserActions[0].iconName, ImageIdentifiers.floorpDrawer)
+        XCTAssertEqual(newState.browserActions[0].a11yId, "floorpDrawerToolbarButton")
+        XCTAssertEqual(newState.browserActions[1].actionType, .menu)
+        XCTAssertEqual(newState.browserActions[2].actionType, .tabs)
+        XCTAssertEqual(newState.browserActions[2].numberOfTabs, 2)
     }
 
     func test_readerModeStateChangedAction_onHomepage_returnsExpectedState() {
@@ -454,10 +457,11 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.trailingPageActions[0].actionType, .reload)
         XCTAssertEqual(newState.leadingPageActions[0].actionType, .share)
 
-        XCTAssertEqual(newState.browserActions.count, 3)
+        XCTAssertEqual(newState.browserActions.count, 4)
         XCTAssertEqual(newState.browserActions[0].actionType, .newTab)
-        XCTAssertEqual(newState.browserActions[1].actionType, .menu)
-        XCTAssertEqual(newState.browserActions[2].actionType, .tabs)
+        XCTAssertEqual(newState.browserActions[1].actionType, .floorpDrawer)
+        XCTAssertEqual(newState.browserActions[2].actionType, .menu)
+        XCTAssertEqual(newState.browserActions[3].actionType, .tabs)
     }
 
     func test_backForwardButtonStateChangedAction_withNavigationToolbar_returnsExpectedState() {
@@ -764,9 +768,10 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
         XCTAssertEqual(newState.trailingPageActions.count, 0)
         XCTAssertEqual(newState.leadingPageActions.count, 0)
 
-        XCTAssertEqual(newState.browserActions.count, 2)
-        XCTAssertEqual(newState.browserActions[0].actionType, .menu)
-        XCTAssertEqual(newState.browserActions[1].actionType, .tabs)
+        XCTAssertEqual(newState.browserActions.count, 3)
+        XCTAssertEqual(newState.browserActions[0].actionType, .floorpDrawer)
+        XCTAssertEqual(newState.browserActions[1].actionType, .menu)
+        XCTAssertEqual(newState.browserActions[2].actionType, .tabs)
 
         XCTAssertEqual(newState.searchTerm, nil)
     }
@@ -792,11 +797,12 @@ final class AddressBarStateTests: XCTestCase, StoreTestUtility {
 
         XCTAssertEqual(newState.trailingPageActions.count, 0)
 
-        XCTAssertEqual(newState.browserActions.count, 2)
-        XCTAssertEqual(newState.browserActions[0].actionType, .menu)
-        XCTAssertNotNil(newState.browserActions[0].badgeImageName)
-        XCTAssertNotNil(newState.browserActions[0].maskImageName)
-        XCTAssertEqual(newState.browserActions[1].actionType, .tabs)
+        XCTAssertEqual(newState.browserActions.count, 3)
+        XCTAssertEqual(newState.browserActions[0].actionType, .floorpDrawer)
+        XCTAssertEqual(newState.browserActions[1].actionType, .menu)
+        XCTAssertNotNil(newState.browserActions[1].badgeImageName)
+        XCTAssertNotNil(newState.browserActions[1].maskImageName)
+        XCTAssertEqual(newState.browserActions[2].actionType, .tabs)
 
         XCTAssertEqual(newState.searchTerm, nil)
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Toolbar/AddressBarStateTests.swift
@@ -13,6 +13,8 @@ import SummarizeKit
 final class AddressBarStateTests: XCTestCase, StoreTestUtility {
     let storeUtilityHelper = StoreTestUtilityHelper()
     let windowUUID: WindowUUID = .XCTestDefaultUUID
+    // This upstream XCTest fixture is initialized and released for every test.
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var mockProfile: MockProfile!
 
     override func setUp() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpAdaptiveUI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpAdaptiveUI.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "8D10A4A6-5310-4D3E-BAB6-16F0FB4F534A",
+      "name" : "Floorp Adaptive UI",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en-US",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "FloorpAdaptiveSidebarIPadUITests\/testPortraitOverlayMigratesToLandscapePinnedAndPreservesNotesState()",
+        "FloorpAdaptiveSidebarIPadUITests\/testRTLPinnedResizeKeepsBrowserChromeSeparate()",
+        "FloorpAdaptiveSidebarIPhoneUITests\/testOverlayStaysAboveBottomAddressBar()",
+        "FloorpAdaptiveSidebarIPhoneUITests\/testOverlayStaysAboveTopAddressBar()"
+      ],
+      "target" : {
+        "containerPath" : "container:Client.xcodeproj",
+        "identifier" : "3BFE4B061D342FB800DDF53F",
+        "name" : "XCUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -131,6 +131,7 @@
     },
     {
       "selectedTests" : [
+        "AddressBarStateTests\/test_numberOfTabsChangedAction_withoutNavToolbar_returnsExpectedState()",
         "FloorpBrowserChromeLayoutTests\/testCustomGuidesReserveManagedBrowserChromeSurfacesInLTRAndRTL()",
         "FloorpBrowserChromeLayoutTests\/testDefaultGuidesPreserveOriginalFullWidthAndSafeAreaAnchors()",
         "FloorpLibraryPanelHostTests\/testBookmarkEditModeBlocksExternalPanelSwitchingAndDismissal()",
@@ -356,6 +357,7 @@
         "FloorpOverlayDrawerPresentationTests\/testDirectionalLayoutMetricsAndSidebarClamp()",
         "FloorpOverlayDrawerPresentationTests\/testDrawerUsesModalOverlayOutsideBrowserSubviewZOrder()",
         "FloorpOverlayDrawerPresentationTests\/testExternalDismissalFinishesOnceAndAllowsReplacementDrawer()",
+        "FloorpOverlayDrawerPresentationTests\/testOverlayRemainsDismissibleWhenUIKitPromotesPresenterToNavigationController()",
         "FloorpOverlayDrawerPresentationTests\/testPresentationIsRejectedWhileParentAlreadyOwnsAModal()",
         "FloorpOverlayDrawerPresentationTests\/testPinnedRTLReservesLeftEdgeAndKeepsResizeHandleInteractive()",
         "FloorpOverlayDrawerPresentationTests\/testPinnedDrawerPresentsAndAcknowledgesPendingNotesOperationError()",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpAdaptiveSidebarUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpAdaptiveSidebarUITests.swift
@@ -1,0 +1,355 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+private enum FloorpAdaptiveSidebarIdentifier {
+    static let toolbarButton = "floorpDrawerToolbarButton"
+    static let drawerContainer = "Floorp.Drawer.Container"
+    static let drawerClose = "Floorp.Drawer.Close"
+    static let notesPanel = "floorp//notes"
+    static let notesSearch = "Floorp.Notes.Search"
+    static let resizeHandle = "Floorp.Drawer.ResizeHandle"
+    static let addressBar = "AddressToolbar.address"
+
+    static let browserFrames = [
+        "content": "Browser.contentContainer",
+        "header": "Browser.headerContainer",
+        "address bar": addressBar,
+    ]
+}
+
+@MainActor
+class FloorpAdaptiveSidebarUITestCase: BaseTestCase {
+    private let frameTolerance: CGFloat = 2
+
+    func element(withIdentifier identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    @discardableResult
+    func waitForElement(
+        withIdentifier identifier: String,
+        timeout: TimeInterval = TIMEOUT
+    ) -> XCUIElement {
+        let element = element(withIdentifier: identifier)
+        let exists = element.waitForExistence(timeout: timeout)
+        if !exists {
+            let hierarchy = XCTAttachment(string: app.debugDescription)
+            hierarchy.name = "missing-\(identifier)-hierarchy"
+            hierarchy.lifetime = .keepAlways
+            add(hierarchy)
+
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "missing-\(identifier)-screenshot"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+        }
+        XCTAssertTrue(exists, "Timed out waiting for \(identifier)")
+        return element
+    }
+
+    func waitForHittable(_ element: XCUIElement, timeout: TimeInterval = TIMEOUT) {
+        let predicate = NSPredicate(format: "exists == true AND hittable == true")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expectation], timeout: timeout),
+            .completed,
+            "Timed out waiting for \(element) to become hittable"
+        )
+    }
+
+    func waitForUnhittable(_ element: XCUIElement, timeout: TimeInterval = TIMEOUT) {
+        let predicate = NSPredicate(format: "exists == false OR hittable == false")
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expectation], timeout: timeout),
+            .completed,
+            "Timed out waiting for \(element) to become unavailable"
+        )
+    }
+
+    func openNotesDrawer() -> XCUIElement {
+        let toolbarButton = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.toolbarButton
+        )
+        waitForHittable(toolbarButton)
+        toolbarButton.tap()
+        _ = waitForElement(withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer)
+        let notesButton = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.notesPanel
+        )
+        waitForHittable(notesButton)
+        notesButton.tap()
+        return waitForElement(withIdentifier: FloorpAdaptiveSidebarIdentifier.notesSearch)
+    }
+
+    func closeDrawer() {
+        let closeButton = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerClose
+        )
+        waitForHittable(closeButton)
+        closeButton.tap()
+        waitForUnhittable(
+            element(withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer)
+        )
+    }
+
+    func assertNotesSearch(contains expectedValue: String) {
+        let searchField = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.notesSearch
+        )
+        let predicate = NSPredicate { object, _ in
+            guard let element = object as? XCUIElement,
+                  let value = element.value as? String else { return false }
+            return value.contains(expectedValue)
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: searchField)
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [expectation], timeout: TIMEOUT),
+            .completed,
+            "Notes search did not preserve \(expectedValue)"
+        )
+    }
+
+    func assertOverlayMode() {
+        waitForUnhittable(
+            element(withIdentifier: FloorpAdaptiveSidebarIdentifier.resizeHandle)
+        )
+    }
+
+    func assertPinnedBrowserFrames(rightToLeft: Bool) {
+        let drawer = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer
+        )
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: TIMEOUT))
+
+        if rightToLeft {
+            XCTAssertEqual(drawer.frame.minX, window.frame.minX, accuracy: frameTolerance)
+        } else {
+            XCTAssertEqual(drawer.frame.maxX, window.frame.maxX, accuracy: frameTolerance)
+        }
+
+        for (name, identifier) in FloorpAdaptiveSidebarIdentifier.browserFrames {
+            let browserElement = waitForElement(withIdentifier: identifier)
+            let browserFrame = browserElement.frame
+            XCTAssertGreaterThan(browserFrame.width, 1, "\(name) has no measurable width")
+            XCTAssertGreaterThan(browserFrame.height, 1, "\(name) has no measurable height")
+
+            let intersection = browserFrame.intersection(drawer.frame)
+            XCTAssertTrue(
+                intersection.isNull || intersection.width <= frameTolerance || intersection.height <= frameTolerance,
+                "\(name) intersects the pinned drawer: \(intersection)"
+            )
+
+            if rightToLeft {
+                XCTAssertGreaterThanOrEqual(
+                    browserFrame.minX,
+                    drawer.frame.maxX - frameTolerance,
+                    "\(name) was not reserved to the right of the RTL drawer"
+                )
+            } else {
+                XCTAssertLessThanOrEqual(
+                    browserFrame.maxX,
+                    drawer.frame.minX + frameTolerance,
+                    "\(name) was not reserved to the left of the LTR drawer"
+                )
+            }
+        }
+    }
+
+    func resizePinnedDrawer(horizontalOffset: CGFloat) {
+        let drawer = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer
+        )
+        let handle = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.resizeHandle
+        )
+        waitForHittable(handle)
+        let initialWidth = drawer.frame.width
+        let start = handle.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = start.withOffset(CGVector(dx: horizontalOffset, dy: 0))
+        start.press(forDuration: 0.2, thenDragTo: end)
+
+        XCTAssertTrue(
+            waitUntil(timeout: TIMEOUT) {
+                drawer.exists && drawer.frame.width > initialWidth + 20
+            },
+            "Pinned drawer width did not increase from \(initialWidth)"
+        )
+    }
+
+    func attachEvidence(named name: String) {
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = name
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        let drawer = element(withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer)
+        let addressBar = element(withIdentifier: FloorpAdaptiveSidebarIdentifier.addressBar)
+        let frames = XCTAttachment(
+            string: "window=\(app.windows.firstMatch.frame)\ndrawer=\(drawer.frame)\naddress=\(addressBar.frame)"
+        )
+        frames.name = "\(name)-frames"
+        frames.lifetime = .keepAlways
+        add(frames)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return condition()
+    }
+}
+
+@MainActor
+final class FloorpAdaptiveSidebarIPadUITests: FloorpAdaptiveSidebarUITestCase {
+    private var initialOrientation: UIDeviceOrientation {
+        name.contains("RTL") ? .landscapeLeft : .portrait
+    }
+
+    override func setUp() async throws {
+        specificForPlatform = .pad
+        guard iPad() else { throw XCTSkip("iPad-only adaptive sidebar coverage") }
+
+        if name.contains("RTL") {
+            launchArguments += ["-AppleLanguages", "(ar)", "-AppleLocale", "ar_SA"]
+        }
+        XCUIDevice.shared.orientation = initialOrientation
+        try await super.setUp()
+        waitForRotation(to: initialOrientation)
+    }
+
+    override func tearDown() async throws {
+        XCUIDevice.shared.orientation = .portrait
+        try await super.tearDown()
+    }
+
+    func testPortraitOverlayMigratesToLandscapePinnedAndPreservesNotesState() {
+        let token = "adaptive-state"
+        let searchField = openNotesDrawer()
+        assertOverlayMode()
+        searchField.tap()
+        searchField.typeText("\(token)\n")
+        assertNotesSearch(contains: token)
+        attachEvidence(named: "ipad-portrait-overlay")
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        waitForRotation(to: .landscapeLeft)
+        waitForHittable(
+            element(withIdentifier: FloorpAdaptiveSidebarIdentifier.resizeHandle)
+        )
+        assertNotesSearch(contains: token)
+        assertPinnedBrowserFrames(rightToLeft: false)
+        resizePinnedDrawer(horizontalOffset: -72)
+        assertPinnedBrowserFrames(rightToLeft: false)
+        attachEvidence(named: "ipad-landscape-pinned-resized")
+
+        XCUIDevice.shared.orientation = .portrait
+        waitForRotation(to: .portrait)
+        assertOverlayMode()
+        assertNotesSearch(contains: token)
+        attachEvidence(named: "ipad-portrait-overlay-restored")
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        waitForRotation(to: .landscapeLeft)
+        waitForHittable(
+            element(withIdentifier: FloorpAdaptiveSidebarIdentifier.resizeHandle)
+        )
+        assertNotesSearch(contains: token)
+        assertPinnedBrowserFrames(rightToLeft: false)
+        closeDrawer()
+    }
+
+    func testRTLPinnedResizeKeepsBrowserChromeSeparate() {
+        _ = openNotesDrawer()
+        waitForHittable(
+            element(withIdentifier: FloorpAdaptiveSidebarIdentifier.resizeHandle)
+        )
+        assertPinnedBrowserFrames(rightToLeft: true)
+        resizePinnedDrawer(horizontalOffset: 72)
+        assertPinnedBrowserFrames(rightToLeft: true)
+        attachEvidence(named: "ipad-rtl-pinned-resized")
+        closeDrawer()
+    }
+}
+
+@MainActor
+final class FloorpAdaptiveSidebarIPhoneUITests: FloorpAdaptiveSidebarUITestCase {
+    override func setUp() async throws {
+        specificForPlatform = .phone
+        guard !iPad() else { throw XCTSkip("iPhone-only adaptive sidebar coverage") }
+        launchArguments.append(
+            name.contains("TopAddressBar")
+                ? LaunchArguments.SearchBarTop
+                : LaunchArguments.SearchBarBottom
+        )
+        XCUIDevice.shared.orientation = .portrait
+        try await super.setUp()
+        waitForRotation(to: .portrait)
+    }
+
+    override func tearDown() async throws {
+        XCUIDevice.shared.orientation = .portrait
+        try await super.tearDown()
+    }
+
+    func testOverlayStaysAboveTopAddressBar() {
+        verifyOverlayZOrder(expectAddressBarAtTop: true, evidenceName: "iphone-top-toolbar-overlay")
+        closeDrawer()
+    }
+
+    func testOverlayStaysAboveBottomAddressBar() {
+        verifyOverlayZOrder(expectAddressBarAtTop: false, evidenceName: "iphone-bottom-toolbar-overlay")
+        closeDrawer()
+    }
+
+    private func verifyOverlayZOrder(
+        expectAddressBarAtTop: Bool,
+        evidenceName: String
+    ) {
+        let addressBar = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.addressBar
+        )
+        let window = app.windows.firstMatch
+        XCTAssertTrue(window.waitForExistence(timeout: TIMEOUT))
+        if expectAddressBarAtTop {
+            XCTAssertLessThan(addressBar.frame.midY, window.frame.midY)
+        } else {
+            XCTAssertGreaterThan(addressBar.frame.midY, window.frame.midY)
+        }
+
+        _ = openNotesDrawer()
+        assertOverlayMode()
+        let drawer = waitForElement(
+            withIdentifier: FloorpAdaptiveSidebarIdentifier.drawerContainer
+        )
+        let overlap = drawer.frame.intersection(addressBar.frame)
+        XCTAssertGreaterThan(overlap.width, 10, "Drawer did not cover the address bar horizontally")
+        XCTAssertGreaterThan(overlap.height, 10, "Drawer did not cover the address bar vertically")
+
+        let tapPoint = CGPoint(
+            x: min(overlap.maxX - 8, drawer.frame.minX + 100),
+            y: overlap.midY
+        )
+        let normalizedOffset = CGVector(
+            dx: (tapPoint.x - window.frame.minX) / window.frame.width,
+            dy: (tapPoint.y - window.frame.minY) / window.frame.height
+        )
+        window.coordinate(withNormalizedOffset: normalizedOffset).tap()
+
+        XCTAssertTrue(drawer.exists, "Drawer disappeared after tapping its address-bar overlap")
+        XCTAssertFalse(addressBar.hasKeyboardFocus, "Covered address bar received keyboard focus")
+        XCTAssertFalse(app.keyboards.firstMatch.exists, "Covered address bar opened the keyboard")
+        attachEvidence(named: evidenceName)
+    }
+}


### PR DESCRIPTION
## Summary
- restore the Floorp drawer button in iPad and compact landscape address toolbars
- handle UIKit presenter promotion so overlay drawers remain dismissible
- add dedicated iPhone/iPad adaptive sidebar UI tests and CI coverage

## Validation
- iPad adaptive UI tests: 2 passed
- iPhone adaptive UI tests: 2 passed
- AddressBarState and promoted-presenter unit tests: 48 passed
- SwiftLint strict: 0 violations on changed Swift files
- project, scheme, test plans, workflow YAML, and diff checks passed

## Coverage
- portrait overlay to landscape pinned migration and state preservation
- pinned drawer resize and browser chrome separation
- RTL pinned layout
- top and bottom address-bar overlay z-order
