### PR TITLE
Fix AccountSyncHandler teardown race

### DIFF
--- a/firefox-ios/Client/AccountSyncHandler.swift
+++ b/firefox-ios/Client/AccountSyncHandler.swift
@@ -17,15 +17,24 @@ final class Debouncer {
     }
 
     func call(action: @escaping @MainActor () -> Void) {
-        task?.cancel()
+        cancel()
 
-        let nanos = UInt64(delay) * nanosecondsPerSecond
+        let nanos = UInt64(delay * Double(nanosecondsPerSecond))
 
         task = Task {
             try? await Task.sleep(nanoseconds: nanos)
             guard !Task.isCancelled else { return }
             action()
         }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+
+    deinit {
+        task?.cancel()
     }
 }
 
@@ -38,9 +47,7 @@ final class AccountSyncHandler: TabEventHandler, Notifiable, Sendable {
     private let profile: Profile
     private let logger: Logger
     private let queueDelay: Double
-    private var windowManager: WindowManager {
-        return AppContainer.shared.resolve()
-    }
+    private let windowManager: WindowManager
     let tabEventWindowResponseType: TabEventHandlerWindowResponseType =
         .allWindows
 
@@ -49,6 +56,7 @@ final class AccountSyncHandler: TabEventHandler, Notifiable, Sendable {
 
     init(
         with profile: Profile,
+        windowManager: WindowManager,
         debounceTime: Double = 5.0,
         queue: DispatchQueueInterface = DispatchQueue.global(),
         queueDelay: Double = 0.5,
@@ -56,6 +64,7 @@ final class AccountSyncHandler: TabEventHandler, Notifiable, Sendable {
         onSyncCompleted: (@Sendable () -> Void)? = nil
     ) {
         self.profile = profile
+        self.windowManager = windowManager
         self.debouncer = Debouncer(delay: debounceTime)
         self.logger = logger
         self.queueDelay = queueDelay
@@ -156,7 +165,7 @@ extension AccountSyncHandler {
     nonisolated func handleNotifications(_ notification: Notification) {
         switch notification.name {
         case .accountAuthenticated:
-            ensureMainThread { self.storeTabs() }
+            ensureMainThread { [weak self] in self?.storeTabs() }
         default:
             break
         }

--- a/firefox-ios/Client/TabManagement/GlobalTabEventHandlers.swift
+++ b/firefox-ios/Client/TabManagement/GlobalTabEventHandlers.swift
@@ -5,8 +5,8 @@
 import Foundation
 
 class GlobalTabEventHandlers {
-    // TODO: FXIOS-12592 This global property is not concurrency safe
-    nonisolated(unsafe) private static var globalHandlers: [TabEventHandler] = []
+    @MainActor
+    private static var globalHandlers: [TabEventHandler] = []
 
     /// Creates and configures the client's global TabEvent handlers. These handlers are created
     /// singularly for the entire app and respond to tab events across all windows. If the handlers
@@ -15,12 +15,19 @@ class GlobalTabEventHandlers {
     /// For anything that needs to react to tab events notifications (see `TabEventLabel`), the
     /// pattern is to implement a handler and specify which events to observe.
     @MainActor
-    static func configure(with profile: Profile) {
+    static func configure(with profile: Profile, windowManager: WindowManager) {
         guard globalHandlers.isEmpty else { return }
         globalHandlers = [
             UserActivityHandler(),
             MetadataParserHelper(),
-            AccountSyncHandler(with: profile)
+            AccountSyncHandler(with: profile, windowManager: windowManager)
         ]
+    }
+
+    /// Releases process-wide handlers between tests before their dependency container is reset.
+    /// Tests call this only while tab-event delivery is quiesced.
+    @MainActor
+    static func resetForTests() {
+        globalHandlers.removeAll()
     }
 }

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -133,7 +133,7 @@ final class TabManagerImplementation: NSObject,
 
         synchronizePrivateBrowsingSessionOwnership()
 
-        GlobalTabEventHandlers.configure(with: profile)
+        GlobalTabEventHandlers.configure(with: profile, windowManager: windowManager)
 
         startObservingNotifications(
             withNotificationCenter: notificationCenter,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DependencyInjection/DependencyHelperMock.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
 import Common
+import Foundation
 import Storage
 import TestKit
 @testable import Client
@@ -18,6 +19,7 @@ final class DependencyHelperMock {
         injectedFeatureFlagProvider: FeatureFlagProviding? = nil,
         injectedUserFeaturePreferences: UserFeaturePreferring? = nil
     ) {
+        GlobalTabEventHandlers.resetForTests()
         AppContainer.shared.reset()
 
         let profile: Profile = injectedProfile ?? BrowserProfile(
@@ -36,12 +38,10 @@ final class DependencyHelperMock {
             wrappedManager: WindowManagerImplementation()
         )
 
-        var tabManager: TabManager!
-
         let appSessionProvider: AppSessionProvider = AppSessionManager()
         AppContainer.shared.register(service: appSessionProvider as AppSessionProvider)
 
-        tabManager = injectedTabManager ?? MockTabManager()
+        let tabManager: TabManager = injectedTabManager ?? MockTabManager()
         AppContainer.shared.register(service: MockThemeManager() as ThemeManager)
 
         let searchEnginesManager = SearchEnginesManager(
@@ -85,6 +85,17 @@ final class DependencyHelperMock {
     }
 
     func reset() {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                GlobalTabEventHandlers.resetForTests()
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    GlobalTabEventHandlers.resetForTests()
+                }
+            }
+        }
         AppContainer.shared.reset()
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Helpers/AccountSyncHandlerTests.swift
@@ -10,34 +10,29 @@ import Common
 
 @MainActor
 class AccountSyncHandlerTests: XCTestCase {
-    private var profile: MockProfile!
-    private var syncManager: ClientSyncManagerSpy!
-    private var queue: MockDispatchQueue!
-    private var mockWindowManager: MockWindowManager!
+    private var profile = MockProfile()
+    private var queue = MockDispatchQueue()
+    private var mockWindowManager = MockWindowManager(wrappedManager: WindowManagerImplementation())
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() async throws {
         try await super.setUp()
-        self.profile = MockProfile()
-        self.syncManager = profile.syncManager as? ClientSyncManagerSpy
-        self.queue = MockDispatchQueue()
-        let mockTabManager =  MockTabManager()
-        DependencyHelperMock().bootstrapDependencies(
-            injectedWindowManager: mockWindowManager,
-            injectedTabManager: mockTabManager
-        )
-        mockTabManager.recentlyAccessedNormalTabs = [createTab(profile: profile)]
+        profile = MockProfile()
+        queue = MockDispatchQueue()
+        let mockTabManager = MockTabManager()
         mockWindowManager = MockWindowManager(
             wrappedManager: WindowManagerImplementation(),
             tabManager: mockTabManager
         )
+        DependencyHelperMock().bootstrapDependencies(
+            injectedProfile: profile,
+            injectedWindowManager: mockWindowManager,
+            injectedTabManager: mockTabManager
+        )
+        mockTabManager.recentlyAccessedNormalTabs = [createTab(profile: profile)]
     }
 
     override func tearDown() async throws {
-        self.syncManager = nil
-        self.profile = nil
-        self.queue = nil
-        self.mockWindowManager = nil
         DependencyHelperMock().reset()
         try await super.tearDown()
     }
@@ -46,9 +41,14 @@ class AccountSyncHandlerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "sync is not called without an account")
         expectation.isInverted = true
         profile.hasSyncableAccountMock = false
-        let subject = AccountSyncHandler(with: profile, queue: queue, onSyncCompleted: {
-            expectation.fulfill()
-        })
+        let subject = AccountSyncHandler(
+            with: profile,
+            windowManager: mockWindowManager,
+            queue: queue,
+            onSyncCompleted: {
+                expectation.fulfill()
+            }
+        )
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
 
@@ -58,9 +58,16 @@ class AccountSyncHandlerTests: XCTestCase {
 
     func testTabDidGainFocus_syncWithAccount() {
         let expectation = XCTestExpectation(description: "storeAndSyncTabs called after listed time of tab gaining focus")
-        let subject = AccountSyncHandler(with: profile, debounceTime: 0.1, queue: queue, queueDelay: 0.1, onSyncCompleted: {
-            expectation.fulfill()
-        })
+        let subject = AccountSyncHandler(
+            with: profile,
+            windowManager: mockWindowManager,
+            debounceTime: 0.1,
+            queue: queue,
+            queueDelay: 0.1,
+            onSyncCompleted: {
+                expectation.fulfill()
+            }
+        )
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
 
@@ -72,9 +79,15 @@ class AccountSyncHandlerTests: XCTestCase {
         let expectation = XCTestExpectation(
             description: "storeAndSyncTabs only called once from multiple tab actions")
         let subject = AccountSyncHandler(
-            with: profile, debounceTime: 0.1, queue: DispatchQueue.global(), queueDelay: 0.1, onSyncCompleted: {
+            with: profile,
+            windowManager: mockWindowManager,
+            debounceTime: 0.1,
+            queue: DispatchQueue.global(),
+            queueDelay: 0.1,
+            onSyncCompleted: {
                 expectation.fulfill()
-            })
+            }
+        )
         let tab = createTab(profile: profile)
 
         subject.tabDidGainFocus(tab)
@@ -89,9 +102,15 @@ class AccountSyncHandlerTests: XCTestCase {
             description: "storeAndSyncTabs called multiple times if outside of debounce time")
         expectation.expectedFulfillmentCount = 2
         let subject = AccountSyncHandler(
-            with: profile, debounceTime: 0.1, queue: DispatchQueue.global(), queueDelay: 0.1, onSyncCompleted: {
+            with: profile,
+            windowManager: mockWindowManager,
+            debounceTime: 0.1,
+            queue: DispatchQueue.global(),
+            queueDelay: 0.1,
+            onSyncCompleted: {
                 expectation.fulfill()
-            })
+            }
+        )
         let tab = createTab(profile: profile)
         subject.tabDidGainFocus(tab)
         subject.tabDidLoseFocus(tab)
@@ -102,6 +121,58 @@ class AccountSyncHandlerTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
         XCTAssertEqual(profile.storeAndSyncTabsCalled, 2)
+    }
+
+    func testPendingSyncKeepsInjectedWindowManagerAfterContainerReset() {
+        let expectation = XCTestExpectation(description: "sync completes with the injected window manager")
+        let subject = AccountSyncHandler(
+            with: profile,
+            windowManager: mockWindowManager,
+            debounceTime: 0.1,
+            queueDelay: 0,
+            onSyncCompleted: {
+                expectation.fulfill()
+            }
+        )
+        let replacementTabManager = MockTabManager()
+        let replacementWindowManager = MockWindowManager(
+            wrappedManager: WindowManagerImplementation(),
+            tabManager: replacementTabManager
+        )
+
+        subject.tabDidGainFocus(createTab(profile: profile))
+        DependencyHelperMock().bootstrapDependencies(
+            injectedProfile: profile,
+            injectedWindowManager: replacementWindowManager,
+            injectedTabManager: replacementTabManager
+        )
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockWindowManager.allWindowTabManagersCallCount, 1)
+        XCTAssertEqual(replacementWindowManager.allWindowTabManagersCallCount, 0)
+    }
+
+    func testDebouncerCancelsPendingActionWhenReleased() {
+        let expectation = XCTestExpectation(description: "released debouncer does not run its pending action")
+        expectation.isInverted = true
+        var subject: Debouncer? = Debouncer(delay: 0.1)
+
+        subject?.call {
+            expectation.fulfill()
+        }
+        subject = nil
+
+        wait(for: [expectation], timeout: 0.25)
+    }
+
+    func testDependencyResetReleasesGlobalHandlerBeforePendingSync() {
+        GlobalTabEventHandlers.configure(with: profile, windowManager: mockWindowManager)
+        NotificationCenter.default.post(name: .accountAuthenticated, object: nil)
+
+        DependencyHelperMock().reset()
+        wait(1.0)
+
+        XCTAssertEqual(profile.storeAndSyncTabsCalled, 0)
     }
 }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Mocks/MockWindowManager.swift
@@ -13,6 +13,7 @@ final class MockWindowManager: WindowManager {
     var closePrivateTabsMultiActionCalled = 0
     var overrideWindows = false
     var windowsWereAccessed = false
+    private(set) var allWindowTabManagersCallCount = 0
 
     init(
         wrappedManager: WindowManagerImplementation,
@@ -42,7 +43,8 @@ final class MockWindowManager: WindowManager {
     }
 
     func allWindowTabManagers() -> [TabManager] {
-        wrappedManager.allWindowTabManagers()
+        allWindowTabManagersCallCount += 1
+        return wrappedManager.allWindowTabManagers()
     }
 
     func allWindowUUIDs(includingReserved: Bool) -> [WindowUUID] {

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -131,6 +131,13 @@
     },
     {
       "selectedTests" : [
+        "AccountSyncHandlerTests\/testDebouncerCancelsPendingActionWhenReleased()",
+        "AccountSyncHandlerTests\/testDependencyResetReleasesGlobalHandlerBeforePendingSync()",
+        "AccountSyncHandlerTests\/testPendingSyncKeepsInjectedWindowManagerAfterContainerReset()",
+        "AccountSyncHandlerTests\/testTabDidGainFocus_doesntSyncWithoutAccount()",
+        "AccountSyncHandlerTests\/testTabDidGainFocus_multipleActions_executedAtMostOnce()",
+        "AccountSyncHandlerTests\/testTabDidGainFocus_multipleDebounce_withWithMultipleSyncs()",
+        "AccountSyncHandlerTests\/testTabDidGainFocus_syncWithAccount()",
         "AddressBarStateTests\/test_numberOfTabsChangedAction_withoutNavToolbar_returnsExpectedState()",
         "FloorpBrowserChromeLayoutTests\/testCustomGuidesReserveManagedBrowserChromeSurfacesInLTRAndRTL()",
         "FloorpBrowserChromeLayoutTests\/testDefaultGuidesPreserveOriginalFullWidthAndSafeAreaAnchors()",


### PR DESCRIPTION
## Summary

- inject WindowManager into AccountSyncHandler before delayed sync work
- cancel pending debounce tasks and restore fractional debounce timing
- release global tab handlers on MainActor before test dependency teardown
- add all seven AccountSyncHandler tests to the Floorp CI plan, including deterministic schedule-reset-wake regressions

## Validation

- targeted build-for-testing succeeded
- AccountSyncHandlerTests: 7 passed, 0 failed, without retries
- SwiftLint 0.62.2 strict passed for all changed Swift files
- Floorp branding and Application Services pin checks passed
- independent review found no remaining actionable correctness issues

This is the follow-up for the post-suite AppContainer fatal observed on main after PR #56. The delayed WindowManager service-locator lookup has been removed.