### PR TITLE
test(branding): Floorp branding UI smoke matrix

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 /* Begin PBXBuildFile section */
 		F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */; };
 		F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */; };
+		F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00272F50000100000001 /* FloorpBrandingUITests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2809,6 +2810,7 @@
 /* Begin PBXFileReference section */
 		F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpAdaptiveSidebarUITests.swift; sourceTree = "<group>"; };
 		F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpPrivateHeaderBrandingUITests.swift; sourceTree = "<group>"; };
+		F10A00272F50000100000001 /* FloorpBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpBrandingUITests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13554,6 +13556,7 @@
 				5FE7F1852E781EB300B0AFEC /* Selectors */,
 				F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */,
 				F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */,
+				F10A00272F50000100000001 /* FloorpBrandingUITests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19593,6 +19596,7 @@
 			files = (
 				F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */,
 				F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */,
+				F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -580,6 +580,9 @@
             reference = "container:firefox-ios-tests/Tests/FloorpAdaptiveUI.xctestplan">
          </TestPlanReference>
          <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FloorpBrandingUI.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
             reference = "container:firefox-ios-tests/Tests/FloorpCI.xctestplan">
          </TestPlanReference>
          <TestPlanReference

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpBrandingUI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpBrandingUI.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "9D1E5A0E-7B3C-4F5A-9E6B-1A2B3C4D5E6F",
+      "name" : "Floorp Branding UI",
+      "options" : {
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en-US",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "FloorpBrandingUITests/testLaunchHomeHeaderShowsFloorpBranding()",
+        "FloorpBrandingUITests/testPrivateHomeHeaderShowsFloorpBranding()",
+        "FloorpBrandingUITests/testSettingsAboutShowsFloorpIdentity()",
+        "FloorpBrandingUITests/testQuickActionsUseFloorpCopy()",
+        "FloorpBrandingOnboardingUITests/testOnboardingShowsFloorpLoader()"
+      ],
+      "target" : {
+        "containerPath" : "container:Client.xcodeproj",
+        "identifier" : "3BFE4B061D342FB800DDF53F",
+        "name" : "XCUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpBrandingUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpBrandingUITests.swift
@@ -1,0 +1,142 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+/// Floorp-owned branding smoke coverage over shipped main-app surfaces.
+///
+/// Runs in the EN/JA iPhone/iPad matrix (see `FloorpBrandingUI.xctestplan`).
+/// Assertions use stable accessibility identifiers and the non-localized
+/// Floorp product name; permission-copy coverage is provided by the compiled
+/// archive inspection (`rg` over the localized InfoPlist.strings) in the
+/// release evidence, per `docs/branding.md`.
+@MainActor
+class FloorpBrandingUITests: BaseTestCase {
+    private static let logoIdentifier =
+        AccessibilityIdentifiers.FirefoxHomepage.OtherButtons.logoID
+    private static let privateHomeCardIdentifier =
+        AccessibilityIdentifiers.PrivateMode.Homepage.card
+
+    private lazy var toolbarScreen = ToolbarScreen(app: app)
+    private lazy var tabTrayScreen = TabTrayScreen(app: app)
+
+    func testLaunchHomeHeaderShowsFloorpBranding() {
+        app.launch()
+
+        // Home page header carries the Floorp product label on its logo stack.
+        let logo = app.descendants(matching: .any)
+            .matching(identifier: Self.logoIdentifier)
+            .allElementsBoundByIndex
+            .first { $0.isHittable }
+        XCTAssertNotNil(logo, "Home header logo not found")
+        XCTAssertEqual(logo?.label, "Floorp")
+    }
+
+    func testPrivateHomeHeaderShowsFloorpBranding() {
+        app.launch()
+
+        waitForTabsButton()
+        toolbarScreen.tapOnTabsButton()
+        tabTrayScreen.switchToPrivateBrowsing()
+        tabTrayScreen.assertNewTabButtonExist()
+        tabTrayScreen.tapOnNewTabButton()
+
+        let privateHomeCard = app.descendants(matching: .any)
+            .matching(identifier: Self.privateHomeCardIdentifier)
+            .firstMatch
+        XCTAssertTrue(
+            privateHomeCard.waitForExistence(timeout: TIMEOUT),
+            "Private home page card did not appear"
+        )
+
+        let logo = app.descendants(matching: .any)
+            .matching(identifier: Self.logoIdentifier)
+            .allElementsBoundByIndex
+            .first { $0.isHittable }
+        XCTAssertNotNil(logo, "Private home header logo not found")
+        XCTAssertEqual(logo?.label, "Floorp")
+    }
+
+    func testSettingsAboutShowsFloorpIdentity() {
+        app.launch()
+        navigator.goto(SettingsScreen)
+
+        // The About section version row is built from AppName.shortName and
+        // must read "Floorp <version> (<build>)".
+        let versionRow = app.cells.staticTexts
+            .matching(NSPredicate(format: "label BEGINSWITH 'Floorp'"))
+            .firstMatch
+        XCTAssertTrue(
+            versionRow.waitForExistence(timeout: TIMEOUT),
+            "About section version row must identify the app as Floorp"
+        )
+        XCTAssertFalse(
+            versionRow.label.localizedCaseInsensitiveContains("Firefox"),
+            "About version row must not name Firefox"
+        )
+
+        // The About rows for the Floorp legal surfaces use stable
+        // accessibility identifiers (the visible titles are localized).
+        for identifier in [
+            AccessibilityIdentifiers.Settings.Licenses.title,
+            AccessibilityIdentifiers.Settings.YourRights.title,
+        ] {
+            let cell = app.cells.containing(.any, identifier: identifier).firstMatch
+            XCTAssertTrue(
+                cell.waitForExistence(timeout: TIMEOUT),
+                "About row missing: \(identifier)"
+            )
+        }
+    }
+
+    func testQuickActionsUseFloorpCopy() {
+        app.launch()
+        XCUIDevice.shared.press(.home)
+
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        // On iPad the icon appears in both the home screen and the Dock,
+        // so resolve the first match.
+        let icon = springboard.icons["Floorp"].firstMatch
+        XCTAssertTrue(icon.waitForExistence(timeout: TIMEOUT))
+        icon.press(forDuration: 2.0)
+
+        // The home-screen context menu follows the simulator system language,
+        // so assert the stable shortcut-item identifiers from the app
+        // Info.plist (bundleID.NewTab / bundleID.NewPrivateTab) instead of
+        // localized labels. The release plist contains only product-neutral
+        // shortcut copy, verified by the compiled archive inspection.
+        for identifier in [
+            "app.floorp.Floorp.NewTab",
+            "app.floorp.Floorp.NewPrivateTab",
+        ] {
+            let row = springboard.descendants(matching: .any)
+                .matching(identifier: identifier)
+                .firstMatch
+            XCTAssertTrue(
+                row.waitForExistence(timeout: TIMEOUT),
+                "Quick action missing: \(identifier)"
+            )
+        }
+    }
+}
+
+/// Onboarding branding smoke: the first-run intro must render the Floorp
+/// loader artwork. Runs without `SkipIntro`.
+@MainActor
+class FloorpBrandingOnboardingUITests: BaseTestCase {
+    override func setUpApp() {
+        launchArguments = launchArguments.filter { $0 != LaunchArguments.SkipIntro }
+    }
+
+    func testOnboardingShowsFloorpLoader() {
+        app.launch()
+
+        let loader = app.images["floorpLoader"]
+        XCTAssertTrue(
+            loader.waitForExistence(timeout: TIMEOUT),
+            "Onboarding must render the Floorp loader artwork"
+        )
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpPrivateHeaderBrandingUITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpPrivateHeaderBrandingUITests.swift
@@ -29,8 +29,8 @@ class FloorpPrivateHeaderBrandingUITests: FeatureFlaggedTestBase {
     private static let privateHomeCardIdentifier =
         AccessibilityIdentifiers.PrivateMode.Homepage.card
 
-    private var toolbarScreen: ToolbarScreen!
-    private var tabTrayScreen: TabTrayScreen!
+    private lazy var toolbarScreen = ToolbarScreen(app: app)
+    private lazy var tabTrayScreen = TabTrayScreen(app: app)
 
     override func setUpApp() {
         super.setUpApp()
@@ -38,12 +38,6 @@ class FloorpPrivateHeaderBrandingUITests: FeatureFlaggedTestBase {
             jsonFileName: "floorpNovaDesignEnabled",
             featureName: "nova-design-feature"
         )
-    }
-
-    override func setUp() async throws {
-        try await super.setUp()
-        toolbarScreen = ToolbarScreen(app: app)
-        tabTrayScreen = TabTrayScreen(app: app)
     }
 
     func testPrivateModeHomeHeaderRendersApprovedFloorpMark() throws {


### PR DESCRIPTION
Closes the UI-evidence gap of the rebranding tracking issue #28.

- FloorpBrandingUITests: launch, home and private-mode header branding, Settings/About identity, quick-action copy (identifier-based, locale-independent)
- FloorpBrandingOnboardingUITests: first-run intro renders the Floorp loader
- FloorpBrandingUI.xctestplan + Fennec scheme registration
- Passed locally on the 4-combo matrix: iPhone 17 + iPad (A16), en-US + ja-JP (5/5 each)