### PR TITLE
refactor(notes): isolate deterministic editor save coordination (#21)

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -1440,6 +1440,7 @@
 		CEC2F0B02F98000300D67401 /* FloorpNotesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE903B0A2F98000300D67401 /* FloorpNotesTests.swift */; };
 		CEB3A1002FA1000000D67401 /* FloorpPanelPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB3A1012FA1000000D67401 /* FloorpPanelPreferencesTests.swift */; };
 		F10A00022FA9000000000001 /* FloorpNotesSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00012FA9000000000001 /* FloorpNotesSync.swift */; };
+		F10A00282F50000100000001 /* FloorpNoteSaveCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00292F50000100000001 /* FloorpNoteSaveCoordinator.swift */; };
 		F10A00042FA9000000000001 /* FloorpNotesSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00032FA9000000000001 /* FloorpNotesSyncTests.swift */; };
 		F10A00112FA9000000000001 /* FloorpAdaptivePanelPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00102FA9000000000001 /* FloorpAdaptivePanelPresentation.swift */; };
 		F10A00062FA9000000000001 /* floorp-notes-merge-v1.json in Resources */ = {isa = PBXBuildFile; fileRef = F10A00052FA9000000000001 /* floorp-notes-merge-v1.json */; };
@@ -11121,6 +11122,7 @@
 		CE903B0A2F98000300D67401 /* FloorpNotesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesTests.swift; sourceTree = "<group>"; };
 		CEB3A1012FA1000000D67401 /* FloorpPanelPreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpPanelPreferencesTests.swift; sourceTree = "<group>"; };
 		F10A00012FA9000000000001 /* FloorpNotesSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSync.swift; sourceTree = "<group>"; };
+		F10A00292F50000100000001 /* FloorpNoteSaveCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNoteSaveCoordinator.swift; sourceTree = "<group>"; };
 		F10A00032FA9000000000001 /* FloorpNotesSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncTests.swift; sourceTree = "<group>"; };
 		F10A00102FA9000000000001 /* FloorpAdaptivePanelPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpAdaptivePanelPresentation.swift; sourceTree = "<group>"; };
 		F10A00052FA9000000000001 /* floorp-notes-merge-v1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "../sync-fixtures/floorp-notes/floorp-notes-merge-v1.json"; sourceTree = SOURCE_ROOT; };
@@ -16424,6 +16426,7 @@
 				CE903B072F971B0200D67401 /* FloorpStrings.swift */,
 				CE903B082F98000100D67401 /* FloorpNotes.swift */,
 				F10A00012FA9000000000001 /* FloorpNotesSync.swift */,
+				F10A00292F50000100000001 /* FloorpNoteSaveCoordinator.swift */,
 				F10A00102FA9000000000001 /* FloorpAdaptivePanelPresentation.swift */,
 				CE903B092F98000200D67401 /* FloorpNoteEditorViewController.swift */,
 				CE903B0D2FB0000100D67401 /* FloorpRichTextDocument.swift */,
@@ -20136,6 +20139,7 @@
 				CEC2F0ADE11D4F00BE2EC4DF /* FloorpStrings.swift in Sources */,
 				CEC2F0AE2F98000100D67401 /* FloorpNotes.swift in Sources */,
 				F10A00022FA9000000000001 /* FloorpNotesSync.swift in Sources */,
+				F10A00282F50000100000001 /* FloorpNoteSaveCoordinator.swift in Sources */,
 				F10A00112FA9000000000001 /* FloorpAdaptivePanelPresentation.swift in Sources */,
 				CEC2F0AF2F98000200D67401 /* FloorpNoteEditorViewController.swift in Sources */,
 				CEC2F0B32FB0000100D67401 /* FloorpRichTextDocument.swift in Sources */,

--- a/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
+++ b/firefox-ios/Floorp/FloorpNoteEditorViewController.swift
@@ -146,273 +146,6 @@ final class FloorpNotePersistenceSession: FloorpNotePersistence {
     }
 }
 
-@MainActor
-final class FloorpNoteSaveCoordinator {
-    enum FailureKind: Equatable, Hashable {
-        case conflict
-        case noteDeleted
-        case archiveTooLarge
-        case damagedArchive
-        case newerSchema
-        case storage
-    }
-
-    struct Failure {
-        let kind: FailureKind
-        let underlyingError: Error
-    }
-
-    enum SaveOutcome {
-        case noChanges
-        case saved(FloorpNote)
-        case failed(Failure)
-    }
-
-    private let persistence: FloorpNotePersistence
-    private(set) var draft: FloorpNote
-    private(set) var changeVersion = 0
-    private(set) var savedVersion = 0
-    private(set) var contentChangeVersion = 0
-    private(set) var savedContentVersion = 0
-    private(set) var hasPersistedNote: Bool
-    private(set) var lastFailure: Failure?
-    private var isSaving = false
-    private var saveWaiters = [CheckedContinuation<Void, Never>]()
-
-    var hasUnsavedChanges: Bool { savedVersion != changeVersion }
-    var hasUnsavedContentChanges: Bool { savedContentVersion != contentChangeVersion }
-
-    init(draft: FloorpNote, isPersisted: Bool, persistence: FloorpNotePersistence) {
-        self.draft = draft
-        self.hasPersistedNote = isPersisted
-        self.persistence = persistence
-    }
-
-    @discardableResult
-    func updateTitle(_ title: String) -> Bool {
-        guard draft.title != title else { return false }
-        draft.title = title
-        markChanged()
-        return true
-    }
-
-    @discardableResult
-    func updateContent(
-        _ content: String,
-        contentFormat: FloorpNoteContentFormat? = nil
-    ) -> Bool {
-        let nextFormat = contentFormat ?? draft.contentFormat
-        guard draft.content != content || draft.contentFormat != nextFormat else { return false }
-        draft.content = content
-        draft.contentFormat = nextFormat
-        contentChangeVersion += 1
-        markChanged()
-        return true
-    }
-
-    func requestExplicitSave() {
-        if !hasPersistedNote && !hasUnsavedChanges {
-            markChanged()
-        }
-    }
-
-    func preflightContentUpdate(
-        _ content: String,
-        contentFormat: FloorpNoteContentFormat
-    ) async throws {
-        while true {
-            let candidateVersion = changeVersion
-            var candidate = draft
-            candidate.content = content
-            candidate.contentFormat = contentFormat
-            try await persistence.preflight(candidate)
-            guard changeVersion != candidateVersion else { return }
-        }
-    }
-
-    /// Replaces a plain-text body only if it is still the body that was
-    /// converted. Title edits can race the asynchronous preflight and are
-    /// retried, while a newer body makes the caller rebuild the rich document.
-    func preflightAndReplaceContent(
-        expectedContent: String,
-        expectedContentFormat: FloorpNoteContentFormat,
-        content: String,
-        contentFormat: FloorpNoteContentFormat
-    ) async throws -> Bool {
-        while true {
-            try Task.checkCancellation()
-            guard draft.content == expectedContent,
-                  draft.contentFormat == expectedContentFormat else {
-                return false
-            }
-            let candidateVersion = changeVersion
-            var candidate = draft
-            candidate.content = content
-            candidate.contentFormat = contentFormat
-            try await persistence.preflight(candidate)
-            try Task.checkCancellation()
-            guard draft.content == expectedContent,
-                  draft.contentFormat == expectedContentFormat else {
-                return false
-            }
-            guard changeVersion == candidateVersion else { continue }
-            _ = updateContent(content, contentFormat: contentFormat)
-            return true
-        }
-    }
-
-    func preflightCopyContent(
-        _ content: String,
-        contentFormat: FloorpNoteContentFormat
-    ) async throws {
-        var candidate = draft
-        candidate.content = content
-        candidate.contentFormat = contentFormat
-        try await persistence.preflightCopy(candidate)
-    }
-
-    func saveLatest() async -> SaveOutcome {
-        if isSaving {
-            await withCheckedContinuation { continuation in
-                saveWaiters.append(continuation)
-            }
-            if let lastFailure { return .failed(lastFailure) }
-            return hasUnsavedChanges ? await saveLatest() : .noChanges
-        }
-        guard hasUnsavedChanges else { return .noChanges }
-
-        isSaving = true
-        var lastSavedNote: FloorpNote?
-
-        repeat {
-            let versionToSave = changeVersion
-            let contentVersionToSave = contentChangeVersion
-            let noteToSave = draft
-            do {
-                let persistedNote = try await persistence.save(noteToSave)
-                savedVersion = versionToSave
-                savedContentVersion = contentVersionToSave
-                hasPersistedNote = true
-                lastFailure = nil
-                adoptPersistenceIdentity(from: persistedNote)
-                lastSavedNote = persistedNote
-            } catch {
-                let failure = Failure(kind: Self.failureKind(for: error), underlyingError: error)
-                lastFailure = failure
-                finishSaving()
-                return .failed(failure)
-            }
-        } while hasUnsavedChanges
-
-        finishSaving()
-        return lastSavedNote.map(SaveOutcome.saved) ?? .noChanges
-    }
-
-    func reload() async throws -> FloorpNote {
-        let requestedVersion = changeVersion
-        let requestedNoteID = draft.id
-        await waitUntilIdle()
-        isSaving = true
-        defer { finishSaving() }
-        guard changeVersion == requestedVersion, draft.id == requestedNoteID else {
-            throw FloorpNotesStoreError.editConflict(requestedNoteID)
-        }
-        guard let note = try await persistence.reload() else {
-            throw FloorpNotesStoreError.noteNotFound(draft.id)
-        }
-        guard changeVersion == requestedVersion, draft.id == requestedNoteID else {
-            throw FloorpNotesStoreError.editConflict(requestedNoteID)
-        }
-        persistence.acceptReloaded(note)
-        draft = note
-        changeVersion = 0
-        savedVersion = 0
-        contentChangeVersion = 0
-        savedContentVersion = 0
-        hasPersistedNote = true
-        lastFailure = nil
-        return note
-    }
-
-    func saveAsCopy() async -> SaveOutcome {
-        await waitUntilIdle()
-        isSaving = true
-        let versionToSave = changeVersion
-        let contentVersionToSave = contentChangeVersion
-        let noteToSave = draft
-        do {
-            let persistedNote = try await persistence.saveAsCopy(noteToSave)
-            savedVersion = versionToSave
-            savedContentVersion = contentVersionToSave
-            hasPersistedNote = true
-            lastFailure = nil
-            adoptPersistenceIdentity(from: persistedNote)
-            finishSaving()
-            if hasUnsavedChanges {
-                return await saveLatest()
-            }
-            return .saved(persistedNote)
-        } catch {
-            let failure = Failure(kind: Self.failureKind(for: error), underlyingError: error)
-            lastFailure = failure
-            finishSaving()
-            return .failed(failure)
-        }
-    }
-
-    private func markChanged() {
-        changeVersion += 1
-        lastFailure = nil
-    }
-
-    private func adoptPersistenceIdentity(from persistedNote: FloorpNote) {
-        draft = FloorpNote(
-            id: persistedNote.id,
-            title: draft.title,
-            content: draft.content,
-            createdAt: persistedNote.createdAt,
-            updatedAt: persistedNote.updatedAt,
-            contentFormat: draft.contentFormat
-        )
-    }
-
-    private func finishSaving() {
-        isSaving = false
-        let waiters = saveWaiters
-        saveWaiters.removeAll()
-        waiters.forEach { $0.resume() }
-    }
-
-    private func waitUntilIdle() async {
-        if isSaving {
-            await withCheckedContinuation { continuation in
-                saveWaiters.append(continuation)
-            }
-            await waitUntilIdle()
-        }
-    }
-
-    static func failureKind(for error: Error) -> FailureKind {
-        switch error {
-        case FloorpNotesStoreError.editConflict:
-            return .conflict
-        case FloorpNotesStoreError.noteNotFound:
-            return .noteDeleted
-        case FloorpNotesStoreError.archiveTooLarge, FloorpNotesStoreError.tooManyNotes:
-            return .archiveTooLarge
-        case FloorpNotesStoreError.corruptArchive,
-             FloorpNotesStoreError.corruptArchiveCouldNotBePreserved,
-             FloorpNotesStoreError.writesBlockedByCorruption:
-            return .damagedArchive
-        case FloorpNotesStoreError.unsupportedSchema:
-            return .newerSchema
-        default:
-            return .storage
-        }
-    }
-}
-
-@MainActor
 private final class FloorpNoteClosurePersistence: FloorpNotePersistence {
     private let onSave: @MainActor (FloorpNote) async throws -> FloorpNote
 
@@ -551,7 +284,6 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     private var richRecoveryDraft: FloorpRichTextRecoveryDraft?
     private var richBridgeRecoverySession: FloorpRichTextEditorSessionCursor?
     private var richBridgeFailureVersion = 0
-    private var autosaveTask: Task<Void, Never>?
     private var savedStatusResetTask: Task<Void, Never>?
     private let backgroundSaveLease = FloorpBackgroundSaveLease()
     private let shouldFocusTitleOnFirstAppearance: Bool
@@ -870,6 +602,9 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
             persistence: persistence
         )
         super.init(nibName: nil, bundle: nil)
+        saveCoordinator.onAutosave = { [weak self] in
+            _ = await self?.saveLatestDraft()
+        }
     }
 
     convenience init(
@@ -965,7 +700,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     }
 
     deinit {
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         savedStatusResetTask?.cancel()
         richUpdateDrainTask?.cancel()
         richAuthoritativeFlushTask?.cancel()
@@ -1075,7 +810,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     @discardableResult
     func saveForExplicitRequest() async -> Bool {
         guard !isClosing, !isEditorSessionTerminated else { return false }
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         saveCoordinator.requestExplicitSave()
         setInteractiveDismissalBlocked(saveCoordinator.hasUnsavedChanges)
         let outcome = await saveLatestDraft()
@@ -1097,7 +832,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
         guard !isClosing, !isEditorSessionTerminated else { return false }
         isClosing = true
         plainToRichConversionTask?.cancel()
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         setReloadInteractionEnabled(false, updatesRichEditor: false)
         let outcome = await saveLatestDraft()
         if case .failed(let failure) = outcome {
@@ -1117,7 +852,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
 
     @objc private func applicationWillResignActive() {
         guard saveCoordinator.hasUnsavedChanges || editorMode == .richText else { return }
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         beginBackgroundSaveTask()
         Task { @MainActor [weak self] in
             _ = await self?.saveLatestDraft()
@@ -1132,16 +867,9 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     }
 
     private func scheduleAutosave() {
-        autosaveTask?.cancel()
-        autosaveTask = Task { @MainActor [weak self] in
-            do {
-                try await Task.sleep(nanoseconds: UX.autosaveDelayNanoseconds)
-            } catch {
-                return
-            }
-            guard !Task.isCancelled else { return }
-            _ = await self?.saveLatestDraft()
-        }
+        saveCoordinator.scheduleAutosave(
+            delayNanoseconds: UX.autosaveDelayNanoseconds
+        )
     }
 
     @discardableResult
@@ -1556,7 +1284,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
 
     private func applyReloadedNote(_ note: FloorpNote) {
         guard !isEditorSessionTerminated, !isClosing else { return }
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         contentAnalysis = FloorpNoteContent.analyze(
             note.content,
             contentFormat: note.contentFormat
@@ -1573,7 +1301,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     }
 
     private func dismissDiscardingChanges() {
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         setInteractiveDismissalBlocked(false)
         terminateEditorSession()
         navigationController?.dismiss(animated: true)
@@ -1582,7 +1310,7 @@ final class FloorpNoteEditorViewController: UIViewController, Themeable {
     private func terminateEditorSession() {
         guard !isEditorSessionTerminated else { return }
         isEditorSessionTerminated = true
-        autosaveTask?.cancel()
+        saveCoordinator.cancelAutosave()
         plainToRichConversionTask?.cancel()
         richUpdateDrainTask?.cancel()
         richAuthoritativeFlushTask?.cancel()

--- a/firefox-ios/Floorp/FloorpNoteSaveCoordinator.swift
+++ b/firefox-ios/Floorp/FloorpNoteSaveCoordinator.swift
@@ -1,0 +1,310 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+/// Owns the Floorp Notes editor save state: change versions, in-flight
+/// save coalescing, retry state, and autosave scheduling. Extracted from
+/// the editor view controller so all of it is testable without UIKit or
+/// real timers (issue #21).
+@MainActor
+final class FloorpNoteSaveCoordinator {
+    enum FailureKind: Equatable, Hashable {
+        case conflict
+        case noteDeleted
+        case archiveTooLarge
+        case damagedArchive
+        case newerSchema
+        case storage
+    }
+
+    struct Failure {
+        let kind: FailureKind
+        let underlyingError: Error
+    }
+
+    enum SaveOutcome {
+        case noChanges
+        case saved(FloorpNote)
+        case failed(Failure)
+    }
+
+    private let persistence: FloorpNotePersistence
+    private(set) var draft: FloorpNote
+    private(set) var changeVersion = 0
+    private(set) var savedVersion = 0
+    private(set) var contentChangeVersion = 0
+    private(set) var savedContentVersion = 0
+    private(set) var hasPersistedNote: Bool
+    private(set) var lastFailure: Failure?
+    private var isSaving = false
+    private var saveWaiters = [CheckedContinuation<Void, Never>]()
+
+    var hasUnsavedChanges: Bool { savedVersion != changeVersion }
+    var hasUnsavedContentChanges: Bool { savedContentVersion != contentChangeVersion }
+
+    init(draft: FloorpNote, isPersisted: Bool, persistence: FloorpNotePersistence) {
+        self.draft = draft
+        self.hasPersistedNote = isPersisted
+        self.persistence = persistence
+    }
+
+    @discardableResult
+    func updateTitle(_ title: String) -> Bool {
+        guard draft.title != title else { return false }
+        draft.title = title
+        markChanged()
+        return true
+    }
+
+    @discardableResult
+    func updateContent(
+        _ content: String,
+        contentFormat: FloorpNoteContentFormat? = nil
+    ) -> Bool {
+        let nextFormat = contentFormat ?? draft.contentFormat
+        guard draft.content != content || draft.contentFormat != nextFormat else { return false }
+        draft.content = content
+        draft.contentFormat = nextFormat
+        contentChangeVersion += 1
+        markChanged()
+        return true
+    }
+
+    func requestExplicitSave() {
+        if !hasPersistedNote && !hasUnsavedChanges {
+            markChanged()
+        }
+    }
+
+    func preflightContentUpdate(
+        _ content: String,
+        contentFormat: FloorpNoteContentFormat
+    ) async throws {
+        while true {
+            let candidateVersion = changeVersion
+            var candidate = draft
+            candidate.content = content
+            candidate.contentFormat = contentFormat
+            try await persistence.preflight(candidate)
+            guard changeVersion != candidateVersion else { return }
+        }
+    }
+
+    /// Replaces a plain-text body only if it is still the body that was
+    /// converted. Title edits can race the asynchronous preflight and are
+    /// retried, while a newer body makes the caller rebuild the rich document.
+    func preflightAndReplaceContent(
+        expectedContent: String,
+        expectedContentFormat: FloorpNoteContentFormat,
+        content: String,
+        contentFormat: FloorpNoteContentFormat
+    ) async throws -> Bool {
+        while true {
+            try Task.checkCancellation()
+            guard draft.content == expectedContent,
+                  draft.contentFormat == expectedContentFormat else {
+                return false
+            }
+            let candidateVersion = changeVersion
+            var candidate = draft
+            candidate.content = content
+            candidate.contentFormat = contentFormat
+            try await persistence.preflight(candidate)
+            try Task.checkCancellation()
+            guard draft.content == expectedContent,
+                  draft.contentFormat == expectedContentFormat else {
+                return false
+            }
+            guard changeVersion == candidateVersion else { continue }
+            _ = updateContent(content, contentFormat: contentFormat)
+            return true
+        }
+    }
+
+    func preflightCopyContent(
+        _ content: String,
+        contentFormat: FloorpNoteContentFormat
+    ) async throws {
+        var candidate = draft
+        candidate.content = content
+        candidate.contentFormat = contentFormat
+        try await persistence.preflightCopy(candidate)
+    }
+
+    func saveLatest() async -> SaveOutcome {
+        if isSaving {
+            await withCheckedContinuation { continuation in
+                saveWaiters.append(continuation)
+            }
+            if let lastFailure { return .failed(lastFailure) }
+            return hasUnsavedChanges ? await saveLatest() : .noChanges
+        }
+        guard hasUnsavedChanges else { return .noChanges }
+
+        isSaving = true
+        var lastSavedNote: FloorpNote?
+
+        repeat {
+            let versionToSave = changeVersion
+            let contentVersionToSave = contentChangeVersion
+            let noteToSave = draft
+            do {
+                let persistedNote = try await persistence.save(noteToSave)
+                savedVersion = versionToSave
+                savedContentVersion = contentVersionToSave
+                hasPersistedNote = true
+                lastFailure = nil
+                adoptPersistenceIdentity(from: persistedNote)
+                lastSavedNote = persistedNote
+            } catch {
+                let failure = Failure(kind: Self.failureKind(for: error), underlyingError: error)
+                lastFailure = failure
+                finishSaving()
+                return .failed(failure)
+            }
+        } while hasUnsavedChanges
+
+        finishSaving()
+        return lastSavedNote.map(SaveOutcome.saved) ?? .noChanges
+    }
+
+    func reload() async throws -> FloorpNote {
+        let requestedVersion = changeVersion
+        let requestedNoteID = draft.id
+        await waitUntilIdle()
+        isSaving = true
+        defer { finishSaving() }
+        guard changeVersion == requestedVersion, draft.id == requestedNoteID else {
+            throw FloorpNotesStoreError.editConflict(requestedNoteID)
+        }
+        guard let note = try await persistence.reload() else {
+            throw FloorpNotesStoreError.noteNotFound(draft.id)
+        }
+        guard changeVersion == requestedVersion, draft.id == requestedNoteID else {
+            throw FloorpNotesStoreError.editConflict(requestedNoteID)
+        }
+        persistence.acceptReloaded(note)
+        draft = note
+        changeVersion = 0
+        savedVersion = 0
+        contentChangeVersion = 0
+        savedContentVersion = 0
+        hasPersistedNote = true
+        lastFailure = nil
+        return note
+    }
+
+    func saveAsCopy() async -> SaveOutcome {
+        await waitUntilIdle()
+        isSaving = true
+        let versionToSave = changeVersion
+        let contentVersionToSave = contentChangeVersion
+        let noteToSave = draft
+        do {
+            let persistedNote = try await persistence.saveAsCopy(noteToSave)
+            savedVersion = versionToSave
+            savedContentVersion = contentVersionToSave
+            hasPersistedNote = true
+            lastFailure = nil
+            adoptPersistenceIdentity(from: persistedNote)
+            finishSaving()
+            if hasUnsavedChanges {
+                return await saveLatest()
+            }
+            return .saved(persistedNote)
+        } catch {
+            let failure = Failure(kind: Self.failureKind(for: error), underlyingError: error)
+            lastFailure = failure
+            finishSaving()
+            return .failed(failure)
+        }
+    }
+
+    private func markChanged() {
+        changeVersion += 1
+        lastFailure = nil
+    }
+
+    private func adoptPersistenceIdentity(from persistedNote: FloorpNote) {
+        draft = FloorpNote(
+            id: persistedNote.id,
+            title: draft.title,
+            content: draft.content,
+            createdAt: persistedNote.createdAt,
+            updatedAt: persistedNote.updatedAt,
+            contentFormat: draft.contentFormat
+        )
+    }
+
+    private func finishSaving() {
+        isSaving = false
+        let waiters = saveWaiters
+        saveWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    private func waitUntilIdle() async {
+        if isSaving {
+            await withCheckedContinuation { continuation in
+                saveWaiters.append(continuation)
+            }
+            await waitUntilIdle()
+        }
+    }
+
+    static func failureKind(for error: Error) -> FailureKind {
+        switch error {
+        case FloorpNotesStoreError.editConflict:
+            return .conflict
+        case FloorpNotesStoreError.noteNotFound:
+            return .noteDeleted
+        case FloorpNotesStoreError.archiveTooLarge, FloorpNotesStoreError.tooManyNotes:
+            return .archiveTooLarge
+        case FloorpNotesStoreError.corruptArchive,
+             FloorpNotesStoreError.corruptArchiveCouldNotBePreserved,
+             FloorpNotesStoreError.writesBlockedByCorruption:
+            return .damagedArchive
+        case FloorpNotesStoreError.unsupportedSchema:
+            return .newerSchema
+        default:
+            return .storage
+        }
+    }
+
+    // MARK: - Autosave scheduling (deterministic, injectable sleep)
+
+    /// Invoked when a scheduled autosave fires. The editor wires this to its
+    /// save path; tests drive it without real timers.
+    var onAutosave: (@MainActor () async -> Void)?
+
+    nonisolated(unsafe) private var autosaveTask: Task<Void, Never>?
+
+    /// Schedules an autosave after `delayNanoseconds`, replacing any pending
+    /// schedule. `sleep` is injectable so tests control time deterministically;
+    /// the default is the real task sleep.
+    func scheduleAutosave(
+        delayNanoseconds: UInt64,
+        sleep: @escaping (UInt64) async throws -> Void = { delay in
+            try await Task.sleep(nanoseconds: delay)
+        }
+    ) {
+        autosaveTask?.cancel()
+        autosaveTask = Task { @MainActor [weak self] in
+            do {
+                try await sleep(delayNanoseconds)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            await self?.onAutosave?()
+        }
+    }
+
+    /// Cancels any pending autosave. Safe from any isolation domain (the
+    /// editor calls this from `deinit`).
+    nonisolated func cancelAutosave() {
+        autosaveTask?.cancel()
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -4208,6 +4208,131 @@ final class FloorpNoteSaveCoordinatorTests: XCTestCase {
             contentFormat: .plainText
         )
     }
+
+    // MARK: - Deterministic autosave scheduling (issue #21)
+
+    /// Waits without fixed sub-second sleeps until `condition` becomes true.
+    private func waitUntil(_ condition: () -> Bool) async {
+        while !condition() {
+            await Task.yield()
+        }
+    }
+
+    func testAutosaveFiresAfterScheduledDelayWithInjectedSleep() async {
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence
+        )
+        var fired = false
+        coordinator.onAutosave = { fired = true }
+
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+        var recordedDelay: UInt64?
+        coordinator.scheduleAutosave(delayNanoseconds: 400_000_000) { delay in
+            recordedDelay = delay
+            await withCheckedContinuation { sleepContinuation = $0 }
+        }
+        await waitUntil { sleepContinuation != nil }
+        sleepContinuation?.resume()
+        await waitUntil { fired }
+
+        XCTAssertEqual(recordedDelay, 400_000_000)
+        XCTAssertTrue(fired)
+    }
+
+    func testReschedulingAutosaveCancelsThePriorPendingFire() async {
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence
+        )
+        var fireCount = 0
+        coordinator.onAutosave = { fireCount += 1 }
+
+        var firstSleep: CheckedContinuation<Void, Never>?
+        var secondSleep: CheckedContinuation<Void, Never>?
+        coordinator.scheduleAutosave(delayNanoseconds: 1) { _ in
+            await withCheckedContinuation { firstSleep = $0 }
+        }
+        await waitUntil { firstSleep != nil }
+        coordinator.scheduleAutosave(delayNanoseconds: 2) { _ in
+            await withCheckedContinuation { secondSleep = $0 }
+        }
+        await waitUntil { secondSleep != nil }
+
+        // The first schedule was cancelled by the second; resuming its sleep
+        // must not fire the autosave callback.
+        firstSleep?.resume()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        XCTAssertEqual(fireCount, 0)
+
+        secondSleep?.resume()
+        await waitUntil { fireCount == 1 }
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    func testCancellingAutosavePreventsPendingFire() async {
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence
+        )
+        var fired = false
+        coordinator.onAutosave = { fired = true }
+
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+        coordinator.scheduleAutosave(delayNanoseconds: 1) { _ in
+            await withCheckedContinuation { sleepContinuation = $0 }
+        }
+        await waitUntil { sleepContinuation != nil }
+        coordinator.cancelAutosave()
+        sleepContinuation?.resume()
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        XCTAssertFalse(fired)
+    }
+
+    func testAutosaveCallbackSavesTheDirtyDraft() async {
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        var savedDrafts = [FloorpNote]()
+        persistence.saveHandler = { draft in
+            savedDrafts.append(draft)
+            var saved = draft
+            saved.updatedAt += 1
+            return saved
+        }
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence
+        )
+        coordinator.onAutosave = {
+            _ = await coordinator.saveLatest()
+        }
+        coordinator.updateTitle("Edited")
+
+        var sleepContinuation: CheckedContinuation<Void, Never>?
+        coordinator.scheduleAutosave(delayNanoseconds: 1) { _ in
+            await withCheckedContinuation { sleepContinuation = $0 }
+        }
+        await waitUntil { sleepContinuation != nil }
+        sleepContinuation?.resume()
+        await waitUntil { !savedDrafts.isEmpty }
+
+        XCTAssertEqual(savedDrafts.last?.title, "Edited")
+        XCTAssertFalse(coordinator.hasUnsavedChanges)
+    }
 }
 
 @MainActor


### PR DESCRIPTION
Extracts FloorpNoteSaveCoordinator (change versions, in-flight save coalescing, retry state) from FloorpNoteEditorViewController and moves autosave scheduling into it with an injectable sleep, per issue #21.

- New FloorpNoteSaveCoordinator.swift with scheduleAutosave(delayNanoseconds:sleep:) / cancelAutosave() (nonisolated for deinit)
- Editor delegates scheduling and wires onAutosave to its save path; no behavior change
- 4 new deterministic autosave tests (no real timers / presented controllers)
- Targeted: 58/58 green; full FloorpCI: 477/477 green