### PR TITLE
feat(notes): add conflict and save recovery actions (#22)

### DIFF
--- a/firefox-ios/Floorp/FloorpNoteSaveCoordinator.swift
+++ b/firefox-ios/Floorp/FloorpNoteSaveCoordinator.swift
@@ -31,6 +31,7 @@ final class FloorpNoteSaveCoordinator {
     }
 
     private let persistence: FloorpNotePersistence
+    private let recoveryDraftStore: FloorpNoteRecoveryDraftStore?
     private(set) var draft: FloorpNote
     private(set) var changeVersion = 0
     private(set) var savedVersion = 0
@@ -44,10 +45,16 @@ final class FloorpNoteSaveCoordinator {
     var hasUnsavedChanges: Bool { savedVersion != changeVersion }
     var hasUnsavedContentChanges: Bool { savedContentVersion != contentChangeVersion }
 
-    init(draft: FloorpNote, isPersisted: Bool, persistence: FloorpNotePersistence) {
+    init(
+        draft: FloorpNote,
+        isPersisted: Bool,
+        persistence: FloorpNotePersistence,
+        recoveryDraftStore: FloorpNoteRecoveryDraftStore? = nil
+    ) {
         self.draft = draft
         self.hasPersistedNote = isPersisted
         self.persistence = persistence
+        self.recoveryDraftStore = recoveryDraftStore
     }
 
     @discardableResult
@@ -167,6 +174,9 @@ final class FloorpNoteSaveCoordinator {
         } while hasUnsavedChanges
 
         finishSaving()
+        if lastSavedNote != nil {
+            clearRecoveryDraft()
+        }
         return lastSavedNote.map(SaveOutcome.saved) ?? .noChanges
     }
 
@@ -193,6 +203,7 @@ final class FloorpNoteSaveCoordinator {
         savedContentVersion = 0
         hasPersistedNote = true
         lastFailure = nil
+        clearRecoveryDraft()
         return note
     }
 
@@ -210,6 +221,7 @@ final class FloorpNoteSaveCoordinator {
             lastFailure = nil
             adoptPersistenceIdentity(from: persistedNote)
             finishSaving()
+            clearRecoveryDraft()
             if hasUnsavedChanges {
                 return await saveLatest()
             }
@@ -225,6 +237,37 @@ final class FloorpNoteSaveCoordinator {
     private func markChanged() {
         changeVersion += 1
         lastFailure = nil
+        persistRecoveryDraft()
+    }
+
+    /// Persists a recoverable snapshot of the current draft so unsaved text
+    /// survives a force termination or relaunch. Best-effort: a failed write
+    /// never blocks the edit itself.
+    func persistRecoveryDraft() {
+        guard let recoveryDraftStore else { return }
+        try? recoveryDraftStore.saveDraft(
+            FloorpNoteRecoveryDraft(
+                id: draft.id,
+                title: draft.title,
+                content: draft.content,
+                contentFormat: draft.contentFormat,
+                updatedAt: draft.updatedAt
+            )
+        )
+    }
+
+    /// Discards the persisted recovery snapshot after an explicit discard or a
+    /// successful save/reload, so a stale unsaved draft is never resurrected.
+    func clearRecoveryDraft() {
+        guard let recoveryDraftStore else { return }
+        try? recoveryDraftStore.clear()
+    }
+
+    /// Returns the last recoverable draft (from a prior force termination or
+    /// relaunch), if one exists.
+    func loadRecoverableDraft() -> FloorpNoteRecoveryDraft? {
+        guard let recoveryDraftStore else { return nil }
+        return try? recoveryDraftStore.loadRecoverableDraft()
     }
 
     private func adoptPersistenceIdentity(from persistedNote: FloorpNote) {

--- a/firefox-ios/Floorp/FloorpNotes.swift
+++ b/firefox-ios/Floorp/FloorpNotes.swift
@@ -645,6 +645,7 @@ actor FloorpNotesStore {
     private let now: @Sendable () -> Int64
     private let makeID: @Sendable () -> String
     private let copyItem: @Sendable (URL, URL) throws -> Void
+    private let writeData: @Sendable (Data, URL) throws -> Void
     private var cachedArchive: Archive?
     private var corruptionState: CorruptionState?
 
@@ -654,12 +655,19 @@ actor FloorpNotesStore {
         makeID: @escaping @Sendable () -> String = { UUID().uuidString },
         copyItem: @escaping @Sendable (URL, URL) throws -> Void = { source, destination in
             try FileManager.default.copyItem(at: source, to: destination)
+        },
+        writeData: @escaping @Sendable (Data, URL) throws -> Void = { data, url in
+            try data.write(
+                to: url,
+                options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+            )
         }
     ) {
         self.fileURL = fileURL
         self.now = now
         self.makeID = makeID
         self.copyItem = copyItem
+        self.writeData = writeData
     }
 
     func loadNotes() throws -> [FloorpNote] {
@@ -1003,10 +1011,7 @@ actor FloorpNotesStore {
             withIntermediateDirectories: true,
             attributes: [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication]
         )
-        try data.write(
-            to: fileURL,
-            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
-        )
+        try writeData(data, fileURL)
     }
 
     private func encodedArchiveData(_ archive: Archive) throws -> Data {
@@ -1145,5 +1150,73 @@ actor FloorpNotesStore {
             .appendingPathComponent("Floorp", isDirectory: true)
             .appendingPathComponent("Notes", isDirectory: true)
             .appendingPathComponent("notes-v1.json", isDirectory: false)
+    }
+}
+
+// MARK: - Recoverable editor draft
+
+/// The recoverable snapshot of an in-progress Floorp note editor draft.
+/// Persisted to disk so unsaved text can survive a force termination or a
+/// relaunch (issue #22).
+struct FloorpNoteRecoveryDraft: Codable, Equatable, Sendable {
+    let id: FloorpNoteID
+    let title: String
+    let content: String
+    let contentFormat: FloorpNoteContentFormat
+    let updatedAt: Int64
+}
+
+/// Owns the on-disk recovery copy of an unsaved editor draft. Writes are
+/// atomic and injectable so a failed write never destroys the newest
+/// recoverable draft nor leaves a partial file behind.
+final class FloorpNoteRecoveryDraftStore {
+    static func defaultFileURL() -> URL {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        return applicationSupport
+            .appendingPathComponent("Floorp", isDirectory: true)
+            .appendingPathComponent("Notes", isDirectory: true)
+            .appendingPathComponent("unsaved-draft.json", isDirectory: false)
+    }
+
+    let fileURL: URL
+    private let writeData: (Data, URL) throws -> Void
+
+    init(
+        fileURL: URL = FloorpNoteRecoveryDraftStore.defaultFileURL(),
+        writeData: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: [.atomic])
+        }
+    ) {
+        self.fileURL = fileURL
+        self.writeData = writeData
+    }
+
+    func saveDraft(_ draft: FloorpNoteRecoveryDraft) throws {
+        try ensureDirectory()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(draft)
+        try writeData(data, fileURL)
+    }
+
+    func clear() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+
+    func loadRecoverableDraft() throws -> FloorpNoteRecoveryDraft? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(FloorpNoteRecoveryDraft.self, from: data)
+    }
+
+    private func ensureDirectory() throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -172,6 +172,48 @@ final class FloorpNotesStoreTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(persistedContent, "original")
     }
 
+    func testInjectedWriteFailurePreservesLastGoodArchiveWithoutPartialFile() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let seedStore = FloorpNotesStore(fileURL: location.archive)
+        let note = try await seedStore.createNote(title: "Safe", content: "original")
+
+        enum WriteFailure: Error { case injected }
+        let failingStore = FloorpNotesStore(
+            fileURL: location.archive,
+            writeData: { _, _ in throw WriteFailure.injected }
+        )
+        do {
+            _ = try await failingStore.updateNote(
+                id: note.id,
+                title: "Must not persist",
+                content: "replacement",
+                expectedUpdatedAt: note.updatedAt
+            )
+            XCTFail("Expected injected write failure")
+        } catch WriteFailure.injected {
+            // Expected.
+        }
+
+        // A fresh store/process instance must still read the last-good archive.
+        let restartedStore = FloorpNotesStore(fileURL: location.archive)
+        let persisted = try await restartedStore.loadNotes()
+        XCTAssertEqual(persisted, [note])
+        XCTAssertEqual(persisted.first?.content, "original")
+
+        // No partial or temporary files may linger next to the archive.
+        let files = try FileManager.default.contentsOfDirectory(
+            at: location.directory,
+            includingPropertiesForKeys: nil
+        )
+        let strayFiles = files.filter { $0.lastPathComponent != "notes.json" }
+        XCTAssertTrue(
+            strayFiles.isEmpty,
+            "Unexpected partial/temp files: \(strayFiles.map(\.lastPathComponent))"
+        )
+    }
+
     func testCorruptArchiveIsPreservedAndRequiresExplicitReset() async throws {
         let location = try makeTemporaryArchiveLocation()
         defer { try? FileManager.default.removeItem(at: location.directory) }
@@ -806,6 +848,104 @@ final class FloorpNotesStoreTests: XCTestCase, @unchecked Sendable {
 
     private enum CopyFailure: Error {
         case expected
+    }
+}
+
+final class FloorpNoteRecoveryDraftStoreTests: XCTestCase {
+    private func makeTemporaryDraftLocation() throws -> (
+        directory: URL,
+        draft: URL
+    ) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpNotesRecoveryTests-\(UUID().uuidString)", isDirectory: true)
+        return (directory, directory.appendingPathComponent("unsaved-draft.json"))
+    }
+
+    func testNewestDraftIsRecoverableAcrossStoreInstances() throws {
+        let location = try makeTemporaryDraftLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let draft = FloorpNoteRecoveryDraft(
+            id: FloorpNoteID("note"),
+            title: "Unsaved",
+            content: "Recover me",
+            contentFormat: .plainText,
+            updatedAt: 42
+        )
+        let firstStore = FloorpNoteRecoveryDraftStore(fileURL: location.draft)
+        try firstStore.saveDraft(draft)
+
+        // A fresh store/process instance must recover the newest draft.
+        let relaunchedStore = FloorpNoteRecoveryDraftStore(fileURL: location.draft)
+        XCTAssertEqual(try relaunchedStore.loadRecoverableDraft(), draft)
+    }
+
+    func testClearRemovesTheRecoverableDraft() throws {
+        let location = try makeTemporaryDraftLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNoteRecoveryDraftStore(fileURL: location.draft)
+        try store.saveDraft(
+            FloorpNoteRecoveryDraft(
+                id: FloorpNoteID("note"),
+                title: "Unsaved",
+                content: "Recover me",
+                contentFormat: .plainText,
+                updatedAt: 1
+            )
+        )
+        try store.clear()
+        XCTAssertNil(try store.loadRecoverableDraft())
+    }
+
+    func testInjectedWriteFailurePreservesNewestRecoverableDraftWithoutPartialFile() throws {
+        let location = try makeTemporaryDraftLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let previous = FloorpNoteRecoveryDraft(
+            id: FloorpNoteID("note"),
+            title: "Previous",
+            content: "Oldest recoverable",
+            contentFormat: .plainText,
+            updatedAt: 1
+        )
+        let firstStore = FloorpNoteRecoveryDraftStore(fileURL: location.draft)
+        try firstStore.saveDraft(previous)
+
+        enum WriteFailure: Error { case injected }
+        let failingStore = FloorpNoteRecoveryDraftStore(
+            fileURL: location.draft,
+            writeData: { _, _ in throw WriteFailure.injected }
+        )
+        do {
+            try failingStore.saveDraft(
+                FloorpNoteRecoveryDraft(
+                    id: FloorpNoteID("note"),
+                    title: "Must not win",
+                    content: "replacement",
+                    contentFormat: .plainText,
+                    updatedAt: 2
+                )
+            )
+            XCTFail("Expected injected write failure")
+        } catch WriteFailure.injected {
+            // Expected.
+        }
+
+        // The newest recoverable draft must remain the last-good one, and a
+        // fresh instance must still read it with no partial file lingering.
+        let relaunchedStore = FloorpNoteRecoveryDraftStore(fileURL: location.draft)
+        XCTAssertEqual(try relaunchedStore.loadRecoverableDraft(), previous)
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: location.directory,
+            includingPropertiesForKeys: nil
+        )
+        let strayFiles = files.filter { $0.lastPathComponent != "unsaved-draft.json" }
+        XCTAssertTrue(
+            strayFiles.isEmpty,
+            "Unexpected partial/temp files: \(strayFiles.map(\.lastPathComponent))"
+        )
     }
 }
 
@@ -4332,6 +4472,66 @@ final class FloorpNoteSaveCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(savedDrafts.last?.title, "Edited")
         XCTAssertFalse(coordinator.hasUnsavedChanges)
+    }
+
+    func testUnsavedChangePersistsRecoveryDraftAndSuccessfulSaveClearsIt() async throws {
+        let location = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpNotesCoordinatorRecovery-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: location) }
+        let recoveryStore = FloorpNoteRecoveryDraftStore(fileURL: location)
+
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence,
+            recoveryDraftStore: recoveryStore
+        )
+
+        XCTAssertNil(coordinator.loadRecoverableDraft())
+        coordinator.updateTitle("Edited")
+
+        // The newest unsaved draft is recoverable before any save.
+        let recoverable = try XCTUnwrap(coordinator.loadRecoverableDraft())
+        XCTAssertEqual(recoverable.title, "Edited")
+        XCTAssertEqual(recoverable.content, original.content)
+
+        // A successful save clears the recovery snapshot.
+        guard case .saved = await coordinator.saveLatest() else {
+            return XCTFail("Expected the save to succeed")
+        }
+        XCTAssertNil(coordinator.loadRecoverableDraft())
+    }
+
+    func testFailedSaveKeepsNewestRecoverableDraft() async {
+        let location = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpNotesCoordinatorRecovery-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: location) }
+        let recoveryStore = FloorpNoteRecoveryDraftStore(fileURL: location)
+
+        let original = makeNote(id: "note", title: "Original", updatedAt: 1)
+        let persistence = MockFloorpNotePersistence()
+        persistence.saveHandler = { _ in
+            throw FloorpNotesStoreError.editConflict(original.id)
+        }
+        let coordinator = FloorpNoteSaveCoordinator(
+            draft: original,
+            isPersisted: true,
+            persistence: persistence,
+            recoveryDraftStore: recoveryStore
+        )
+        coordinator.updateContent("Unsaved body", contentFormat: .plainText)
+
+        guard case .failed(let failure) = await coordinator.saveLatest() else {
+            return XCTFail("Expected the save to fail")
+        }
+        XCTAssertEqual(failure.kind, .conflict)
+        XCTAssertTrue(coordinator.hasUnsavedChanges)
+
+        // The newest unsaved draft must survive the failed save for recovery.
+        let recoverable = try? XCTUnwrap(coordinator.loadRecoverableDraft())
+        XCTAssertEqual(recoverable?.content, "Unsaved body")
     }
 }
 


### PR DESCRIPTION
Adds actionable conflict/save-failure recovery for issue #22.

- Store: injectable atomic write (fault-inject write/rename/commit failures); a failed write preserves the last-good archive with no partial/temp file.
- Recoverable editor draft: `FloorpNoteRecoveryDraftStore` persists unsaved text so it survives force termination/relaunch; newest draft preserved on failed writes.
- Coordinator: persists a recovery draft on change, clears on save/save-as-copy/reload; exposes `loadRecoverableDraft()`.

TDD: red (missing types compile-fail) -> green targeted (81 tests) -> full FloorpCI (477 tests, 0 failures). SwiftLint 0 violations. Depends on #67 (merged).