### PR TITLE
feat(notes): add transactional JSON import and export (#23)

### DIFF
--- a/docs/floorp-notes-import-export.md
+++ b/docs/floorp-notes-import-export.md
@@ -1,0 +1,93 @@
+# Floorp Notes JSON Export and Import
+
+> Applies to milestone 0.2.0 (issue #23). Notes remain local-only; this
+> document describes the validated document format, import policy, corruption
+> backup retrieval, and privacy behavior.
+
+## Document format (export)
+
+Export produces the desktop parallel-array payload (schema
+`floorp-notes-desktop-payload-v1`), the same shape Floorp desktop persists in
+`floorp.browser.note.memos`. The payload is a JSON object with four parallel
+arrays:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `ids` | `[string]` | Byte-exact opaque note identifiers |
+| `titles` | `[string]` | Note titles |
+| `contents` | `[string]` | Opaque note bodies (plain text or rich JSON source) |
+| `createdAts` | `[int64]` | Creation timestamps in milliseconds |
+| `updatedAts` | `[int64]` | Last-update timestamps in milliseconds |
+
+`createdAts` and `updatedAts` are optional in the wire type but always emitted
+by export. Timestamps are Unix milliseconds. Content bytes are never rewritten:
+TipTap/Lexical JSON source and unknown rich text remain byte-for-byte
+unchanged through export and import.
+
+## Import validation
+
+Import accepts only the export format above. Every check runs **before** any
+mutation; a rejected document leaves the archive and its revision untouched:
+
+1. **Size** — the document must not exceed the archive byte limit
+   (`FloorpNotesStore.maximumArchiveBytes`).
+2. **Shape** — the document must decode as the desktop payload and every
+   parallel array must have the same length; `ids` is required.
+3. **Identifiers** — each ID must be non-empty (after trimming whitespace) and
+   byte-exact unique. Duplicate or empty IDs reject the import.
+4. **Timestamps** — when present, `createdAts` must be positive and
+   `updatedAts` must be greater than or equal to the corresponding
+   `createdAts` value.
+5. **Limits** — the note count must not exceed
+   `FloorpNotesStore.maximumNoteCount`.
+6. **Rich text** — content is preserved as opaque bytes. Imported notes carry
+   the `automatic` content format and are analyzed on open, so rich source
+   stays byte-identical and plain text remains editable.
+
+Malformed JSON, inconsistent arrays, missing IDs, oversized documents,
+duplicate IDs, invalid timestamps, and over-limit note counts each produce a
+typed `FloorpNotesStoreError` and never partially replace the last-good
+archive.
+
+## Import policy
+
+The UI requires explicit confirmation before either destructive operation.
+
+### Replace
+
+The imported notes replace the entire local archive. `replacedCount` reports
+the number of local notes that were replaced.
+
+### Merge
+
+Notes are merged by exact ID with a deterministic policy:
+
+- A shared ID keeps the version with the newer `updatedAt`.
+- A timestamp tie keeps the local version.
+- Imported IDs that do not exist locally are appended in payload order.
+
+`mergedCount` reports how many existing local notes changed.
+
+Both policies commit atomically. If the write, rename, or commit step fails,
+the last-good archive remains byte-identical and no partial or temporary file
+is left behind; a fresh store open restores the last-good state.
+
+## Corruption backup retrieval
+
+When the local archive is detected as damaged, the store copies the original
+bytes to a `*.corrupt-<timestamp>.json` recovery file and blocks writes until
+an explicit reset. The preserved backup is exposed as **untrusted data**
+through `preservedCorruptionBackupURL()` / `preservedCorruptionBackupData()`:
+
+- The backup is never auto-imported and is never treated as trusted Notes
+  content.
+- Loading still fails while the source is corrupt; the backup is only a
+  read-only recovery artifact for the user to inspect or export manually.
+- `resetAfterCorruption()` requires an explicit destructive decision and keeps
+  the recovery copy byte-identical on disk.
+
+## Privacy
+
+Export and import are local document operations. No network request is
+issued, no telemetry is attached to note content, and the payload is never
+persisted outside the archive and the explicit document the user chose.

--- a/firefox-ios/Floorp/FloorpNotes.swift
+++ b/firefox-ios/Floorp/FloorpNotes.swift
@@ -543,6 +543,101 @@ enum FloorpNoteContent {
     }
 }
 
+// MARK: - Import and export
+
+/// The deterministic conflict policy applied when importing a validated
+/// payload into the local archive.
+enum FloorpNotesImportPolicy: Sendable {
+    /// Replaces the entire local archive with the imported notes.
+    case replace
+
+    /// Merges by exact ID. When a local and an imported note share an ID, the
+    /// version with the newer `updatedAt` wins; ties keep the local version.
+    /// Imported IDs that do not exist locally are appended in payload order.
+    case merge
+}
+
+struct FloorpNotesImportResult: Equatable, Sendable {
+    let revision: UInt64
+    let importedCount: Int
+    /// Number of existing local notes whose value changed (merge policy).
+    let mergedCount: Int
+    /// Number of local notes replaced (replace policy).
+    let replacedCount: Int
+}
+
+/// Validates an import document before any store mutation. The only accepted
+/// format is the desktop payload produced by
+/// `FloorpNotesStore.desktopPayloadData()` (parallel `ids`/`titles`/
+/// `contents`/`createdAts`/`updatedAts` arrays). Validation is strict: invalid
+/// identifiers, byte-exact duplicates, inconsistent arrays, invalid
+/// timestamps, oversized input, and over-limit note counts all reject the
+/// document without touching the archive. Content bytes are never rewritten,
+/// so unknown rich-text source stays byte-for-byte preserved.
+enum FloorpNotesImportValidator {
+    static func validate(data: Data) throws -> [FloorpNote] {
+        guard data.count <= FloorpNotesStore.maximumArchiveBytes else {
+            throw FloorpNotesStoreError.archiveTooLarge(
+                actualBytes: data.count,
+                maximumBytes: FloorpNotesStore.maximumArchiveBytes
+            )
+        }
+
+        let payload: FloorpNotesDesktopPayload
+        do {
+            payload = try JSONDecoder().decode(FloorpNotesDesktopPayload.self, from: data)
+        } catch {
+            throw FloorpNotesStoreError.invalidImportPayload
+        }
+
+        guard let ids = payload.ids else {
+            throw FloorpNotesStoreError.invalidImportPayload
+        }
+        let count = ids.count
+        guard count == payload.titles.count, count == payload.contents.count else {
+            throw FloorpNotesStoreError.invalidImportPayload
+        }
+        if let createdAts = payload.createdAts, createdAts.count != count {
+            throw FloorpNotesStoreError.invalidImportPayload
+        }
+        if let updatedAts = payload.updatedAts, updatedAts.count != count {
+            throw FloorpNotesStoreError.invalidImportPayload
+        }
+        guard count <= FloorpNotesStore.maximumNoteCount else {
+            throw FloorpNotesStoreError.tooManyNotes(count)
+        }
+
+        var seenIDs = Set<FloorpNoteID>()
+        var notes = [FloorpNote]()
+        notes.reserveCapacity(count)
+        for index in ids.indices {
+            let id = FloorpNoteID(ids[index])
+            guard !id.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw FloorpNotesStoreError.invalidNoteID
+            }
+            guard seenIDs.insert(id).inserted else {
+                throw FloorpNotesStoreError.duplicateNoteID(id)
+            }
+            let createdAt = payload.createdAts?[index] ?? 0
+            let updatedAt = payload.updatedAts?[index] ?? createdAt
+            guard createdAt > 0, updatedAt >= createdAt else {
+                throw FloorpNotesStoreError.invalidTimestamp(id)
+            }
+            notes.append(
+                FloorpNote(
+                    id: id,
+                    title: payload.titles[index],
+                    content: payload.contents[index],
+                    createdAt: createdAt,
+                    updatedAt: updatedAt,
+                    contentFormat: .automatic
+                )
+            )
+        }
+        return notes
+    }
+}
+
 // MARK: - Store
 
 enum FloorpNotesStoreError: Error, LocalizedError {
@@ -552,6 +647,8 @@ enum FloorpNotesStoreError: Error, LocalizedError {
     case writesBlockedByCorruption(recoveryURL: URL)
     case invalidNoteID
     case duplicateNoteID(FloorpNoteID)
+    case invalidTimestamp(FloorpNoteID)
+    case invalidImportPayload
     case noteNotFound(FloorpNoteID)
     case editConflict(FloorpNoteID)
     case reorderConflict(expectedRevision: UInt64, actualRevision: UInt64)
@@ -573,6 +670,10 @@ enum FloorpNotesStoreError: Error, LocalizedError {
             return "A note has an invalid identifier."
         case .duplicateNoteID:
             return "Two notes have the same identifier."
+        case .invalidTimestamp(let id):
+            return "A note has an invalid timestamp (\(id.rawValue))."
+        case .invalidImportPayload:
+            return "The imported JSON payload is not a valid Floorp Notes document."
         case .noteNotFound:
             return "The note no longer exists."
         case .editConflict:
@@ -850,6 +951,58 @@ actor FloorpNotesStore {
         return data
     }
 
+    /// Imports a validated JSON document produced by `desktopPayloadData()`.
+    ///
+    /// Validation happens entirely before mutation: malformed, oversized,
+    /// duplicate, or timestamp-invalid input leaves the archive and revision
+    /// unchanged. The subsequent commit is atomic, so an injected write,
+    /// rename, or commit failure leaves the last-good archive intact with no
+    /// partial or temporary file behind.
+    @discardableResult
+    func importNotes(
+        from data: Data,
+        policy: FloorpNotesImportPolicy = .replace
+    ) throws -> FloorpNotesImportResult {
+        let archive = try loadArchiveForWriting()
+        let imported = try FloorpNotesImportValidator.validate(data: data)
+        let local = archive.notes
+        let notes: [FloorpNote]
+        var mergedCount = 0
+        var replacedCount = 0
+        switch policy {
+        case .replace:
+            notes = imported
+            replacedCount = local.count
+        case .merge:
+            (notes, mergedCount) = Self.mergedImport(imported, into: local)
+        }
+        try commit(notes: notes, replacing: archive)
+        return FloorpNotesImportResult(
+            revision: archiveByAdvancingRevision(of: archive, notes: notes).revision,
+            importedCount: imported.count,
+            mergedCount: mergedCount,
+            replacedCount: replacedCount
+        )
+    }
+
+    /// Returns the URL of the preserved corruption backup, if the current
+    /// store instance has one. The backup is untrusted data and is never
+    /// auto-imported.
+    func preservedCorruptionBackupURL() -> URL? {
+        if case .preserved(let recoveryURL) = corruptionState {
+            return recoveryURL
+        }
+        return nil
+    }
+
+    /// Returns the preserved corruption backup as raw untrusted data, or nil
+    /// when no recovery copy is currently preserved. Callers must never treat
+    /// this data as trusted Notes content.
+    func preservedCorruptionBackupData() throws -> Data? {
+        guard let recoveryURL = preservedCorruptionBackupURL() else { return nil }
+        return try Data(contentsOf: recoveryURL)
+    }
+
     /// Allows the UI to recover only after an explicit destructive decision
     /// and only when a separate recovery copy was successfully created.
     func resetAfterCorruption() throws {
@@ -862,6 +1015,34 @@ actor FloorpNotesStore {
         cachedArchive = emptyArchive
         self.corruptionState = nil
         postChangeNotification(revision: emptyArchive.revision)
+    }
+
+    /// Deterministic merge: newer `updatedAt` wins for a shared ID, ties keep
+    /// the local version, and imported IDs missing locally are appended in
+    /// payload order.
+    private static func mergedImport(
+        _ imported: [FloorpNote],
+        into local: [FloorpNote]
+    ) -> (notes: [FloorpNote], mergedCount: Int) {
+        var byID = Dictionary(uniqueKeysWithValues: local.map { ($0.id, $0) })
+        var mergedCount = 0
+        for note in imported {
+            if let existing = byID[note.id] {
+                if note.updatedAt > existing.updatedAt {
+                    byID[note.id] = note
+                    mergedCount += 1
+                }
+            } else {
+                byID[note.id] = note
+            }
+        }
+        var notes = local.map { byID[$0.id] ?? $0 }
+        var seen = Set(local.map(\.id))
+        for note in imported where !seen.contains(note.id) {
+            notes.append(note)
+            seen.insert(note.id)
+        }
+        return (notes, mergedCount)
     }
 
     private func loadArchiveForWriting() throws -> Archive {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -949,6 +949,384 @@ final class FloorpNoteRecoveryDraftStoreTests: XCTestCase {
     }
 }
 
+final class FloorpNotesImportExportTests: XCTestCase, @unchecked Sendable {
+    private func makeTemporaryArchiveLocation() throws -> (directory: URL, archive: URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FloorpNotesImportTests-\(UUID().uuidString)", isDirectory: true)
+        return (directory, directory.appendingPathComponent("notes.json"))
+    }
+
+    private func payloadData(notes: [FloorpNote]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(FloorpNotesDesktopPayload(notes: notes))
+    }
+
+    func testExportImportRoundTripPreservesIDsTimestampsAndOpaqueRichBytes() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let richJSON = #"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Rich"}]}]}"#
+        let plain = makeFloorpTestNote(
+            id: "plain",
+            title: "Plain",
+            content: "Hello",
+            createdAt: 10,
+            updatedAt: 20,
+            contentFormat: .plainText
+        )
+        let rich = makeFloorpTestNote(
+            id: "rich",
+            title: "Rich",
+            content: richJSON,
+            createdAt: 30,
+            updatedAt: 40,
+            contentFormat: .automatic
+        )
+        try await store.replaceAllNotes(with: [plain, rich])
+
+        let exported = try await store.desktopPayloadData()
+        let restartedStore = FloorpNotesStore(fileURL: location.archive)
+        let result = try await restartedStore.importNotes(from: exported, policy: .replace)
+        let notes = try await restartedStore.loadNotes()
+
+        XCTAssertEqual(result.importedCount, 2)
+        XCTAssertEqual(result.replacedCount, 2)
+        XCTAssertEqual(result.mergedCount, 0)
+        XCTAssertEqual(notes.map(\.id), [plain.id, rich.id])
+        XCTAssertEqual(notes.map(\.title), ["Plain", "Rich"])
+        XCTAssertEqual(notes.map(\.content), ["Hello", richJSON])
+        XCTAssertEqual(notes.map(\.createdAt), [10, 30])
+        XCTAssertEqual(notes.map(\.updatedAt), [20, 40])
+    }
+
+    func testMalformedInconsistentOrInvalidIDImportLeavesArchiveUnchanged() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let seed = makeFloorpTestNote(
+            id: "seed",
+            title: "Seed",
+            content: "keep",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        try await store.replaceAllNotes(with: [seed])
+        let before = try await store.loadSnapshot()
+
+        let invalidJSON = Data("not json".utf8)
+        let inconsistentArrays = Data(#"{"ids":["a"],"titles":["T"],"contents":["C","extra"]}"#.utf8)
+        let missingIDs = Data(#"{"titles":["T"],"contents":["C"]}"#.utf8)
+        let emptyID = Data(#"{"ids":[""],"titles":["T"],"contents":["C"],"createdAts":[1],"updatedAts":[2]}"#.utf8)
+
+        do {
+            _ = try await store.importNotes(from: invalidJSON, policy: .replace)
+            XCTFail("Expected invalidImportPayload")
+        } catch FloorpNotesStoreError.invalidImportPayload {
+            // Expected.
+        }
+        do {
+            _ = try await store.importNotes(from: inconsistentArrays, policy: .replace)
+            XCTFail("Expected invalidImportPayload")
+        } catch FloorpNotesStoreError.invalidImportPayload {
+            // Expected.
+        }
+        do {
+            _ = try await store.importNotes(from: missingIDs, policy: .replace)
+            XCTFail("Expected invalidImportPayload")
+        } catch FloorpNotesStoreError.invalidImportPayload {
+            // Expected.
+        }
+        do {
+            _ = try await store.importNotes(from: emptyID, policy: .replace)
+            XCTFail("Expected invalidNoteID")
+        } catch FloorpNotesStoreError.invalidNoteID {
+            // Expected.
+        }
+
+        let after = try await store.loadSnapshot()
+        XCTAssertEqual(after, before, "rejected imports must leave archive and revision unchanged")
+    }
+
+    func testOversizedDuplicateTimestampAndLimitImportsAreRejected() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let seed = makeFloorpTestNote(
+            id: "seed",
+            title: "Seed",
+            content: "keep",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        try await store.replaceAllNotes(with: [seed])
+        let before = try await store.loadSnapshot()
+
+        let oversized = Data(#"{"ids":["a"],"titles":["T"],"contents":[""#.utf8)
+            + Data(String(repeating: "x", count: FloorpNotesStore.maximumArchiveBytes).utf8)
+            + Data(#""],"createdAts":[1],"updatedAts":[2]}"#.utf8)
+        do {
+            _ = try await store.importNotes(from: oversized, policy: .replace)
+            XCTFail("Expected archiveTooLarge")
+        } catch FloorpNotesStoreError.archiveTooLarge(_, _) {
+            // Expected.
+        }
+
+        let duplicate = Data(
+            #"{"ids":["a","a"],"titles":["T","U"],"contents":["C","D"],"createdAts":[1,1],"updatedAts":[2,2]}"#.utf8
+        )
+        do {
+            _ = try await store.importNotes(from: duplicate, policy: .replace)
+            XCTFail("Expected duplicateNoteID")
+        } catch FloorpNotesStoreError.duplicateNoteID(let id) {
+            XCTAssertEqual(id, FloorpNoteID("a"))
+        }
+
+        let zeroTimestamp = Data(
+            #"{"ids":["a"],"titles":["T"],"contents":["C"],"createdAts":[0],"updatedAts":[2]}"#.utf8
+        )
+        do {
+            _ = try await store.importNotes(from: zeroTimestamp, policy: .replace)
+            XCTFail("Expected invalidTimestamp")
+        } catch FloorpNotesStoreError.invalidTimestamp(let id) {
+            XCTAssertEqual(id, FloorpNoteID("a"))
+        }
+
+        let reversedTimestamp = Data(
+            #"{"ids":["a"],"titles":["T"],"contents":["C"],"createdAts":[5],"updatedAts":[2]}"#.utf8
+        )
+        do {
+            _ = try await store.importNotes(from: reversedTimestamp, policy: .replace)
+            XCTFail("Expected invalidTimestamp")
+        } catch FloorpNotesStoreError.invalidTimestamp {
+            // Expected.
+        }
+
+        let overLimit = (0..<(FloorpNotesStore.maximumNoteCount + 1)).map { index in
+            makeFloorpTestNote(
+                id: "note-\(index)",
+                title: "T",
+                content: "",
+                createdAt: 1,
+                updatedAt: 2,
+                contentFormat: .plainText
+            )
+        }
+        do {
+            _ = try await store.importNotes(from: try payloadData(notes: overLimit), policy: .replace)
+            XCTFail("Expected tooManyNotes")
+        } catch FloorpNotesStoreError.tooManyNotes(let count) {
+            XCTAssertEqual(count, FloorpNotesStore.maximumNoteCount + 1)
+        }
+
+        let after = try await store.loadSnapshot()
+        XCTAssertEqual(after, before, "rejected imports must leave archive and revision unchanged")
+    }
+
+    func testMergePolicyNewerWinsTieKeepsLocalAndNewIDsAppend() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let localA = makeFloorpTestNote(
+            id: "a",
+            title: "A local",
+            content: "a1",
+            createdAt: 1,
+            updatedAt: 100,
+            contentFormat: .plainText
+        )
+        let localB = makeFloorpTestNote(
+            id: "b",
+            title: "B local",
+            content: "b1",
+            createdAt: 1,
+            updatedAt: 200,
+            contentFormat: .plainText
+        )
+        try await store.replaceAllNotes(with: [localA, localB])
+
+        let importedA = makeFloorpTestNote(
+            id: "a",
+            title: "A remote newer",
+            content: "a2",
+            createdAt: 1,
+            updatedAt: 150,
+            contentFormat: .plainText
+        )
+        let importedB = makeFloorpTestNote(
+            id: "b",
+            title: "B remote tie",
+            content: "b2",
+            createdAt: 1,
+            updatedAt: 200,
+            contentFormat: .plainText
+        )
+        let importedC = makeFloorpTestNote(
+            id: "c",
+            title: "C new",
+            content: "c1",
+            createdAt: 1,
+            updatedAt: 300,
+            contentFormat: .plainText
+        )
+        let data = try payloadData(notes: [importedA, importedB, importedC])
+
+        let result = try await store.importNotes(from: data, policy: .merge)
+        let notes = try await store.loadNotes()
+
+        XCTAssertEqual(result.importedCount, 3)
+        XCTAssertEqual(result.mergedCount, 1)
+        XCTAssertEqual(result.replacedCount, 0)
+        XCTAssertEqual(notes.map(\.id), [FloorpNoteID("a"), FloorpNoteID("b"), FloorpNoteID("c")])
+        XCTAssertEqual(notes[0].title, "A remote newer")
+        XCTAssertEqual(notes[1].title, "B local")
+        XCTAssertEqual(notes[2].title, "C new")
+    }
+
+    func testReplacePolicyReplacesAllNotesAndAdvancesRevision() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let first = makeFloorpTestNote(
+            id: "first",
+            title: "First",
+            content: "old",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        let second = makeFloorpTestNote(
+            id: "second",
+            title: "Second",
+            content: "old",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        try await store.replaceAllNotes(with: [first, second])
+        let before = try await store.loadSnapshot()
+
+        let replacement = makeFloorpTestNote(
+            id: "replacement",
+            title: "Replacement",
+            content: "new",
+            createdAt: 3,
+            updatedAt: 4,
+            contentFormat: .plainText
+        )
+        let result = try await store.importNotes(
+            from: try payloadData(notes: [replacement]),
+            policy: .replace
+        )
+
+        XCTAssertEqual(result.replacedCount, 2)
+        XCTAssertEqual(result.mergedCount, 0)
+        XCTAssertEqual(result.revision, before.revision + 1)
+        let notes = try await store.loadNotes()
+        XCTAssertEqual(notes.map(\.id), [replacement.id])
+    }
+
+    func testInjectedWriteFailureDuringImportRestoresLastGoodArchive() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let seedStore = FloorpNotesStore(fileURL: location.archive)
+        let seed = makeFloorpTestNote(
+            id: "seed",
+            title: "Seed",
+            content: "original",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        try await seedStore.replaceAllNotes(with: [seed])
+        let originalArchiveBytes = try Data(contentsOf: location.archive)
+
+        enum WriteFailure: Error { case injected }
+        let failingStore = FloorpNotesStore(
+            fileURL: location.archive,
+            writeData: { _, _ in throw WriteFailure.injected }
+        )
+        let incoming = makeFloorpTestNote(
+            id: "other",
+            title: "Other",
+            content: "x",
+            createdAt: 1,
+            updatedAt: 2,
+            contentFormat: .plainText
+        )
+        do {
+            _ = try await failingStore.importNotes(
+                from: try payloadData(notes: [incoming]),
+                policy: .replace
+            )
+            XCTFail("Expected injected write failure")
+        } catch WriteFailure.injected {
+            // Expected.
+        }
+
+        // A fresh store open restores the last-good archive byte-for-byte.
+        let restartedStore = FloorpNotesStore(fileURL: location.archive)
+        let restartedNotes = try await restartedStore.loadNotes()
+        XCTAssertEqual(restartedNotes, [seed])
+        XCTAssertEqual(try Data(contentsOf: location.archive), originalArchiveBytes)
+
+        // No partial or temporary files may linger.
+        let files = try FileManager.default.contentsOfDirectory(
+            at: location.directory,
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertTrue(files.allSatisfy { $0.lastPathComponent == "notes.json" })
+    }
+
+    func testCorruptionBackupIsRetrievableUntrustedAndNeverAutoImported() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+        try FileManager.default.createDirectory(at: location.directory, withIntermediateDirectories: true)
+        let corruptBytes = Data("not-json".utf8)
+        try corruptBytes.write(to: location.archive)
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        do {
+            _ = try await store.loadNotes()
+            XCTFail("Expected corruptArchive")
+        } catch FloorpNotesStoreError.corruptArchive {
+            // Expected.
+        }
+
+        let backup = try await store.preservedCorruptionBackupData()
+        XCTAssertEqual(backup, corruptBytes)
+        let preservedURL = await store.preservedCorruptionBackupURL()
+        XCTAssertNotNil(preservedURL)
+
+        // The backup is never auto-imported: loading still fails.
+        do {
+            _ = try await store.loadNotes()
+            XCTFail("Expected corruptArchive")
+        } catch FloorpNotesStoreError.corruptArchive {
+            // Expected.
+        }
+
+        // Reset keeps the recovery copy byte-identical on disk.
+        try await store.resetAfterCorruption()
+        let clearedURL = await store.preservedCorruptionBackupURL()
+        XCTAssertNil(clearedURL)
+        let remaining = try FileManager.default.contentsOfDirectory(
+            at: location.directory,
+            includingPropertiesForKeys: nil
+        )
+        let backupURL = try XCTUnwrap(remaining.first { $0.lastPathComponent.contains(".corrupt-") })
+        XCTAssertEqual(try Data(contentsOf: backupURL), corruptBytes)
+    }
+}
+
 @MainActor
 final class FloorpNoteEditorViewControllerTests: XCTestCase {
     private let safePNGDataURL = "data:image/png;base64,"


### PR DESCRIPTION
Adds validated JSON export/import and corruption-backup retrieval for issue #23.

- Strict import validation (size, exact byte-exact IDs, timestamps, duplicates, limits, opaque rich-text preservation) before any mutation; rejected documents leave archive/revision unchanged.
- Deterministic replace/merge policy (`FloorpNotesImportPolicy`): newer `updatedAt` wins, ties keep local, new IDs append.
- Transactional atomic commit: injected write/rename/commit failure restores the last-good archive byte-for-byte with no partial/temp file.
- Corruption backup exposed as untrusted data (`preservedCorruptionBackupURL/Data`), never auto-imported.
- Schema/version and privacy documented in `docs/floorp-notes-import-export.md`.

TDD: red (missing APIs compile-fail) -> green targeted (72 tests) -> full FloorpCI (477 tests, 0 failures). SwiftLint 0 violations. Depends on #68 (merged).