### PR TITLE
test(notes): add local v1 UI smoke workflow (#24)

### DIFF
--- a/.github/workflows/notes-ui.yml
+++ b/.github/workflows/notes-ui.yml
@@ -1,0 +1,179 @@
+name: Floorp Notes UI smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/notes-ui.yml
+      - .xcode-version
+      - BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+      - firefox-ios/Client/Application/UITestAppDelegate.swift
+      - firefox-ios/Floorp/**
+      - firefox-ios/Client.xcodeproj/project.pbxproj
+      - firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+      - firefox-ios/firefox-ios-tests/Tests/FloorpNotesUI.xctestplan
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/BaseTestCase.swift
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesLocalV1UITests.swift
+      - firefox-ios/firefox-ios-tests/Tests/XCUITests/XCUIElementHelpers.swift
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: floorp-notes-ui-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_PATH: firefox-ios/Client.xcodeproj
+  SCHEME: Fennec
+  CONFIGURATION: Fennec_Testing
+  SIMULATOR_OS: "26.2"
+
+jobs:
+  notes-ui:
+    name: Notes UI (${{ matrix.simulator_name }}, ${{ matrix.language }})
+    runs-on: macos-26
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - simulator_name: iPhone 17
+            language: en-US
+            region: US
+            artifact_suffix: iphone-17-en
+          - simulator_name: iPhone 17
+            language: ja-JP
+            region: JP
+            artifact_suffix: iphone-17-ja
+          - simulator_name: iPad (A16)
+            language: en-US
+            region: US
+            artifact_suffix: ipad-a16-en
+          - simulator_name: iPad (A16)
+            language: ja-JP
+            region: JP
+            artifact_suffix: ipad-a16-ja
+    env:
+      SIMULATOR_NAME: ${{ matrix.simulator_name }}
+      TEST_LANGUAGE: ${{ matrix.language }}
+      TEST_REGION: ${{ matrix.region }}
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Select Xcode
+        run: |
+          xcode_version="$(<.xcode-version)"
+          sudo xcode-select --switch "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
+          xcodebuild -version
+          swift --version
+
+      - name: Bootstrap generated sources
+        run: ./bootstrap.sh firefox
+        env:
+          CI: "true"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
+      - name: Prepare iOS Simulator
+        timeout-minutes: 10
+        run: |
+          runtime="com.apple.CoreSimulator.SimRuntime.iOS-${SIMULATOR_OS//./-}"
+          simulator_id="$(
+            xcrun simctl list devices available --json \
+              | jq -er --arg runtime "$runtime" --arg name "$SIMULATOR_NAME" \
+                '.devices[$runtime] | map(select(.name == $name)) | first | .udid'
+          )"
+          simulator_arch="$(uname -m)"
+
+          xcrun simctl bootstatus "$simulator_id" -b
+          printf 'DESTINATION=platform=iOS Simulator,id=%s,arch=%s\n' \
+            "$simulator_id" "$simulator_arch" >> "$GITHUB_ENV"
+          printf 'Using %s (%s, %s)\n' "$SIMULATOR_NAME" "$simulator_id" "$simulator_arch"
+
+      - name: Build Floorp Notes UI tests
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing -quiet \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -destination "$DESTINATION" \
+            -testPlan FloorpNotesUI \
+            -only-testing:XCUITests/FloorpNotesLocalV1UITests \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/notes-ui-build.log"
+
+      - name: Run Floorp Notes UI tests
+        timeout-minutes: 30
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -project "$PROJECT_PATH" \
+            -scheme "$SCHEME" \
+            -configuration "$CONFIGURATION" \
+            -destination "$DESTINATION" \
+            -testPlan FloorpNotesUI \
+            -only-testing:XCUITests/FloorpNotesLocalV1UITests \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            -testLanguage "$TEST_LANGUAGE" \
+            -testRegion "$TEST_REGION" \
+            -test-timeouts-enabled YES \
+            -default-test-execution-time-allowance 180 \
+            -maximum-test-execution-time-allowance 300 \
+            -retry-tests-on-failure \
+            -test-iterations 2 \
+            -test-repetition-relaunch-enabled YES \
+            -resultBundlePath "$RUNNER_TEMP/FloorpNotesUI.xcresult" \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/notes-ui-test.log"
+
+      - name: Upload Floorp Notes UI evidence and diagnostics
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: floorp-notes-ui-${{ matrix.artifact_suffix }}-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/notes-ui-build.log
+            ${{ runner.temp }}/notes-ui-test.log
+            ${{ runner.temp }}/FloorpNotesUI.xcresult
+          if-no-files-found: ignore
+          retention-days: 7

--- a/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
+++ b/BrowserKit/Sources/Common/Constants/LaunchArguments.swift
@@ -17,6 +17,10 @@ public struct LaunchArguments {
     /// Clears the WKWebView website data store (cookies, local storage, cache) on launch. Web data
     /// lives in WKWebsiteDataStore, which ClearProfile does not touch.
     public static let ClearWebData = "FIREFOX_CLEAR_WEB_DATA"
+    /// Clears the Floorp Notes local archive (including recovery copies and
+    /// unsaved drafts) on launch. Notes live outside the browser profile, so
+    /// ClearProfile does not touch them; UI tests opt in explicitly.
+    public static let FloorpNotesClearArchive = "FLOORP_NOTES_CLEAR_ARCHIVE"
     public static let StageServer = "FIREFOX_USE_STAGE_SERVER"
     public static let FxAChinaServer = "FIREFOX_USE_FXA_CHINA_SERVER"
     public static let DeviceName = "DEVICE_NAME"

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */; };
 		F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */; };
 		F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00272F50000100000001 /* FloorpBrandingUITests.swift */; };
+		F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2812,6 +2813,7 @@
 		F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpAdaptiveSidebarUITests.swift; sourceTree = "<group>"; };
 		F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpPrivateHeaderBrandingUITests.swift; sourceTree = "<group>"; };
 		F10A00272F50000100000001 /* FloorpBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpBrandingUITests.swift; sourceTree = "<group>"; };
+		F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesLocalV1UITests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13559,6 +13561,7 @@
 				F10A00202F50000100000001 /* FloorpAdaptiveSidebarUITests.swift */,
 				F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */,
 				F10A00272F50000100000001 /* FloorpBrandingUITests.swift */,
+				F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19600,6 +19603,7 @@
 				F10A00212F50000100000001 /* FloorpAdaptiveSidebarUITests.swift in Sources */,
 				F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */,
 				F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */,
+				F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/Fennec.xcscheme
@@ -583,6 +583,9 @@
             reference = "container:firefox-ios-tests/Tests/FloorpBrandingUI.xctestplan">
          </TestPlanReference>
          <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FloorpNotesUI.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
             reference = "container:firefox-ios-tests/Tests/FloorpCI.xctestplan">
          </TestPlanReference>
          <TestPlanReference

--- a/firefox-ios/Client/Application/UITestAppDelegate.swift
+++ b/firefox-ios/Client/Application/UITestAppDelegate.swift
@@ -252,6 +252,21 @@ class UITestAppDelegate: AppDelegate {
             ) {}
         }
 
+        // Floorp Notes live outside the browser profile, so ClearProfile does
+        // not touch them. UI tests opt into a clean archive explicitly so the
+        // create/edit/search/delete/relaunch smoke is deterministic.
+        if ProcessInfo.processInfo.arguments.contains(LaunchArguments.FloorpNotesClearArchive) {
+            let notesDirectory = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first?
+                .appendingPathComponent("Floorp", isDirectory: true)
+                .appendingPathComponent("Notes", isDirectory: true)
+            if let notesDirectory {
+                try? FileManager.default.removeItem(at: notesDirectory)
+            }
+        }
+
         Tab.ChangeUserAgent.clear()
 
         let didFinishLaunching = super.application(

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpNotesUI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpNotesUI.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "8D10A4A6-5310-4D3E-BAB6-16F0FB4F534B",
+      "name" : "Floorp Notes UI",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en-US",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "FloorpNotesLocalV1UITests/testCloseKeepsUnsavedEditsThroughAutosave()",
+        "FloorpNotesLocalV1UITests/testCreateEditSearchDeleteAndRelaunchPersistence()"
+      ],
+      "target" : {
+        "containerPath" : "container:Client.xcodeproj",
+        "identifier" : "3BFE4B061D342FB800DDF53F",
+        "name" : "XCUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesLocalV1UITests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesLocalV1UITests.swift
@@ -1,0 +1,216 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import XCTest
+
+/// Floorp Notes Local v1 UI smoke coverage (issue #24).
+///
+/// Runs in the EN/JA iPhone/iPad matrix (see `FloorpNotesUI.xctestplan`).
+/// Every interaction targets a stable accessibility identifier; assertions
+/// never depend on localized visible text. The archive is cleared through the
+/// test-only `LaunchArguments.FloorpNotesClearArchive` hook on the first
+/// launch so the create/edit/search/delete/relaunch flow is deterministic.
+@MainActor
+final class FloorpNotesLocalV1UITests: BaseTestCase {
+    private enum Identifier {
+        static let toolbarButton = "floorpDrawerToolbarButton"
+        static let drawerContainer = "Floorp.Drawer.Container"
+        static let notesPanel = "floorp//notes"
+        static let notesSearch = "Floorp.Notes.Search"
+        static let notesAdd = "Floorp.Notes.Add"
+        static let drawerClose = "Floorp.Drawer.Close"
+        static let editorTitle = "Floorp.Notes.Editor.Title"
+        static let editorBody = "Floorp.Notes.Editor.Body"
+        static let editorClose = "Floorp.Notes.Editor.Close"
+        static let editorSave = "Floorp.Notes.Editor.Save"
+        static let rowPrefix = "Floorp.Notes.Row."
+    }
+
+    override func setUp() async throws {
+        launchArguments.append(LaunchArguments.FloorpNotesClearArchive)
+        try await super.setUp()
+    }
+
+    private func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any).matching(identifier: identifier).firstMatch
+    }
+
+    @discardableResult
+    private func waitFor(
+        _ identifier: String,
+        timeout: TimeInterval = TIMEOUT
+    ) -> XCUIElement {
+        let result = element(identifier)
+        if !result.waitForExistence(timeout: timeout) {
+            let hierarchy = XCTAttachment(string: app.debugDescription)
+            hierarchy.name = "missing-\(identifier)-hierarchy"
+            hierarchy.lifetime = .keepAlways
+            add(hierarchy)
+
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "missing-\(identifier)-screenshot"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+        }
+        XCTAssertTrue(result.exists, "Timed out waiting for \(identifier)")
+        return result
+    }
+
+    private func noteRows() -> XCUIElementQuery {
+        app.descendants(matching: .any).matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", Identifier.rowPrefix)
+        )
+    }
+
+    private func openNotes() {
+        let toolbarButton = waitFor(Identifier.toolbarButton)
+        XCTAssertTrue(toolbarButton.isHittable)
+        toolbarButton.tap()
+        _ = waitFor(Identifier.drawerContainer)
+        let notesButton = waitFor(Identifier.notesPanel)
+        XCTAssertTrue(notesButton.isHittable)
+        notesButton.tap()
+        _ = waitFor(Identifier.notesSearch)
+    }
+
+    private func createNote(title: String, body: String) {
+        let add = waitFor(Identifier.notesAdd)
+        XCTAssertTrue(add.isHittable)
+        add.tap()
+
+        let titleField = waitFor(Identifier.editorTitle)
+        XCTAssertTrue(titleField.isHittable)
+        titleField.clearText()
+        titleField.typeText(title)
+
+        let bodyField = waitFor(Identifier.editorBody)
+        bodyField.tap()
+        bodyField.typeText(body)
+
+        waitFor(Identifier.editorSave).tap()
+        // Closing saves the latest draft and returns to the notes list; the
+        // resulting row is verified through search rather than a transient
+        // status label.
+        waitFor(Identifier.editorClose).tap()
+        _ = waitFor(Identifier.notesSearch)
+    }
+
+    private func searchFor(_ text: String) {
+        let search = waitFor(Identifier.notesSearch)
+        search.tap()
+        search.clearText()
+        search.typeText(text)
+    }
+
+    /// Reveals the trailing delete action for a row and returns it without
+    /// depending on its localized title: the revealed action is the only
+    /// hittable drawer button whose frame intersects the row.
+    private func revealDeleteAction(for row: XCUIElement) -> XCUIElement {
+        row.swipeLeft()
+        let drawer = element(Identifier.drawerContainer)
+        let candidate = drawer.buttons.allElementsBoundByIndex.first { button in
+            button.isHittable && button.frame.intersects(row.frame)
+        }
+        XCTAssertNotNil(candidate, "Delete action must appear after swiping the row")
+        return candidate!
+    }
+
+    func testCreateEditSearchDeleteAndRelaunchPersistence() {
+        let title = "UITest-\(UUID().uuidString.prefix(8))"
+        let editedBody = "Edited-\(UUID().uuidString)"
+
+        openNotes()
+
+        // Create + edit in one pass, then save.
+        createNote(title: title, body: "Original-\(UUID().uuidString)")
+
+        // Reopen the note from search and edit it.
+        searchFor(title)
+        let row = noteRows().firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: TIMEOUT), "created note row must appear in search")
+        row.tap()
+
+        let bodyField = waitFor(Identifier.editorBody)
+        bodyField.tap()
+        bodyField.typeText(editedBody)
+        waitFor(Identifier.editorSave).tap()
+        waitFor(Identifier.editorClose).tap()
+        _ = waitFor(Identifier.notesSearch)
+
+        // Search still finds it after the edit.
+        searchFor(title)
+        XCTAssertTrue(noteRows().firstMatch.waitForExistence(timeout: TIMEOUT))
+
+        // Relaunch persistence: terminate and relaunch without clearing the archive.
+        app.terminate()
+        app.launchArguments = app.launchArguments.filter {
+            $0 != LaunchArguments.FloorpNotesClearArchive
+        }
+        app.launch()
+        openNotes()
+        searchFor(title)
+        XCTAssertTrue(
+            noteRows().firstMatch.waitForExistence(timeout: TIMEOUT),
+            "Note must persist across relaunch"
+        )
+
+        // Delete via the trailing swipe action and explicit confirmation.
+        let rowToDelete = noteRows().firstMatch
+        XCTAssertTrue(rowToDelete.waitForExistence(timeout: TIMEOUT))
+        let deleteAction = revealDeleteAction(for: rowToDelete)
+        XCTAssertTrue(deleteAction.waitForExistence(timeout: TIMEOUT))
+        deleteAction.tap()
+
+        let alert = app.alerts.firstMatch
+        XCTAssertTrue(alert.waitForExistence(timeout: TIMEOUT), "Delete confirmation must appear")
+        // Cancel is the first alert button; the destructive Delete is the last.
+        alert.buttons.element(boundBy: alert.buttons.count - 1).tap()
+
+        // The table empties immediately, but a stale accessibility cell can
+        // linger until the list is rebuilt. Reopen the drawer and search again
+        // to verify the deletion persisted.
+        waitFor(Identifier.drawerClose).tap()
+        let drawerGone = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: element(Identifier.drawerContainer)
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [drawerGone], timeout: TIMEOUT),
+            .completed,
+            "Drawer must close after the delete"
+        )
+        openNotes()
+        searchFor(title)
+        XCTAssertFalse(
+            noteRows().firstMatch.exists,
+            "Deleted note must not reappear after reopening the drawer"
+        )
+    }
+
+    func testCloseKeepsUnsavedEditsThroughAutosave() {
+        let title = "Unsaved-\(UUID().uuidString.prefix(8))"
+
+        openNotes()
+        let add = waitFor(Identifier.notesAdd)
+        XCTAssertTrue(add.isHittable)
+        add.tap()
+
+        let titleField = waitFor(Identifier.editorTitle)
+        XCTAssertTrue(titleField.isHittable)
+        titleField.tap()
+        titleField.typeText(title)
+
+        // Closing an editor with unsaved changes saves the draft rather than
+        // silently losing it (recovery smoke).
+        waitFor(Identifier.editorClose).tap()
+        _ = waitFor(Identifier.notesSearch)
+
+        searchFor(title)
+        XCTAssertTrue(
+            noteRows().firstMatch.waitForExistence(timeout: TIMEOUT),
+            "Closing must not lose the unsaved draft"
+        )
+    }
+}


### PR DESCRIPTION
Adds the dedicated Floorp Notes UI smoke plan and retained CI workflow for issue #24.

- `FloorpNotesUI.xctestplan` + `XCUITests/FloorpNotesLocalV1UITests.swift`: create → edit → search → delete → relaunch persistence, plus close-keeps-unsaved-edits recovery smoke. All interactions use stable accessibility identifiers; no localized visible-text assertions.
- `.github/workflows/notes-ui.yml`: exactly four iOS 26.2 combinations (iPhone 17 / iPad (A16) × en-US / ja-JP) with `-testLanguage`/`-testRegion`, failure artifacts (build/test logs + xcresult with screenshots/hierarchy) retained 7 days.
- Test-only `FLOORP_NOTES_CLEAR_ARCHIVE` launch hook (LaunchArguments + UITestAppDelegate) so the smoke starts from a clean archive deterministically.
- Registered the test file in project.pbxproj and the plan in Fennec.xcscheme.

Local matrix: 4/4 combinations green (2 tests, 0 failures each). SwiftLint 0 violations. Depends on #70 (merged).