### PR TITLE
docs(privacy): record external beta service boundaries (#15)

### DIFF
--- a/docs/app-store-connect-metadata.json
+++ b/docs/app-store-connect-metadata.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "note": "App Store Connect metadata and App Privacy/export-compliance artifact for the Floorp release line. Internally consistent by construction; validate-floorp-privacy.py rejects drift (wrong app id, locales outside the acceptance set, contradictory privacy answers, or unset export fields).",
+  "app": {
+    "bundle_id": "app.floorp.Floorp",
+    "apple_id": "6796708699",
+    "team_id": "DV2U35YBHT",
+    "name": "Floorp",
+    "primary_locales": ["en-US", "ja-JP"],
+    "marketing_version_source": "firefox-ios/Client/Configuration/FloorpRelease.xcconfig (FLOORP_MARKETING_VERSION)",
+    "build_number_source": "Xcode Cloud monotonic distribution build numbers (single authority)",
+    "app_store_id": "unset until the public listing is live (FLOORP_APP_STORE_ID empty)"
+  },
+  "privacy": {
+    "privacy_policy_url": "https://floorp.app/privacy",
+    "data_types": [
+      {
+        "category": "Contact Info",
+        "data_type": "Email Address",
+        "collected": true,
+        "linked_to_user_identity": true,
+        "purpose": ["App Functionality"],
+        "note": "FxA account email"
+      },
+      {
+        "category": "Identifiers",
+        "data_type": "User ID",
+        "collected": true,
+        "linked_to_user_identity": true,
+        "purpose": ["App Functionality"],
+        "note": "FxA user id for Sync"
+      }
+    ],
+    "collected_data_notes": "Notes remain local-only in the iOS app; no note content is collected. Analytics/other third-party data collection categories intentionally omitted."
+  },
+  "export_compliance": {
+    "uses_encryption": true,
+    "exempt_from_export_compliance": true,
+    "exemption_notes": "Standard TLS plus FxA/Sync over TLS only; no custom non-exempt cryptography",
+    "itsapp_uses_non_exempt_encryption": false
+  },
+  "listing": {
+    "category": "Utilities",
+    "age_rating_notes": "Unrestricted web browsing; final age rating requires App Store review",
+    "description": "Floorp web browser",
+    "support_url": "https://floorp.app",
+    "marketing_url": "https://floorp.app"
+  }
+}

--- a/docs/floorp-release-endpoints.json
+++ b/docs/floorp-release-endpoints.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": 1,
+  "note": "Floorp release runtime endpoint matrix. Every endpoint reachable from a FloorpRelease build must be listed; the network capture harness and validate-floorp-privacy.py treat any traced host outside this matrix as an unowned-service failure. Disabled services remain disabled by build/runtime policy (docs/ci-cd.md) and must not appear in traces.",
+  "endpoints": [
+    {
+      "host": "accounts.firefox.com",
+      "purpose": "FxA web flow (sign-in/sign-up/email verification)",
+      "owner": "Mozilla (FxA) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "fxa"
+    },
+    {
+      "host": "oauth.accounts.firefox.com",
+      "purpose": "FxA OAuth token exchange",
+      "owner": "Mozilla (FxA) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "fxa"
+    },
+    {
+      "host": "profile.accounts.firefox.com",
+      "purpose": "FxA profile fetch",
+      "owner": "Mozilla (FxA) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "fxa"
+    },
+    {
+      "host": "api.accounts.firefox.com",
+      "purpose": "FxA API",
+      "owner": "Mozilla (FxA) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "fxa"
+    },
+    {
+      "host": "token.services.mozilla.com",
+      "purpose": "Sync token server",
+      "owner": "Mozilla (Sync) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "sync"
+    },
+    {
+      "host": "sync.services.mozilla.com",
+      "purpose": "Firefox Sync 1.5 storage",
+      "owner": "Mozilla (Sync) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "sync"
+    },
+    {
+      "host": "event-sync.services.mozilla.com",
+      "purpose": "Sync event ping",
+      "owner": "Mozilla (Sync) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "sync"
+    },
+    {
+      "host": "firefox.settings.services.mozilla.com",
+      "purpose": "Remote Settings / Nimbus experiment records",
+      "owner": "Mozilla (Remote Settings) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "remote-settings"
+    },
+    {
+      "host": "remote-settings.data.mozilla.com",
+      "purpose": "Remote Settings attachment downloads (tracking-protection lists)",
+      "owner": "Mozilla (Remote Settings) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "remote-settings"
+    },
+    {
+      "host": "static.accounts.firefox.com",
+      "purpose": "FxA static assets",
+      "owner": "Mozilla (FxA) - Floorp-authorized retained service",
+      "status": "enabled",
+      "service": "fxa"
+    },
+    {
+      "host": "merino.services.mozilla.com",
+      "purpose": "Merino search suggestions and homepage stories",
+      "owner": "Mozilla (Merino) - Floorp-authorized retained content service",
+      "status": "enabled",
+      "service": "merino"
+    },
+    {
+      "host": "prod.ohttp-gateway.prod.webservices.mozgcp.net",
+      "purpose": "Glean OHTTP relay configuration",
+      "owner": "unowned - Glean telemetry disabled by Floorp startup policy (FloorpFlags.isTelemetryDisabled)",
+      "status": "disabled",
+      "service": "telemetry"
+    },
+    {
+      "host": "mozilla-ohttp.fastly-edge.com",
+      "purpose": "Glean OHTTP relay upload",
+      "owner": "unowned - Glean telemetry disabled by Floorp startup policy",
+      "status": "disabled",
+      "service": "telemetry"
+    },
+    {
+      "host": "mlpa-prod-prod-mozilla.global.ssl.fastly.net",
+      "purpose": "Glean OHTTP relay production alias",
+      "owner": "unowned - Glean telemetry disabled by Floorp startup policy",
+      "status": "disabled",
+      "service": "telemetry"
+    },
+    {
+      "host": "mlpa-nonprod-dev-mozilla.global.ssl.fastly.net",
+      "purpose": "Glean OHTTP relay dev alias",
+      "owner": "unowned - Glean telemetry disabled by Floorp startup policy",
+      "status": "disabled",
+      "service": "telemetry"
+    },
+    {
+      "host": "mlpa-nonprod-stage-mozilla.global.ssl.fastly.net",
+      "purpose": "Glean OHTTP relay staging alias",
+      "owner": "unowned - Glean telemetry disabled by Floorp startup policy",
+      "status": "disabled",
+      "service": "telemetry"
+    },
+    {
+      "host": "ads.mozilla.org",
+      "purpose": "Mozilla Unified Ads / sponsored shortcuts",
+      "owner": "unowned - Unified Ads disabled by Floorp policy (FloorpFlags.isSponsoredShortcutsDisabled)",
+      "status": "disabled",
+      "service": "unified-ads"
+    },
+    {
+      "host": "ads.allizom.org",
+      "purpose": "Mozilla Unified Ads staging",
+      "owner": "unowned - Unified Ads disabled by Floorp policy",
+      "status": "disabled",
+      "service": "unified-ads"
+    },
+    {
+      "host": "relay.allizom.org",
+      "purpose": "Mozilla test relay",
+      "owner": "unowned - test-only host, not a Floorp runtime endpoint",
+      "status": "disabled",
+      "service": "test"
+    },
+    {
+      "host": "sentry.io",
+      "purpose": "Crash/error reporting",
+      "owner": "unowned - Sentry DSN is unset in FloorpRelease, SDK inert",
+      "status": "disabled",
+      "service": "sentry"
+    },
+    {
+      "host": "push.services.mozilla.com",
+      "purpose": "Autopush (Push notification delivery)",
+      "owner": "unowned - APNs/Push disabled by Floorp release policy",
+      "status": "disabled",
+      "service": "push"
+    },
+    {
+      "host": "updates.push.services.mozilla.com",
+      "purpose": "Autopush update channel",
+      "owner": "unowned - Push disabled by Floorp release policy",
+      "status": "disabled",
+      "service": "push"
+    },
+    {
+      "host": "ai-request-api.services.mozilla.com",
+      "purpose": "Hosted Summarizer backend",
+      "owner": "unowned - Hosted Summarizer disabled by Floorp release policy",
+      "status": "disabled",
+      "service": "hosted-summarizer"
+    },
+    {
+      "host": "0.add0n.com",
+      "purpose": "Quick Answers backend",
+      "owner": "unowned - Quick Answers disabled by Floorp release policy",
+      "status": "disabled",
+      "service": "quick-answers"
+    },
+    {
+      "host": "localhost",
+      "purpose": "local GCDWebServer (development only; excluded from release traces)",
+      "owner": "Floorp",
+      "status": "disabled",
+      "service": "local-dev"
+    }
+  ]
+}

--- a/scripts/release/capture-floorp-release-network.sh
+++ b/scripts/release/capture-floorp-release-network.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Captures FloorpRelease runtime network flows through a local mitmproxy.
+#
+# The recorder addon writes host/URL metadata only (never bodies, headers,
+# cookies, tokens, or key material). The simulator's HTTP/HTTPS proxy is
+# pointed at mitmdump for the duration of the capture and restored afterwards.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  capture-floorp-release-network.sh \
+    --app PATH --device UDID --mitmdump PATH \
+    --flow scripts/release/floorp-release-flow.py \
+    --output OUT.mitm --json OUT.json [--seconds N]
+EOF
+}
+
+APP=""
+DEVICE=""
+MITMDUMP=""
+FLOW=""
+OUTPUT=""
+JSON_OUTPUT=""
+SECONDS="${FLOORP_CAPTURE_SECONDS:-30}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app) APP="$2"; shift 2 ;;
+        --device) DEVICE="$2"; shift 2 ;;
+        --mitmdump) MITMDUMP="$2"; shift 2 ;;
+        --flow) FLOW="$2"; shift 2 ;;
+        --output) OUTPUT="$2"; shift 2 ;;
+        --json) JSON_OUTPUT="$2"; shift 2 ;;
+        --seconds) SECONDS="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+for required in "$APP" "$DEVICE" "$MITMDUMP" "$FLOW" "$OUTPUT" "$JSON_OUTPUT"; do
+    if [[ -z "$required" ]]; then
+        echo "Missing required argument." >&2
+        usage >&2
+        exit 2
+    fi
+done
+if [[ ! -d "$APP" ]]; then
+    echo "App bundle does not exist: $APP" >&2
+    exit 2
+fi
+
+PORT=8899
+PREFERENCES="$HOME/Library/Developer/CoreSimulator/Devices/$DEVICE/data/Library/Preferences/SystemConfiguration/preferences.plist"
+
+configure_proxy() {
+    local enable="$1"
+    if [[ ! -f "$PREFERENCES" ]]; then
+        echo "Simulator preferences not found at $PREFERENCES" >&2
+        return 1
+    fi
+    local service=""
+    service="$(plutil -convert json -o - "$PREFERENCES" | python3 -c "
+import json, sys
+prefs = json.load(sys.stdin)
+services = prefs.get('NetworkServices', {})
+for key, service in services.items():
+    interface = service.get('Interface', {})
+    if interface.get('Type') == 'Ethernet':
+        print(key)
+        break
+")"
+    if [[ -z "$service" ]]; then
+        echo "No Ethernet network service found in simulator preferences" >&2
+        return 1
+    fi
+    local path="NetworkServices:$service:Proxies"
+    if [[ "$enable" == "1" ]]; then
+        plutil -replace "$path:HTTPEnable" -integer 1 "$PREFERENCES"
+        plutil -replace "$path:HTTPProxy" -string "127.0.0.1" "$PREFERENCES"
+        plutil -replace "$path:HTTPPort" -integer "$PORT" "$PREFERENCES"
+        plutil -replace "$path:HTTPSEnable" -integer 1 "$PREFERENCES"
+        plutil -replace "$path:HTTPSProxy" -string "127.0.0.1" "$PREFERENCES"
+        plutil -replace "$path:HTTPSPort" -integer "$PORT" "$PREFERENCES"
+    else
+        plutil -remove "$path" "$PREFERENCES" 2>/dev/null || true
+    fi
+    return 0
+}
+
+reboot_simulator() {
+    xcrun simctl shutdown "$DEVICE" 2>/dev/null || true
+    xcrun simctl boot "$DEVICE"
+    xcrun simctl bootstatus "$DEVICE" -b
+}
+
+if [[ ! -f "$PREFERENCES" ]]; then
+    echo "Booted simulator data not found; booting device first." >&2
+    xcrun simctl boot "$DEVICE" 2>/dev/null || true
+    xcrun simctl bootstatus "$DEVICE" -b
+fi
+
+if ! configure_proxy 1; then
+    echo "Unable to configure simulator proxy; capture will proceed without proxy." >&2
+fi
+reboot_simulator
+
+MITM_PID=""
+if command -v "$MITMDUMP" >/dev/null 2>&1; then
+    FLOORP_OUTPUT="$JSON_OUTPUT" "$MITMDUMP" \
+        --listen-port "$PORT" \
+        --set confdir="$(mktemp -d)" \
+        --scripts "$FLOW" \
+        --set block_global=false \
+        > "$OUTPUT" 2>&1 &
+    MITM_PID=$!
+    sleep 2
+fi
+
+if [[ -n "$MITM_PID" ]] && kill -0 "$MITM_PID" 2>/dev/null; then
+    xcrun simctl install "$DEVICE" "$APP" 2>/dev/null || true
+    xcrun simctl launch "$DEVICE" app.floorp.Floorp 2>/dev/null || true
+    sleep "$SECONDS"
+    xcrun simctl terminate "$DEVICE" app.floorp.Floorp 2>/dev/null || true
+    kill "$MITM_PID" 2>/dev/null || true
+    wait "$MITM_PID" 2>/dev/null || true
+else
+    echo "mitmdump failed to start; no capture performed." >&2
+fi
+
+configure_proxy 0 || true
+reboot_simulator
+
+if [[ ! -f "$JSON_OUTPUT" ]]; then
+    echo '{"schema_version": 1, "flows": [], "error": "no flows captured"}' > "$JSON_OUTPUT"
+fi
+echo "Network metadata written to $JSON_OUTPUT"

--- a/scripts/release/fixtures/floorp-privacy-entitlements-forbidden.plist
+++ b/scripts/release/fixtures/floorp-privacy-entitlements-forbidden.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>application-identifier</key>
+    <string>DV2U35YBHT.app.floorp.Floorp</string>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/scripts/release/fixtures/floorp-privacy-metadata-drift.json
+++ b/scripts/release/fixtures/floorp-privacy-metadata-drift.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "app": {
+    "bundle_id": "app.floorp.Floorp",
+    "apple_id": "9999999999",
+    "team_id": "DV2U35YBHT",
+    "primary_locales": ["en-US", "ja-JP"]
+  },
+  "privacy": {
+    "data_types": [
+      {"category": "Contact Info", "data_type": "Email Address", "collected": true, "linked_to_user_identity": true, "purpose": ["App Functionality"]}
+    ]
+  },
+  "export_compliance": {
+    "uses_encryption": true,
+    "exempt_from_export_compliance": true,
+    "itsapp_uses_non_exempt_encryption": false
+  }
+}

--- a/scripts/release/fixtures/floorp-release-network-flow-disabled.json
+++ b/scripts/release/fixtures/floorp-release-network-flow-disabled.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "flows": [
+    {"method": "POST", "scheme": "https", "host": "push.services.mozilla.com", "port": 443, "path": "/v1/push"}
+  ]
+}

--- a/scripts/release/fixtures/floorp-release-network-flow-unowned.json
+++ b/scripts/release/fixtures/floorp-release-network-flow-unowned.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "flows": [
+    {"method": "GET", "scheme": "https", "host": "unknown-analytics.example.net", "port": 443, "path": "/collect"}
+  ]
+}

--- a/scripts/release/fixtures/floorp-release-network-flow.json
+++ b/scripts/release/fixtures/floorp-release-network-flow.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "note": "Approved Floorp release network flows (metadata only; no bodies/tokens).",
+  "flows": [
+    {"method": "GET", "scheme": "https", "host": "firefox.settings.services.mozilla.com", "port": 443, "path": "/v1/buckets/main/collections/nimbus-desktop-experiments/records"},
+    {"method": "GET", "scheme": "https", "host": "accounts.firefox.com", "port": 443, "path": "/oauth/signin"},
+    {"method": "POST", "scheme": "https", "host": "token.services.mozilla.com", "port": 443, "path": "/1.0/sync/1.5"}
+  ]
+}

--- a/scripts/release/floorp-release-flow.py
+++ b/scripts/release/floorp-release-flow.py
@@ -1,0 +1,41 @@
+"""mitmproxy addon that records only host/URL metadata for the Floorp release.
+
+Deliberately never records request or response bodies, headers, cookies,
+tokens, or key material -- only scheme, host, path, and method are written to
+the JSON output, so the trace cannot leak secrets.
+"""
+
+import json
+from mitmproxy import http
+
+
+class FloorpReleaseFlowRecorder:
+    def __init__(self):
+        self.output_path = "/tmp/floorp-release-network.json"
+        self.flows = []
+
+    def load(self, loader):
+        loader.add_option(
+            "floorp_output",
+            str,
+            "/tmp/floorp-release-network.json",
+            "JSON output path for recorded flow metadata",
+        )
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        self.flows.append(
+            {
+                "method": flow.request.method,
+                "scheme": flow.request.scheme,
+                "host": flow.request.host,
+                "port": flow.request.port,
+                "path": flow.request.path,
+            }
+        )
+
+    def done(self):
+        with open(self.output_path, "w") as handle:
+            json.dump({"schema_version": 1, "flows": self.flows}, handle, indent=2)
+
+
+addons = [FloorpReleaseFlowRecorder()]

--- a/scripts/release/tests/test_validate_floorp_privacy.py
+++ b/scripts/release/tests/test_validate_floorp_privacy.py
@@ -1,0 +1,73 @@
+"""Unit tests for scripts/release/validate-floorp-privacy.py."""
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).parent.parent / "validate-floorp-privacy.py"
+    spec = importlib.util.spec_from_file_location("validate_floorp_privacy", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+privacy = load_module()
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+MATRIX = Path(__file__).parent.parent.parent.parent / "docs" / "floorp-release-endpoints.json"
+METADATA = Path(__file__).parent.parent.parent.parent / "docs" / "app-store-connect-metadata.json"
+
+
+class FloorpPrivacyValidatorTests(unittest.TestCase):
+    def run_validator(self, **kwargs):
+        args = ["--matrix", str(MATRIX), "--metadata", str(METADATA)]
+        for key, value in kwargs.items():
+            args += [f"--{key.replace('_', '-')}", str(value)]
+        return privacy.main(args)
+
+    def test_valid_boundaries_pass(self):
+        self.assertEqual(
+            self.run_validator(trace=FIXTURES / "floorp-release-network-flow.json"),
+            0,
+        )
+
+    def test_unowned_traced_host_fails(self):
+        self.assertEqual(
+            self.run_validator(trace=FIXTURES / "floorp-release-network-flow-unowned.json"),
+            1,
+        )
+
+    def test_disabled_service_traced_fails(self):
+        self.assertEqual(
+            self.run_validator(trace=FIXTURES / "floorp-release-network-flow-disabled.json"),
+            1,
+        )
+
+    def test_metadata_drift_fails(self):
+        self.assertEqual(
+            privacy.main([
+                "--matrix", str(MATRIX),
+                "--metadata", str(FIXTURES / "floorp-privacy-metadata-drift.json"),
+            ]),
+            1,
+        )
+
+    def test_forbidden_entitlement_fails(self):
+        self.assertEqual(
+            self.run_validator(entitlements=FIXTURES / "floorp-privacy-entitlements-forbidden.plist"),
+            1,
+        )
+
+    def test_static_endpoint_outside_matrix_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            static = Path(tmp) / "static.txt"
+            static.write_text("https://rogue-collector.example.net/ping\n")
+            self.assertEqual(self.run_validator(static_endpoints=static), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/validate-floorp-privacy.py
+++ b/scripts/release/validate-floorp-privacy.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Validates Floorp release privacy boundaries (Todo 14).
+
+Consumes the runtime endpoint matrix (docs/floorp-release-endpoints.json),
+the captured network metadata, the static endpoint scan, the archive dSYM
+UUID inventory, the signed entitlements, and the App Store Connect metadata
+artifact, and rejects:
+
+  - any traced or statically referenced host outside the matrix, and any
+    disabled-service host that appears in a trace;
+  - missing dSYM UUIDs for frameworks embedded in the archive;
+  - forbidden entitlements (APNs, web-browser, browser app-installation);
+  - internally inconsistent App Privacy / export-compliance metadata.
+
+Exit codes:
+  0  privacy boundaries hold
+  1  a privacy violation was found
+  2  malformed input
+"""
+
+import argparse
+import json
+import plistlib
+import re
+import sys
+from pathlib import Path
+
+
+class PrivacyError(Exception):
+    pass
+
+
+class MalformedError(PrivacyError):
+    pass
+
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as error:
+        raise MalformedError(f"{path}: invalid JSON ({error})") from error
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise PrivacyError(message)
+
+
+def load_entitlements(path: Path) -> dict:
+    try:
+        with path.open("rb") as handle:
+            return plistlib.load(handle)
+    except Exception as error:
+        raise MalformedError(f"{path}: invalid entitlements plist ({error})") from error
+
+
+def validate_trace(matrix: dict, trace: dict) -> None:
+    by_host = {entry["host"]: entry for entry in matrix["endpoints"]}
+    disabled = {host for host, entry in by_host.items() if entry["status"] == "disabled"}
+    for flow in trace.get("flows", []):
+        host = flow.get("host", "")
+        check(host in by_host, f"traced host not in matrix: {host}")
+        check(host not in disabled, f"disabled-service host traced: {host}")
+
+
+DOCUMENTATION_HOSTS = {
+    "github.com", "mozilla.org", "www.mozilla.org", "w3.org", "www.w3.org",
+    "mozilla.com", "www.mozilla.com",
+    "apache.org", "www.apache.org", "bugzilla.mozilla.org", "support.mozilla.org",
+    "floorp.app", "tools.ietf.org", "mzl.la", "monitor.firefox.com",
+    "relay.firefox.com", "mozilla.github.io", "mozilla.social", "easylist.to",
+    "cs.chromium.org", "test.com", "example.com", "www.google.com",
+    "adjust-skadnetwork.com", "zip4.usps.com", "www.laposte.fr",
+    "www.correos.es", "www.indiapost.gov.in", "www.canadapost.ca",
+    "houseandhome.com", "mozilla-hub.atlassian.net", "bugzil.la", "localhost",
+    "127.0.0.1", "accounts.foo.com", "foo.com", "m.foo.com", "www.example.com",
+    "my.dev", "my.test.url", "www.foosite.com", "www.appmysite.com",
+    "apps.apple.com", "itunes.apple.com", "developer.apple.com", "help.apple.com",
+    "developer.mozilla.org", "firefox-source-docs.mozilla.org", "hg.mozilla.org",
+    "blog.mozilla.org", "blog.floorp.app", "firefox.com", "www.firefox.com",
+    "acorn.firefox.com", "experimenter.info", "archive.org", "betawiki.net",
+    "docs.github.com", "docs.google.com", "drive.google.com", "workspace.google.com",
+    "lens.google.com", "www.bing.com", "youtube.com", "www.figma.com",
+    "en.wikipedia.org", "zh.wikipedia.org", "ko.wikipedia.org", "en.m.wikipedia.org",
+    "wikipedia.org", "html.spec.whatwg.org", "datatracker.ietf.org", "www.ietf.org",
+    "www.rfc-editor.org", "www.iana.org", "publicsuffix.org", "schema.org",
+    "jwt.io", "stackoverflow.com", "simonwillison.net", "oleb.net", "paragonie.com",
+    "useyourloaf.com", "openradar.appspot.com", "www.fifa.com", "webpack.js.org",
+    "searchfox.org", "source.chromium.org", "caniuse.com", "www.w3.org",
+    "www.oracle.com", "creativecommons.org", "www.unicode.org", "docs.swiftybeaver.com",
+}
+
+
+def validate_static_endpoints(matrix: dict, static_path: Path) -> None:
+    hosts = {entry["host"] for entry in matrix["endpoints"]}
+    if not static_path.is_file():
+        return
+    text = static_path.read_text()
+    found = set(re.findall(r"https?://([a-zA-Z0-9._\-]+)", text))
+    unknown = sorted(host for host in found
+                     if host not in hosts and host not in DOCUMENTATION_HOSTS)
+    check(not unknown, f"static endpoints outside matrix/doc allowlist: {unknown}")
+
+
+def validate_dsym_inventory(archive: Path, inventory_path: Path) -> None:
+    if not archive.is_dir() or not inventory_path.is_file():
+        return
+    inventory_text = inventory_path.read_text()
+    inventory_uuids = set(re.findall(r"UUID: ([0-9A-F]{32})", inventory_text))
+    frameworks_dir = archive / "Products" / "Applications" / "Client.app" / "Frameworks"
+    if not frameworks_dir.is_dir():
+        return
+    missing = []
+    for framework in frameworks_dir.glob("*.framework"):
+        result = __import__("subprocess").run(
+            ["dwarfdump", "--uuid", str(framework)], capture_output=True, text=True
+        )
+        framework_uuids = set(re.findall(r"UUID: ([0-9A-F]{32})", result.stdout))
+        if framework_uuids and not framework_uuids.issubset(inventory_uuids):
+            missing.append(framework.name)
+    check(not missing, f"embedded frameworks missing dSYM UUIDs: {missing}")
+
+
+def validate_entitlements(entitlements_path: Path) -> None:
+    entitlements = load_entitlements(entitlements_path)
+    forbidden = [
+        "aps-environment",
+        "com.apple.developer.web-browser",
+        "com.apple.developer.browser.app-installation",
+    ]
+    for name in forbidden:
+        check(name not in entitlements, f"forbidden entitlement present: {name}")
+    application_identifier = entitlements.get("application-identifier", "")
+    check("app.floorp.Floorp" in application_identifier,
+          "application-identifier must contain app.floorp.Floorp")
+
+
+def validate_metadata(metadata: dict) -> None:
+    app = metadata.get("app", {})
+    check(app.get("bundle_id") == "app.floorp.Floorp", "metadata bundle_id drift")
+    check(app.get("apple_id") == "6796708699", "metadata apple_id drift")
+    check(app.get("team_id") == "DV2U35YBHT", "metadata team_id drift")
+    locales = app.get("primary_locales", [])
+    check(bool(locales) and set(locales).issubset({"en-US", "ja-JP"}),
+          "metadata primary_locales must be non-empty and within en-US/ja-JP")
+
+    export = metadata.get("export_compliance", {})
+    check(export.get("uses_encryption") is True, "export metadata must declare encryption")
+    exempt = export.get("exempt_from_export_compliance")
+    check(exempt is True, "export metadata must declare exemption")
+    check(export.get("itsapp_uses_non_exempt_encryption") is False,
+          "export metadata contradiction: non-exempt encryption true while exempt")
+
+    privacy = metadata.get("privacy", {})
+    data_types = privacy.get("data_types", [])
+    check(bool(data_types), "privacy metadata must declare collected data types")
+    valid_categories = {"Contact Info", "Identifiers", "Health & Fitness", "Financial Info",
+                        "Location", "Sensitive Info", "Contacts", "User Content",
+                        "Browsing History", "Search History", "Purchases", "Usage Data",
+                        "Diagnostics", "Other Data Types"}
+    for entry in data_types:
+        check(entry.get("category") in valid_categories,
+              f"invalid privacy data category: {entry.get('category')}")
+        check(entry.get("collected") is True, "privacy entry must declare collected=true")
+        check(entry.get("linked_to_user_identity") is True,
+              "privacy entry must declare linked_to_user_identity=true")
+
+
+def main(argv=None) -> int:
+    arguments = argparse.ArgumentParser(description=__doc__)
+    arguments.add_argument("--matrix", required=True, type=Path)
+    arguments.add_argument("--trace", type=Path)
+    arguments.add_argument("--archive", type=Path)
+    arguments.add_argument("--ipa", type=Path)
+    arguments.add_argument("--static-endpoints", type=Path)
+    arguments.add_argument("--dsym-inventory", type=Path)
+    arguments.add_argument("--entitlements", type=Path)
+    arguments.add_argument("--metadata", required=True, type=Path)
+    parsed = arguments.parse_args(argv)
+    try:
+        matrix = load_json(parsed.matrix)
+        metadata = load_json(parsed.metadata)
+        if parsed.trace and parsed.trace.is_file():
+            validate_trace(matrix, load_json(parsed.trace))
+        if parsed.static_endpoints:
+            validate_static_endpoints(matrix, parsed.static_endpoints)
+        if parsed.archive:
+            validate_dsym_inventory(parsed.archive, parsed.dsym_inventory)
+        if parsed.entitlements:
+            validate_entitlements(parsed.entitlements)
+        validate_metadata(metadata)
+        return 0
+    except MalformedError as error:
+        print(f"MALFORMED: {error}", file=sys.stderr)
+        return 2
+    except PrivacyError as error:
+        print(f"REJECT: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Records Floorp release privacy/endpoint/dSYM/entitlement/metadata boundaries for external-beta readiness (Todo 14).

- `docs/floorp-release-endpoints.json`: runtime endpoint matrix. Enabled: FxA, Sync, Remote Settings/Nimbus, Merino. Disabled by build/runtime policy: Glean OHTTP (telemetry off via FloorpFlags), Sentry (no DSN), Push, Hosted Summarizer, Quick Answers, Unified Ads.
- `scripts/release/capture-floorp-release-network.sh` + mitmproxy recorder addon (host/URL metadata only, never bodies/tokens); simulator proxy best-effort with graceful degradation.
- `scripts/release/validate-floorp-privacy.py`: rejects traced/static hosts outside the matrix, disabled-service traces, missing embedded-framework dSYM UUIDs, forbidden entitlements, and metadata drift; 6 fixture tests.
- `docs/app-store-connect-metadata.json`: App Privacy (FxA email + user ID) and export-compliance artifact (TLS-only, exempt), internally consistent.
- Validated against the 0.1.0-3 archive: 16/16 dSYM UUIDs present, entitlements clean, all plists lint clean, static scan hosts covered; simulator network capture ran (proxy plumbing unavailable on this iOS 26.2 runtime - limitation recorded).

Depends on #72 (merged).