### PR TITLE
fix(release): Xcode Cloud macro trust and real API routes

### DIFF
--- a/firefox-ios/ci_scripts/ci_post_clone.sh
+++ b/firefox-ios/ci_scripts/ci_post_clone.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+# Xcode Cloud has no interactive "Trust & Enable" prompt for Swift macro
+# packages; skip macro fingerprint validation so packages such as
+# ModifiedCopyMacro can be used without a one-time local approval.
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+
 readonly REPOSITORY_PATH="${CI_PRIMARY_REPOSITORY_PATH:?CI_PRIMARY_REPOSITORY_PATH is required}"
 readonly NODE_VERSION="$(<"${REPOSITORY_PATH}/.nvmrc")"
 

--- a/scripts/release/app-store-connect-api.py
+++ b/scripts/release/app-store-connect-api.py
@@ -49,11 +49,12 @@ READ_ROUTES = [
     r"^/v1/builds/[^/]+$",
     r"^/v1/ciProducts$",
     r"^/v1/ciProducts/[^/]+/workflows$",
+    r"^/v1/ciProducts/[^/]+/buildRuns$",
     r"^/v1/ciWorkflows/[^/]+$",
-    r"^/v1/ciBuildRuns$",
-    r"^/v1/ciRuns$",
-    r"^/v1/ciRuns/[^/]+$",
-    r"^/v1/ciRuns/[^/]+/artifacts$",
+    r"^/v1/ciBuildRuns/[^/]+$",
+    r"^/v1/ciBuildRuns/[^/]+/actions$",
+    r"^/v1/ciBuildActions/[^/]+$",
+    r"^/v1/ciBuildActions/[^/]+/artifacts$",
     r"^/v1/betaGroups$",
     r"^/v1/betaGroups/[^/]+/builds$",
     r"^/v1/betaBuildLocalizations$",
@@ -208,7 +209,7 @@ def write_output(path: Path, value) -> None:
 
 def wait_ci_run(client, run_id: str, expected_head: str, output: Path,
                 dry_run: bool) -> None:
-    path = f"/v1/ciRuns/{run_id}"
+    path = f"/v1/ciBuildRuns/{run_id}"
     deadline = time.time() + 180 * 60
     while True:
         response = client("GET", path, dry_run=dry_run)
@@ -216,11 +217,14 @@ def wait_ci_run(client, run_id: str, expected_head: str, output: Path,
             write_output(output, {"dry_run": True, "run_id": run_id})
             return
         attributes = response.get("data", {}).get("attributes", {})
-        status = attributes.get("status")
-        if status in ("SUCCESS", "FAILED", "CANCELED"):
-            if expected_head and attributes.get("sourceCommit") != expected_head:
+        progress = attributes.get("executionProgress")
+        status = attributes.get("completionStatus")
+        if progress == "COMPLETE" and status in ("SUCCESS", "FAILED", "CANCELED"):
+            source_commit = attributes.get("sourceCommit") or {}
+            commit_sha = source_commit.get("commitSha") if isinstance(source_commit, dict) else None
+            if expected_head and commit_sha != expected_head:
                 raise AllowlistError(
-                    f"CI run head {attributes.get('sourceCommit')} != expected {expected_head}"
+                    f"CI run head {commit_sha} != expected {expected_head}"
                 )
             write_output(output, response)
             if status != "SUCCESS":
@@ -251,19 +255,27 @@ def build_polling_client(issuer_id: str, key_id: str, private_key_path: Path,
 
 def download_ci_artifact(client, run_id: str, relationship: str, output: Path,
                          sha256_output: Path, dry_run: bool) -> None:
-    path = f"/v1/ciRuns/{run_id}/artifacts"
-    response = client("GET", path, dry_run=dry_run)
+    actions_response = client("GET", f"/v1/ciBuildRuns/{run_id}/actions", dry_run=dry_run)
     if dry_run:
         write_output(sha256_output, {"dry_run": True})
         return
+    actions = actions_response.get("data", [])
+    if not actions:
+        raise AllowlistError(f"no ciBuildActions on run {run_id}")
+    action_id = actions[0].get("id")
+    response = client("GET", f"/v1/ciBuildActions/{action_id}/artifacts", dry_run=dry_run)
     artifacts = response.get("data", [])
+    wanted = relationship.rstrip("s").lower()
     match = next(
         (item for item in artifacts
-         if item.get("attributes", {}).get("relationship") == relationship),
+         if (item.get("attributes", {}).get("fileType") or "").lower().rstrip("s") == wanted),
         None,
     )
     if match is None:
-        raise AllowlistError(f"no artifact with relationship {relationship} on run {run_id}")
+        raise AllowlistError(
+            f"no artifact with fileType {relationship} on run {run_id} "
+            f"(found {[a.get('attributes', {}).get('fileType') for a in artifacts]})"
+        )
     download_url = match.get("attributes", {}).get("downloadUrl")
     if not download_url:
         raise AllowlistError("artifact has no downloadUrl")

--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -1,6 +1,7 @@
 """Unit tests for scripts/release/app-store-connect-api.py."""
 
 import importlib.util
+import hashlib
 import json
 import subprocess
 import tempfile
@@ -24,12 +25,14 @@ class AllowlistTests(unittest.TestCase):
         for path in [
             "/v1/ciProducts",
             "/v1/ciProducts/37C53C81-4C23-4E04-ADBB-1F238907A310/workflows",
+            "/v1/ciProducts/37C53C81-4C23-4E04-ADBB-1F238907A310/buildRuns",
             "/v1/ciWorkflows/D00DF3AC-15CD-430A-9FCB-39F876242926",
-            "/v1/ciBuildRuns",
+            "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376",
+            "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376/actions",
+            "/v1/ciBuildActions/4294e7e3-8adf-47fe-8f7c-02456baba2bb",
+            "/v1/ciBuildActions/4294e7e3-8adf-47fe-8f7c-02456baba2bb/artifacts",
             "/v1/builds",
             "/v1/betaGroups",
-            "/v1/ciRuns/123",
-            "/v1/ciRuns/123/artifacts",
             "/v1/betaAppReviewDetails",
             "/v1/betaAppReviewSubmissions",
             "/v1/betaBuildLocalizations",
@@ -59,6 +62,9 @@ class AllowlistTests(unittest.TestCase):
             ("POST", "/v1/betaAppReviewDetails"),
             ("GET", "/v1/secrets"),
             ("GET", "/v1/ciWorkflows"),
+            ("GET", "/v1/ciRuns/123"),
+            ("GET", "/v1/ciRuns/123/artifacts"),
+            ("GET", "/v1/ciBuildRuns"),
         ]
         for method, path in denied:
             self.assertFalse(asc.route_allowed(method, path), f"{method} {path}")
@@ -176,6 +182,114 @@ class ClientBehaviorTests(unittest.TestCase):
             # Credentials are absent, so the JWT step must fail AFTER the
             # allowlist checks pass (exit 1, no network request).
             self.assertEqual(code, 1)
+
+    def test_wait_ci_run_polls_ci_build_run_completion(self):
+        # App Store Connect exposes runs as ciBuildRuns: terminal state is
+        # executionProgress COMPLETE + completionStatus SUCCESS, and the head
+        # lives in sourceCommit.commitSha.
+        calls = []
+
+        def client(method, path, dry_run=False):
+            calls.append(path)
+            return {
+                "data": {
+                    "id": "run-1",
+                    "type": "ciBuildRuns",
+                    "attributes": {
+                        "executionProgress": "COMPLETE",
+                        "completionStatus": "SUCCESS",
+                        "sourceCommit": {"commitSha": "a" * 40},
+                    },
+                }
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "run.json"
+            asc.wait_ci_run(client, "run-1", "a" * 40, out, dry_run=False)
+            self.assertEqual(calls, ["/v1/ciBuildRuns/run-1"])
+            self.assertEqual(json.loads(out.read_text())["data"]["id"], "run-1")
+
+    def test_wait_ci_run_rejects_head_mismatch(self):
+        def client(method, path, dry_run=False):
+            return {
+                "data": {
+                    "id": "run-1",
+                    "attributes": {
+                        "executionProgress": "COMPLETE",
+                        "completionStatus": "SUCCESS",
+                        "sourceCommit": {"commitSha": "b" * 40},
+                    },
+                }
+            }
+
+        with self.assertRaises(asc.AllowlistError):
+            asc.wait_ci_run(client, "run-1", "a" * 40, Path("/tmp/x.json"), dry_run=False)
+
+    def test_wait_ci_run_raises_on_failed_completion(self):
+        def client(method, path, dry_run=False):
+            return {
+                "data": {
+                    "id": "run-1",
+                    "attributes": {
+                        "executionProgress": "COMPLETE",
+                        "completionStatus": "FAILED",
+                        "sourceCommit": {"commitSha": "a" * 40},
+                    },
+                }
+            }
+
+        with self.assertRaises(asc.AllowlistError):
+            asc.wait_ci_run(client, "run-1", "a" * 40, Path("/tmp/x.json"), dry_run=False)
+
+    def test_download_ci_artifact_resolves_actions_then_artifacts(self):
+        # Artifacts hang off ciBuildActions: list actions, then the action's
+        # artifacts, and pick the one whose fileType matches the relationship.
+        responses = {
+            "/v1/ciBuildRuns/run-1/actions": {
+                "data": [{"id": "action-1", "type": "ciBuildActions"}]
+            },
+            "/v1/ciBuildActions/action-1/artifacts": {
+                "data": [
+                    {"id": "a1", "attributes": {"fileType": "LOG_BUNDLE", "downloadUrl": "https://x/log"}},
+                    {"id": "a2", "attributes": {"fileType": "ARCHIVE", "downloadUrl": "https://x/archive"}},
+                ]
+            },
+        }
+        calls = []
+
+        def client(method, path, dry_run=False):
+            calls.append(path)
+            return responses[path]
+
+        original_urlopen = asc.urllib.request.urlopen
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                return b"archive-bytes"
+
+        asc.urllib.request.urlopen = lambda request, timeout=300: FakeResponse()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp) / "a.zip"
+                sha = Path(tmp) / "a.zip.sha256"
+                asc.download_ci_artifact(client, "run-1", "archives", out, sha, dry_run=False)
+                self.assertEqual(out.read_bytes(), b"archive-bytes")
+                self.assertEqual(
+                    sha.read_text().strip(),
+                    hashlib.sha256(b"archive-bytes").hexdigest(),
+                )
+                self.assertEqual(calls, [
+                    "/v1/ciBuildRuns/run-1/actions",
+                    "/v1/ciBuildActions/action-1/artifacts",
+                ])
+        finally:
+            asc.urllib.request.urlopen = original_urlopen
 
 
 class CryptoTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Two fixes discovered by the first real Xcode Cloud run (bfd267d8-696a-4394-94db-570f0aa9b376, FAILED 2026-08-08T17:21:55Z):

1. **Macro trust in Xcode Cloud**: archive failed with `Macro "ModifiedCopyMacros" from package "ModifiedCopy" must be enabled before it can be used` — the clean cloud clone has no interactive Trust & Enable prompt. Fix: `defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES` in `firefox-ios/ci_scripts/ci_post_clone.sh`.
2. **ASC client routes vs the real API**:
   - Runs are `ciBuildRuns`; `/v1/ciRuns/*` does not exist (404). `wait-ci-run` now polls `executionProgress`/`completionStatus` and validates `sourceCommit.commitSha`.
   - Artifacts hang off `ciBuildActions`; `download-ci-artifact` now lists actions then artifacts, matching `fileType` against `--relationship`.
   - Read allowlist updated (no write-route changes).

## Verification
- TDD red captured (`task-12-followup-attempt-3/red-ci-routes.txt`); full release suite 33/33 green
- Live-verified routes: `/v1/ciProducts/{id}/workflows` and `/v1/ciProducts/{id}/buildRuns` return 200 with the Admin key
- Failure evidence saved under `task-13-attempt-2/` (run JSON + build logs)

SwiftLint not applicable (Python + shell only).