### PR TITLE
release: prepare Floorp 0.2.0 internal candidate

### DIFF
--- a/firefox-ios/Client/Configuration/FloorpRelease.xcconfig
+++ b/firefox-ios/Client/Configuration/FloorpRelease.xcconfig
@@ -9,8 +9,8 @@
 // Floorp release identity. Xcode and Xcode Cloud use automatic signing for
 // this team; certificates and provisioning profiles are never stored here.
 FLOORP_DEVELOPMENT_TEAM = DV2U35YBHT
-FLOORP_MARKETING_VERSION = 0.1.0
-FLOORP_BUILD_NUMBER = 3
+FLOORP_MARKETING_VERSION = 0.2.0
+FLOORP_BUILD_NUMBER = 4
 // Keep empty until the public listing is live; otherwise Settings exposes a dead rating link.
 FLOORP_APP_STORE_ID =
 // Team-scoped because the shorter App Group is owned outside this Apple Developer team.

--- a/firefox-ios/TestFlight/WhatToTest.en-US.txt
+++ b/firefox-ios/TestFlight/WhatToTest.en-US.txt
@@ -1,11 +1,11 @@
 Floorp for iOS internal beta
 
-This is the 0.1.0 (3) Web panel sidebar parity candidate. Test both a clean install and an update from 0.1.0 (2). Confirm the Floorp name and icon throughout launch and that the sidebar toolbar button has a visible, correctly aligned icon.
+This is the 0.2.0 (4) internal candidate. Test both a clean install and an update from 0.1.0 (3). Confirm the Floorp name and icon throughout launch and that the sidebar toolbar button has a visible, correctly aligned icon.
 
 On iPhone, open and close the overlay drawer with both top and bottom address-bar layouts; the browser address bar must never cover the drawer. On iPad, test the pinned sidebar in portrait, landscape, Split View, resized windows, and right-to-left layout. Open Notes, Bookmarks, History, and Downloads, including empty states and opening an item.
 
 For Web panels, add, edit, delete, and reorder panels. Test Back, Forward, Home, Reload/Stop, and Find; switch Mobile/Desktop content mode; toggle Block Images; change and reset zoom; Pause/Resume media; and use Unload followed by restore. Hide and reopen the drawer, leave panels hidden long enough for auto-unload, and confirm normal/private data stays isolated across two windows. Repeat key paths in English and Japanese with VoiceOver.
 
-Also smoke-test normal and private browsing, tabs, settings, and Floorp Notes persistence. Do not use production account credentials until Floorp's account-service ownership is confirmed.
+Also smoke-test normal and private browsing, tabs, settings, and the local Floorp Notes v1 experience: create, edit, and delete notes; confirm notes persist across relaunch and survive a clean reinstall of the same build; and verify notes are not synchronized anywhere (network sync stays disabled in this build). Do not use production account credentials until Floorp's account-service ownership is confirmed.
 
 Known limitations: Floorp cannot yet be selected as the default browser because its managed entitlement is not approved. Push, cloud-hosted page summarization, Quick Answers, and app extensions are disabled. Rate Floorp is hidden until the public App Store listing is live. On supported devices, Apple Intelligence page summarization remains available on-device.

--- a/scripts/release/FloorpAppStoreExportOptions.plist
+++ b/scripts/release/FloorpAppStoreExportOptions.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>uploadSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>DV2U35YBHT</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Todo 11 candidate preparation:
- `FloorpRelease.xcconfig`: marketing version 0.2.0, build number 4
- `WhatToTest.en-US.txt`: 0.2.0 (4) candidate text incl. local Notes v1 smoke paths (sync stays disabled)
- New `scripts/release/FloorpAppStoreExportOptions.plist` (app-store-connect, automatic signing, team DV2U35YBHT)

No behavioral changes; CI is the standard gate.