### PR TITLE
fix(release): record IPA signing identity when cloud archive is unsigned

### DIFF
--- a/scripts/release/collect-floorp-release-evidence.sh
+++ b/scripts/release/collect-floorp-release-evidence.sh
@@ -131,6 +131,9 @@ if [[ -z "$TEAM_ID" && "$ARCHIVE_ONLY" -eq 0 && -n "$IPA" ]]; then
     unzip -q -o "$IPA" 'Payload/Client.app/*' -d "$(dirname "$(dirname "$IPA_APP_TEAM")")" 2>/dev/null || true
     if [[ -d "$IPA_APP_TEAM" ]]; then
         TEAM_ID="$(codesign -dv "$IPA_APP_TEAM" 2>&1 | sed -n 's/^TeamIdentifier=//p' | head -1)"
+        if [[ -z "$SIGNING_IDENTITY" ]]; then
+            SIGNING_IDENTITY="$(codesign -dvv "$IPA_APP_TEAM" 2>&1 | sed -n 's/^Authority=//p' | head -1)"
+        fi
     fi
     rm -rf "$(dirname "$(dirname "$IPA_APP_TEAM")")"
 fi


### PR DESCRIPTION
Extends the collector's IPA fallback to capture the codesign Authority as signing_identity. Candidate evidence now binds 'Apple Distribution: Ryousuke Asano (DV2U35YBHT)' for the 0.2.0 (4) internal candidate.