### PR TITLE
fix(release): external-beta wrapper filters, idempotency, and 204 handling

### DIFF
--- a/scripts/release/app-store-connect-api.py
+++ b/scripts/release/app-store-connect-api.py
@@ -156,7 +156,10 @@ def make_jwt(issuer_id: str, key_id: str, private_key_path: Path, now: int) -> s
 def _http_request(method: str, url: str, headers: dict, body: bytes) -> dict:
     request = urllib.request.Request(url, method=method, headers=headers, data=body or None)
     with urllib.request.urlopen(request, timeout=60) as response:
-        return json.loads(response.read())
+        raw = response.read()
+        if not raw:
+            return {}
+        return json.loads(raw)
 
 
 def api_call(method: str, path: str, jwt: str, body: Optional[bytes] = None,

--- a/scripts/release/submit-floorp-external-beta.sh
+++ b/scripts/release/submit-floorp-external-beta.sh
@@ -72,9 +72,9 @@ asc_get() {
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-asc_get "/v1/betaAppReviewDetails" "$TMP_DIR/review-details-before.json"
-asc_get "/v1/betaAppReviewSubmissions" "$TMP_DIR/submissions-before.json"
-asc_get "/v1/betaBuildLocalizations" "$TMP_DIR/localizations-before.json"
+asc_get "/v1/betaAppReviewDetails?filter[app]=$APP_ID" "$TMP_DIR/review-details-before.json"
+asc_get "/v1/betaAppReviewSubmissions?filter[build]=$BUILD_ID" "$TMP_DIR/submissions-before.json"
+asc_get "/v1/betaBuildLocalizations?filter[build]=$BUILD_ID" "$TMP_DIR/localizations-before.json"
 asc_get "/v1/betaGroups/$GROUP_ID/builds" "$TMP_DIR/group-builds-before.json"
 asc_get "/v1/builds/$BUILD_ID" "$TMP_DIR/build-before.json"
 
@@ -213,9 +213,9 @@ python3 "$CLIENT" post "/v1/betaGroups/$GROUP_ID/relationships/builds" \
     --output "$TMP_DIR/group-assigned.json"
 
 # 5. After-state capture and diff.
-asc_get "/v1/betaAppReviewDetails" "$TMP_DIR/review-details-after.json"
-asc_get "/v1/betaAppReviewSubmissions" "$TMP_DIR/submissions-after.json"
-asc_get "/v1/betaBuildLocalizations" "$TMP_DIR/localizations-after.json"
+asc_get "/v1/betaAppReviewDetails?filter[app]=$APP_ID" "$TMP_DIR/review-details-after.json"
+asc_get "/v1/betaAppReviewSubmissions?filter[build]=$BUILD_ID" "$TMP_DIR/submissions-after.json"
+asc_get "/v1/betaBuildLocalizations?filter[build]=$BUILD_ID" "$TMP_DIR/localizations-after.json"
 asc_get "/v1/betaGroups/$GROUP_ID/builds" "$TMP_DIR/group-builds-after.json"
 asc_get "/v1/builds/$BUILD_ID" "$TMP_DIR/build-after.json"
 

--- a/scripts/release/submit-floorp-external-beta.sh
+++ b/scripts/release/submit-floorp-external-beta.sh
@@ -122,8 +122,18 @@ JA_TEXT="$(cat "${WHAT_TO_TEST_JA:-firefox-ios/TestFlight/WhatToTest.ja-JP.txt}"
 LOCALIZATIONS_BEFORE_SHA="$(sha256_of "$TMP_DIR/localizations-before.json")"
 
 # 1. Localization (create or patch the en-US/ja-JP beta build localizations).
+asc_beta_locale() {
+    # betaBuildLocalizations uses the ASC beta locale set ("ja", not "ja-JP").
+    case "$1" in
+        ja-JP|ja) echo "ja" ;;
+        *) echo "$1" ;;
+    esac
+}
+
 upsert_localization() {
-    local locale="$1" text="$2"
+    local source_locale="$1" text="$2"
+    local locale
+    locale="$(asc_beta_locale "$source_locale")"
     local existing_id
     existing_id="$(python3 -c "
 import json
@@ -188,29 +198,57 @@ python3 "$CLIENT" patch "/v1/betaAppReviewDetails/$REVIEW_DETAILS_ID" \
     --output "$TMP_DIR/review-details-patched.json"
 
 # 3. Beta App Review submission for the exact build.
-python3 - "$BUILD_ID" > "$TMP_DIR/submission-body.json" <<'PYEOF'
+EXISTING_SUBMISSION_ID="$(python3 -c "
+import json
+data = json.load(open('$TMP_DIR/submissions-before.json'))
+rows = data.get('data', [])
+print(rows[0]['id'] if rows else '')
+")"
+if [[ -n "$EXISTING_SUBMISSION_ID" ]]; then
+    # Idempotency: the build already has a Beta App Review submission.
+    python3 - "$EXISTING_SUBMISSION_ID" "$BUILD_ID" > "$TMP_DIR/submission-created.json" <<'PYEOF'
+import json, sys
+print(json.dumps({"idempotent": True, "submission_id": sys.argv[1], "build_id": sys.argv[2]}))
+PYEOF
+else
+    python3 - "$BUILD_ID" > "$TMP_DIR/submission-body.json" <<'PYEOF'
 import json, sys
 print(json.dumps({"data": {"type": "betaAppReviewSubmissions", "relationships": {
     "build": {"data": {"type": "builds", "id": sys.argv[1]}}}}}))
 PYEOF
-python3 "$CLIENT" post /v1/betaAppReviewSubmissions \
-    --body "$TMP_DIR/submission-body.json" \
-    --intended-id "$BUILD_ID" \
-    --prior-state-sha256 "$(sha256_of "$TMP_DIR/submissions-before.json")" \
-    $AUTHORIZE $DRY_RUN \
-    --output "$TMP_DIR/submission-created.json"
+    python3 "$CLIENT" post /v1/betaAppReviewSubmissions \
+        --body "$TMP_DIR/submission-body.json" \
+        --intended-id "$BUILD_ID" \
+        --prior-state-sha256 "$(sha256_of "$TMP_DIR/submissions-before.json")" \
+        $AUTHORIZE $DRY_RUN \
+        --output "$TMP_DIR/submission-created.json"
+fi
 
 # 4. Assign the build to the external group (idempotent relationship).
-python3 - "$BUILD_ID" > "$TMP_DIR/group-body.json" <<'PYEOF'
+GROUP_HAS_BUILD="$(python3 -c "
+import json
+data = json.load(open('$TMP_DIR/group-builds-before.json'))
+rows = [r for r in data.get('data', []) if r.get('id') == '$BUILD_ID']
+print('yes' if rows else 'no')
+")"
+if [[ "$GROUP_HAS_BUILD" == "yes" ]]; then
+    # Idempotency: the build is already assigned to the external group.
+    python3 - "$BUILD_ID" "$GROUP_ID" > "$TMP_DIR/group-assigned.json" <<'PYEOF'
+import json, sys
+print(json.dumps({"idempotent": True, "build_id": sys.argv[1], "group_id": sys.argv[2]}))
+PYEOF
+else
+    python3 - "$BUILD_ID" > "$TMP_DIR/group-body.json" <<'PYEOF'
 import json, sys
 print(json.dumps({"data": [{"type": "builds", "id": sys.argv[1]}]}))
 PYEOF
-python3 "$CLIENT" post "/v1/betaGroups/$GROUP_ID/relationships/builds" \
-    --body "$TMP_DIR/group-body.json" \
-    --intended-id "$BUILD_ID" \
-    --prior-state-sha256 "$(sha256_of "$TMP_DIR/group-builds-before.json")" \
-    $AUTHORIZE $DRY_RUN \
-    --output "$TMP_DIR/group-assigned.json"
+    python3 "$CLIENT" post "/v1/betaGroups/$GROUP_ID/relationships/builds" \
+        --body "$TMP_DIR/group-body.json" \
+        --intended-id "$BUILD_ID" \
+        --prior-state-sha256 "$(sha256_of "$TMP_DIR/group-builds-before.json")" \
+        $AUTHORIZE $DRY_RUN \
+        --output "$TMP_DIR/group-assigned.json"
+fi
 
 # 5. After-state capture and diff.
 asc_get "/v1/betaAppReviewDetails?filter[app]=$APP_ID" "$TMP_DIR/review-details-after.json"
@@ -236,10 +274,21 @@ SUBMISSION_ID="$(python3 -c "
 import json
 try:
     data = json.load(open('$TMP_DIR/submission-created.json'))
-    print(data.get('data', {}).get('id', ''))
+    if 'data' in data:
+        print(data.get('data', {}).get('id', ''))
+    else:
+        print(data.get('submission_id', ''))
 except Exception:
     print('')
 ")"
+if [[ -z "$SUBMISSION_ID" ]]; then
+    SUBMISSION_ID="$(python3 -c "
+import json
+data = json.load(open('$TMP_DIR/submissions-before.json'))
+rows = data.get('data', [])
+print(rows[0]['id'] if rows else '')
+")"
+fi
 
 python3 - "$OUTPUT" "$APP_ID" "$BUILD_ID" "$GROUP_ID" "$SUBMISSION_ID" \
     "$BEFORE" "$AFTER" <<'PYEOF'

--- a/scripts/release/tests/test_submit_floorp_external_beta.py
+++ b/scripts/release/tests/test_submit_floorp_external_beta.py
@@ -33,14 +33,14 @@ class SubmitExternalBetaScriptTests(unittest.TestCase):
             path = sys.argv[2]
             if command == "get":
                 canned = {
-                    "/v1/betaAppReviewDetails": {"data": [{"id": "rev-1", "type": "betaAppReviewDetails"}]},
-                    "/v1/betaAppReviewSubmissions": {"data": []},
-                    "/v1/betaBuildLocalizations": {"data": []},
+                    "/v1/betaAppReviewDetails?filter[app]=6796708699": {"data": [{"id": "rev-1", "type": "betaAppReviewDetails"}]},
+                    "/v1/betaAppReviewSubmissions?filter[build]=bld-1": {"data": []},
+                    "/v1/betaBuildLocalizations?filter[build]=bld-1": {"data": []},
                     "/v1/betaGroups/grp-1/builds": {"data": []},
                     "/v1/builds/bld-1": {"data": {"id": "bld-1", "type": "builds"}},
                 }
                 output = sys.argv[sys.argv.index("--output") + 1]
-                json.dump(canned.get(path, {"data": []}), open(output, "w"))
+                json.dump(canned.get(path, canned.get(path.split("?", 1)[0], {"data": []})), open(output, "w"))
             else:
                 if "--authorize-mutation" not in sys.argv:
                     sys.stderr.write("write routes require --authorize-mutation\\n")


### PR DESCRIPTION
External beta wrapper hardening found while running Todo 15 live:
- Preflight/after GETs scoped by app/build filters (unfiltered beta collections return 400).
- Idempotent submission and group assignment (skip mutations whose state already exists).
- ASC client tolerates 204/empty responses.
Live run: build 09f7505f -> Floorp External (426690b7), Beta App Review WAITING_FOR_REVIEW, before/after hashes identical.