### PR TITLE
feat(sync): canonical production-QA recipe preparer

### DIFF
--- a/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
+++ b/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
@@ -764,6 +764,12 @@ def git_command(
         "-c",
         f"core.worktree={worktree}",
         "-c",
+        "core.trustctime=true",
+        "-c",
+        "core.checkStat=default",
+        "-c",
+        "core.fileMode=true",
+        "-c",
         "maintenance.auto=false",
         "-c",
         "gc.auto=0",
@@ -826,6 +832,173 @@ def validate_git_worktree(path: Path, label: str) -> None:
     require(git_text(path, ("rev-parse", "--is-inside-work-tree"), label) == "true", f"{label}: not a Git worktree")
 
 
+def tracked_path_parts(raw_path: bytes, label: str) -> tuple[bytes, ...]:
+    require(bool(raw_path), f"{label}: tracked path is empty")
+    require(not raw_path.startswith(b"/"), f"{label}: tracked path is absolute")
+    parts = tuple(raw_path.split(b"/"))
+    require(
+        all(part not in (b"", b".", b"..", b".git") for part in parts),
+        f"{label}: tracked path contains a forbidden component",
+    )
+    return parts
+
+
+def open_tracked_parent(root_descriptor: int, parts: tuple[bytes, ...], label: str) -> int:
+    descriptor = os.dup(root_descriptor)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        for component in parts[:-1]:
+            try:
+                child = os.open(component, flags, dir_fd=descriptor)
+            except OSError as error:
+                raise PreparationError(
+                    f"{label}: tracked parent is missing, unsafe, or not a directory ({error})"
+                ) from error
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def hash_tracked_regular(
+    parent_descriptor: int,
+    basename: bytes,
+    expected_executable: bool,
+    label: str,
+) -> str:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(basename, flags, dir_fd=parent_descriptor)
+    except OSError as error:
+        raise PreparationError(f"{label}: tracked file cannot be opened safely ({error})") from error
+    try:
+        before = os.fstat(descriptor)
+        require(stat.S_ISREG(before.st_mode), f"{label}: tracked file is not regular")
+        require(
+            bool(before.st_mode & stat.S_IXUSR) == expected_executable,
+            f"{label}: tracked executable mode differs from the index",
+        )
+        digest = hashlib.sha1(f"blob {before.st_size}\0".encode("ascii"))
+        size = 0
+        while chunk := os.read(descriptor, READ_CHUNK_BYTES):
+            digest.update(chunk)
+            size += len(chunk)
+        after = os.fstat(descriptor)
+        require(stable_snapshot(before) == stable_snapshot(after), f"{label}: tracked file changed while read")
+        require(size == before.st_size, f"{label}: tracked file size changed while read")
+        return digest.hexdigest()
+    finally:
+        os.close(descriptor)
+
+
+def hash_tracked_symlink(parent_descriptor: int, basename: bytes, label: str) -> str:
+    try:
+        before = os.stat(basename, dir_fd=parent_descriptor, follow_symlinks=False)
+        require(stat.S_ISLNK(before.st_mode), f"{label}: tracked symlink type differs from the index")
+        target = os.readlink(basename, dir_fd=parent_descriptor)
+        after = os.stat(basename, dir_fd=parent_descriptor, follow_symlinks=False)
+    except OSError as error:
+        raise PreparationError(f"{label}: tracked symlink cannot be read safely ({error})") from error
+    require(stable_snapshot(before) == stable_snapshot(after), f"{label}: tracked symlink changed while read")
+    raw_target = target if isinstance(target, bytes) else os.fsencode(target)
+    return git_blob_sha(raw_target)
+
+
+def validate_tracked_worktree_content(path: Path, commit_oid: str) -> None:
+    label = "merged iOS worktree"
+    entries = git_command(
+        path,
+        ("ls-files", "--stage", "-z"),
+        f"{label} tracked index",
+    ).stdout.split(b"\0")
+    index_records: dict[bytes, tuple[bytes, bytes]] = {}
+    for entry in entries:
+        if not entry:
+            continue
+        try:
+            metadata, raw_path = entry.split(b"\t", 1)
+            mode, expected_oid, stage = metadata.split(b" ")
+            expected_text = expected_oid.decode("ascii")
+        except (UnicodeError, ValueError) as error:
+            raise PreparationError(f"{label}: malformed tracked index entry") from error
+        require(stage == b"0", f"{label}: unmerged tracked index entry is forbidden")
+        require(raw_path not in index_records, f"{label}: duplicate tracked index path")
+        require(SHA1_PATTERN.fullmatch(expected_text) is not None, f"{label}: malformed blob OID")
+        index_records[raw_path] = (mode, expected_oid)
+
+    head_entries = git_command(
+        path,
+        ("ls-tree", "-r", "--full-tree", "-z", commit_oid),
+        f"{label} detached HEAD tree",
+    ).stdout.split(b"\0")
+    head_records: dict[bytes, tuple[bytes, bytes]] = {}
+    for entry in head_entries:
+        if not entry:
+            continue
+        try:
+            metadata, raw_path = entry.split(b"\t", 1)
+            mode, object_type, object_oid = metadata.split(b" ")
+            object_text = object_oid.decode("ascii")
+        except (UnicodeError, ValueError) as error:
+            raise PreparationError(f"{label}: malformed detached HEAD tree entry") from error
+        require(raw_path not in head_records, f"{label}: duplicate detached HEAD tree path")
+        require(SHA1_PATTERN.fullmatch(object_text) is not None, f"{label}: malformed HEAD object OID")
+        expected_type = b"commit" if mode == b"160000" else b"blob"
+        require(object_type == expected_type, f"{label}: malformed HEAD object type")
+        head_records[raw_path] = (mode, object_oid)
+    require(
+        index_records == head_records,
+        f"{label}: dirty staged index differs from detached HEAD",
+    )
+
+    root_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        root_descriptor = os.open(path, root_flags)
+    except OSError as error:
+        raise PreparationError(f"{label}: cannot open worktree safely ({error})") from error
+    try:
+        for raw_path, (mode, expected_oid) in index_records.items():
+            require(mode in (b"100644", b"100755", b"120000"), f"{label}: unsupported tracked mode")
+            parts = tracked_path_parts(raw_path, label)
+            display_path = os.fsdecode(raw_path)
+            entry_label = f"{label}: dirty tracked path {display_path!r}"
+            parent_descriptor = open_tracked_parent(root_descriptor, parts, entry_label)
+            try:
+                if mode == b"120000":
+                    actual_oid = hash_tracked_symlink(parent_descriptor, parts[-1], entry_label)
+                else:
+                    actual_oid = hash_tracked_regular(
+                        parent_descriptor,
+                        parts[-1],
+                        mode == b"100755",
+                        entry_label,
+                    )
+            finally:
+                os.close(parent_descriptor)
+            require(actual_oid == expected_oid.decode("ascii"), f"{entry_label}: content differs from the index")
+    finally:
+        os.close(root_descriptor)
+
+    untracked = git_command(
+        path,
+        ("ls-files", "--others", "-z"),
+        f"{label} untracked files",
+    ).stdout
+    require(untracked == b"", f"{label}: dirty untracked paths are forbidden")
+
+
 def validate_merged_worktree(
     path: Path,
     merged_oid: str,
@@ -859,12 +1032,7 @@ def validate_merged_worktree(
                     "merged iOS worktree: assume-unchanged/skip-worktree index flags are forbidden"
                 )
             raise PreparationError("merged iOS worktree: assume-unchanged index flags are forbidden")
-    status = git_command(
-        path,
-        ("status", "--porcelain=v1", "--untracked-files=all"),
-        "merged iOS worktree",
-    ).stdout
-    require(status == b"", "merged iOS worktree: worktree is dirty")
+    validate_tracked_worktree_content(path, merged_oid)
     parents = git_text(path, ("show", "-s", "--format=%P", merged_oid), "merged iOS worktree").split()
     require(parents == [contract.base_oid], "merged iOS worktree: squash commit parent does not equal guarded base")
     merged_tree = git_text(path, ("rev-parse", f"{merged_oid}^{{tree}}"), "merged iOS worktree")

--- a/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
+++ b/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
@@ -10,11 +10,20 @@ Files are published with no-clobber semantics.  A pre-existing managed file is
 accepted only when it is a regular, non-symlink, owner-only file containing the
 exact expected bytes.  The integration receipt is never created here; the
 assembler remains its sole producer.
+
+The required integration execution capture is canonical JSON with exactly six
+root fields: ``schema_version``, ``pull_request``, ``pr_checks``,
+``commands``, ``merge_response``, and ``main_ref``.  It records the guarded PR
+base/head, all eight PR checks in deterministic UTF-8 bytewise sorted order,
+four exact terminal command records, the successful merge response, and the
+resulting main ref.  The recipe command list and receipt digest are derived
+from this capture.
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
 import os
@@ -56,6 +65,24 @@ ARTIFACT_METADATA_KEYS = {
     "head_sha",
     "run_id",
 }
+INTEGRATION_CAPTURE_KEYS = {
+    "commands",
+    "main_ref",
+    "merge_response",
+    "pr_checks",
+    "pull_request",
+    "schema_version",
+}
+PR_CHECK_NAMES = (
+    "Adaptive sidebar UI (iPad (A16))",
+    "Adaptive sidebar UI (iPhone 17)",
+    "Build and unit test",
+    "Notes UI (iPad (A16), en-US)",
+    "Notes UI (iPad (A16), ja-JP)",
+    "Notes UI (iPhone 17, en-US)",
+    "Notes UI (iPhone 17, ja-JP)",
+    "Validate workflows",
+)
 GATE_SOURCE_ROLES = {
     "g1": (
         "task-manifest",
@@ -720,19 +747,59 @@ def materialize_file(
         os.close(source_fd)
 
 
-def git_command(worktree: Path, arguments: Iterable[str], label: str, *, accepted: tuple[int, ...] = (0,)) -> subprocess.CompletedProcess[bytes]:
+def git_command(
+    worktree: Path,
+    arguments: Iterable[str],
+    label: str,
+    *,
+    accepted: tuple[int, ...] = (0,),
+) -> subprocess.CompletedProcess[bytes]:
+    hardened_configuration = (
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.bare=false",
+        "-c",
+        f"core.worktree={worktree}",
+        "-c",
+        "maintenance.auto=false",
+        "-c",
+        "gc.auto=0",
+        "-c",
+        "fetch.recurseSubmodules=false",
+        "-c",
+        "submodule.recurse=false",
+        "-c",
+        "credential.helper=",
+        "-c",
+        "core.askPass=",
+    )
     try:
         result = subprocess.run(
-            [GIT, "-C", os.fspath(worktree), *arguments],
+            [GIT, *hardened_configuration, "-C", os.fspath(worktree), *arguments],
             check=False,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             env={
                 "HOME": os.environ.get("HOME", ""),
+                "GCM_INTERACTIVE": "Never",
+                "GIT_ALLOW_PROTOCOL": "",
+                "GIT_ASKPASS": "/usr/bin/false",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_NO_LAZY_FETCH": "1",
+                "GIT_NO_REPLACE_OBJECTS": "1",
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_PAGER": "cat",
+                "GIT_TERMINAL_PROMPT": "0",
                 "LANG": "C",
                 "LC_ALL": "C",
+                "PAGER": "cat",
                 "PATH": "/usr/bin:/bin",
+                "SSH_ASKPASS": "/usr/bin/false",
             },
         )
     except OSError as error:
@@ -774,6 +841,24 @@ def validate_merged_worktree(
         accepted=(0, 1),
     )
     require(detached.returncode == 1 and detached.stdout == b"", "merged iOS worktree: HEAD must be detached")
+    index_entries = git_command(
+        path,
+        ("ls-files", "-v", "-z"),
+        "merged iOS worktree index",
+    ).stdout.split(b"\0")
+    for entry in index_entries:
+        if not entry:
+            continue
+        require(len(entry) >= 3 and entry[1:2] == b" ", "merged iOS worktree: malformed index entry")
+        tag = chr(entry[0])
+        if tag == "S":
+            raise PreparationError("merged iOS worktree: skip-worktree index flags are forbidden")
+        if tag.islower():
+            if tag == "s":
+                raise PreparationError(
+                    "merged iOS worktree: assume-unchanged/skip-worktree index flags are forbidden"
+                )
+            raise PreparationError("merged iOS worktree: assume-unchanged index flags are forbidden")
     status = git_command(
         path,
         ("status", "--porcelain=v1", "--untracked-files=all"),
@@ -966,51 +1051,135 @@ def role_only(source: dict[str, Any], role: str) -> dict[str, Any]:
     return rebound
 
 
-def integration_commands(contract: PreparationContract) -> list[dict[str, Any]]:
+def integration_command_argv(contract: PreparationContract) -> tuple[tuple[str, ...], ...]:
     reviewed = contract.reviewed_head_oid
-    return [
-        {
-            "argv": [
-                "/opt/homebrew/bin/gh",
-                "pr",
-                "checks",
-                "83",
-                "--repo",
-                "Floorp-Projects/floorp-ios",
-            ],
-            "exit_code": 0,
-            "terminal": True,
-        },
-        {
-            "argv": ["/usr/bin/test", reviewed, "=", reviewed],
-            "exit_code": 0,
-            "terminal": True,
-        },
-        {
-            "argv": [
-                "/opt/homebrew/bin/gh",
-                "api",
-                "-X",
-                "PUT",
-                "repos/Floorp-Projects/floorp-ios/pulls/83/merge",
-                "-f",
-                f"sha={reviewed}",
-                "-f",
-                "merge_method=squash",
-            ],
-            "exit_code": 0,
-            "terminal": True,
-        },
-        {
-            "argv": [
-                "/opt/homebrew/bin/gh",
-                "api",
-                "repos/Floorp-Projects/floorp-ios/git/ref/heads/main",
-            ],
-            "exit_code": 0,
-            "terminal": True,
-        },
-    ]
+    return (
+        (
+            "/opt/homebrew/bin/gh",
+            "pr",
+            "checks",
+            "83",
+            "--repo",
+            "Floorp-Projects/floorp-ios",
+        ),
+        (
+            "/opt/homebrew/bin/gh",
+            "pr",
+            "view",
+            "83",
+            "--repo",
+            "Floorp-Projects/floorp-ios",
+            "--json",
+            "number,baseRefOid,headRefOid",
+        ),
+        (
+            "/opt/homebrew/bin/gh",
+            "api",
+            "-X",
+            "PUT",
+            "repos/Floorp-Projects/floorp-ios/pulls/83/merge",
+            "-f",
+            f"sha={reviewed}",
+            "-f",
+            "merge_method=squash",
+        ),
+        (
+            "/opt/homebrew/bin/gh",
+            "api",
+            "repos/Floorp-Projects/floorp-ios/git/ref/heads/main",
+        ),
+    )
+
+
+def validate_integration_capture(
+    capture: dict[str, Any],
+    merged_oid: str,
+    contract: PreparationContract,
+) -> list[dict[str, Any]]:
+    label = "integration execution capture"
+    require(set(capture) == INTEGRATION_CAPTURE_KEYS, f"{label}: root fields are not exact")
+    schema_version = capture.get("schema_version")
+    require(
+        isinstance(schema_version, int)
+        and not isinstance(schema_version, bool)
+        and schema_version == 1,
+        f"{label}: schema_version must be integer 1",
+    )
+
+    pull_request = capture.get("pull_request")
+    require(isinstance(pull_request, dict), f"{label}: pull_request is malformed")
+    require(
+        set(pull_request) == {"base_oid", "head_oid", "number"},
+        f"{label}: pull request fields are not exact",
+    )
+    number = pull_request.get("number")
+    require(
+        isinstance(number, int) and not isinstance(number, bool) and number == 83,
+        f"{label}: pull request number mismatch",
+    )
+    require(pull_request.get("base_oid") == contract.base_oid, f"{label}: pull request base mismatch")
+    require(
+        pull_request.get("head_oid") == contract.reviewed_head_oid,
+        f"{label}: pull request head mismatch",
+    )
+
+    checks = capture.get("pr_checks")
+    require(isinstance(checks, list), f"{label}: PR checks are malformed")
+    check_names: list[str] = []
+    for index, check in enumerate(checks):
+        require(isinstance(check, dict), f"{label}: PR check {index} is malformed")
+        require(
+            set(check) == {"conclusion", "name"},
+            f"{label}: PR check {index} fields are not exact",
+        )
+        require(check.get("conclusion") == "success", f"{label}: PR checks did not all succeed")
+        name = check.get("name")
+        require(isinstance(name, str) and bool(name), f"{label}: PR check name is malformed")
+        check_names.append(name)
+    require(len(check_names) == len(set(check_names)), f"{label}: PR checks contain a duplicate")
+    require(
+        check_names == sorted(check_names, key=lambda name: name.encode("utf-8")),
+        f"{label}: PR checks are not in deterministic UTF-8 sorted order",
+    )
+    require(tuple(check_names) == PR_CHECK_NAMES, f"{label}: PR checks are not exact")
+
+    commands = capture.get("commands")
+    expected_argv = integration_command_argv(contract)
+    require(
+        isinstance(commands, list) and len(commands) == len(expected_argv),
+        f"{label}: command set is not exact",
+    )
+    for index, (command, expected) in enumerate(zip(commands, expected_argv)):
+        require(isinstance(command, dict), f"{label}: command {index} is malformed")
+        require(
+            set(command) == {"argv", "exit_code", "terminal"},
+            f"{label}: command {index} fields are not exact",
+        )
+        require(command.get("argv") == list(expected), f"{label}: command {index} argv mismatch")
+        exit_code = command.get("exit_code")
+        require(
+            isinstance(exit_code, int)
+            and not isinstance(exit_code, bool)
+            and exit_code == 0,
+            f"{label}: command {index} exit_code must be integer 0",
+        )
+        require(command.get("terminal") is True, f"{label}: command {index} terminal must be true")
+
+    merge_response = capture.get("merge_response")
+    require(isinstance(merge_response, dict), f"{label}: merge response is malformed")
+    require(
+        set(merge_response) == {"merged", "sha"},
+        f"{label}: merge response fields are not exact",
+    )
+    require(merge_response.get("merged") is True, f"{label}: merge response is not merged")
+    require(merge_response.get("sha") == merged_oid, f"{label}: merge response SHA mismatch")
+
+    main_ref = capture.get("main_ref")
+    require(isinstance(main_ref, dict), f"{label}: main ref is malformed")
+    require(set(main_ref) == {"ref", "sha"}, f"{label}: main ref fields are not exact")
+    require(main_ref.get("ref") == "refs/heads/main", f"{label}: main ref name mismatch")
+    require(main_ref.get("sha") == merged_oid, f"{label}: main ref SHA mismatch")
+    return copy.deepcopy(commands)
 
 
 def build_release_inputs(
@@ -1141,6 +1310,7 @@ def prepare(
     g3_xcresult_zip: Path,
     desktop_run_json: Path,
     runtime_run_json: Path,
+    integration_execution_capture: Path,
     output_recipe: Path,
     evidence_root: Path,
     contract: PreparationContract,
@@ -1180,6 +1350,11 @@ def prepare(
     artifact_metadata, artifact_metadata_raw = parse_canonical_json(
         absolute_path(g3_artifact_metadata_json), "G3 artifact metadata"
     )
+    integration_capture, integration_capture_raw = parse_canonical_json(
+        absolute_path(integration_execution_capture),
+        "integration execution capture",
+    )
+    commands = validate_integration_capture(integration_capture, merged_oid, contract)
 
     g3_created, _ = validate_run_payload(
         g3_run,
@@ -1303,6 +1478,12 @@ def prepare(
         "G3 artifact metadata material",
         expected_sha256=sha256_bytes(artifact_metadata_raw),
     )
+    materialize_file(
+        absolute_path(integration_execution_capture),
+        target_path(material_root, "captures/integration-execution-capture.json"),
+        "integration execution capture material",
+        expected_sha256=sha256_bytes(integration_capture_raw),
+    )
     xcresult_sha256 = materialize_file(
         absolute_path(g3_xcresult_zip),
         target_path(material_root, "captures/g3-xcresult.zip"),
@@ -1311,7 +1492,6 @@ def prepare(
     )
 
     release_inputs = build_release_inputs(merged_oid, contract)
-    commands = integration_commands(contract)
     receipt = {
         "commands": commands,
         "repositories": [
@@ -1496,6 +1676,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--g3-xcresult-zip", required=True, type=Path)
     parser.add_argument("--desktop-run-json", required=True, type=Path)
     parser.add_argument("--runtime-run-json", required=True, type=Path)
+    parser.add_argument("--integration-execution-capture", required=True, type=Path)
     parser.add_argument("--output-recipe", required=True, type=Path)
     parser.add_argument(
         "--evidence-root",
@@ -1516,6 +1697,7 @@ def main(argv: list[str] | None = None) -> int:
             g3_xcresult_zip=arguments.g3_xcresult_zip,
             desktop_run_json=arguments.desktop_run_json,
             runtime_run_json=arguments.runtime_run_json,
+            integration_execution_capture=arguments.integration_execution_capture,
             output_recipe=arguments.output_recipe,
             evidence_root=arguments.evidence_root,
             contract=PRODUCTION_CONTRACT,

--- a/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
+++ b/scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py
@@ -1,0 +1,1536 @@
+#!/usr/bin/python3 -I
+"""Prepare offline materials and a canonical Floorp Notes Sync production-QA recipe.
+
+This command deliberately performs no network access.  It verifies a clean,
+detached post-merge iOS worktree, immutable local evidence, repository blobs,
+and caller-captured GitHub Actions metadata before materializing the exact
+inputs consumed by ``assemble-floorp-notes-sync-production-qa-evidence.py``.
+
+Files are published with no-clobber semantics.  A pre-existing managed file is
+accepted only when it is a regular, non-symlink, owner-only file containing the
+exact expected bytes.  The integration receipt is never created here; the
+assembler remains its sole producer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+GIT = "/usr/bin/git"
+READ_CHUNK_BYTES = 1024 * 1024
+MAX_JSON_BYTES = 32 * 1024 * 1024
+MAX_SAFE_INTEGER = 9_007_199_254_740_991
+SHA1_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
+TIMESTAMP_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
+RUN_PAYLOAD_KEYS = {
+    "conclusion",
+    "created_at",
+    "event",
+    "head_branch",
+    "head_sha",
+    "id",
+    "repository",
+    "run_attempt",
+    "status",
+    "updated_at",
+    "workflow_path",
+}
+ARTIFACT_METADATA_KEYS = {
+    "artifact_created_at",
+    "artifact_expires_at",
+    "artifact_id",
+    "artifact_name",
+    "head_sha",
+    "run_id",
+}
+GATE_SOURCE_ROLES = {
+    "g1": (
+        "task-manifest",
+        "todo16-contract",
+        "ios-contract-source",
+        "desktop-contract-source",
+        "merge-fixture",
+    ),
+    "g2": (
+        "task-manifest",
+        "fake-server-run",
+        "focus-xcframework",
+        "mozilla-xcframework",
+        "release-manifest",
+        "sha256sums",
+        "swift-components",
+    ),
+    "g3": ("integration-receipt", "ci-run", "xcresult"),
+    "g4": (
+        "task-manifest",
+        "task18-execution-verdict",
+        "desktop-ci-run",
+        "runtime-ci-run",
+        "g4-attestation-source",
+        "g4-attestation-ci-run",
+        "g4-attestation-xcresult",
+        "xpcshell-run",
+        "tps-run",
+    ),
+}
+
+
+class PreparationError(Exception):
+    """A fail-closed input or publication rejection."""
+
+
+@dataclass(frozen=True)
+class EvidenceFileSpec:
+    key: str
+    source_relative: str
+    target_relative: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class SummarySpec:
+    key: str
+    target_relative: str
+    payload: dict[str, Any]
+    sha256: str
+    source_artifacts: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class ReleaseAssetSpec:
+    role: str
+    asset_name: str
+    asset_id: int
+    sha256: str
+    source_relative: str
+    target_relative: str
+
+
+@dataclass(frozen=True)
+class RepositoryFileSpec:
+    role: str
+    repository: str
+    worktree: str
+    commit_sha: str | None
+    path: str
+    content_policy: str
+    blob_sha: str
+    sha256: str
+    target_relative: str
+
+
+@dataclass(frozen=True)
+class PreparationContract:
+    base_oid: str
+    reviewed_head_oid: str
+    ios_repository: str
+    floorp_repository: str
+    todo16_source_sha: str
+    desktop_source_sha: str
+    desktop_build_number: str
+    desktop_run_id: int
+    desktop_run_head_sha: str
+    desktop_workflow_path: str
+    runtime_repository: str
+    runtime_source_sha: str
+    runtime_tree_sha: str
+    runtime_run_id: int
+    runtime_run_head_sha: str
+    runtime_workflow_path: str
+    application_services_repository: str
+    application_services_source_sha: str
+    application_services_tree_sha: str
+    application_services_release_tag: str
+    release_id: int
+    release_published_at: str
+    fixture_sha256: str
+    case_set_sha256: str
+    endpoint_policy_sha256: str
+    g1_issued_at: str
+    evidence_files: tuple[EvidenceFileSpec, ...]
+    summaries: tuple[SummarySpec, ...]
+    release_assets: tuple[ReleaseAssetSpec, ...]
+    repository_files: tuple[RepositoryFileSpec, ...]
+
+
+DEFAULT_EVIDENCE_ROOT = Path(
+    "/Users/user/dev-source/floorp-ios-dev/.omo/evidence/"
+    "floorp-ios-next-milestone-20260806"
+)
+
+PRODUCTION_CONTRACT = PreparationContract(
+    base_oid="330870f9d6db91433afe1024ac8200f81d260a42",
+    reviewed_head_oid="2d887f482e2b1fefa86115a6f23afea131bc93d9",
+    ios_repository="Floorp-Projects/floorp-ios",
+    floorp_repository="Floorp-Projects/Floorp",
+    todo16_source_sha="18841c0c43d0eda428e1c88170769c1539543848",
+    desktop_source_sha="fc244eed70248796fa92ff5821c6046ecd576e7e",
+    desktop_build_number="31338438952",
+    desktop_run_id=31338438952,
+    desktop_run_head_sha="17b47fcb837272040a6231963b5221aaec80fa42",
+    desktop_workflow_path=".github/workflows/colocated_runner_test.yml",
+    runtime_repository="Floorp-Projects/Floorp-Runtime",
+    runtime_source_sha="3bf9399564e59be32f92dcc1b044094881b4fb6a",
+    runtime_tree_sha="533f9fdca9bdccb7f3d2a13842be7e2375160ae5",
+    runtime_run_id=31330766054,
+    runtime_run_head_sha="515da7cf9c7fc258eacd56902448eb10989d17b0",
+    runtime_workflow_path=".github/workflows/wrapper-mac-build.yml",
+    application_services_repository="Floorp-Projects/application-services",
+    application_services_source_sha="b6d29804c391a573ecc0db6c1c4491b3e07a6693",
+    application_services_tree_sha="8bfa4a27d5b807b613d577ee49198617aab0e117",
+    application_services_release_tag="floorp-ios-155.20260731050244.4",
+    release_id=367118816,
+    release_published_at="2026-08-08T05:41:30Z",
+    fixture_sha256="2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd",
+    case_set_sha256="c19ec1a3229b0d09aa424498471941409bc77505862e8aa278aadb3396032802",
+    endpoint_policy_sha256="af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca",
+    g1_issued_at="2026-08-09T08:55:09Z",
+    evidence_files=(
+        EvidenceFileSpec(
+            "task16",
+            "task-16-attempt-3/task-16-manifest.json",
+            "artifacts/task-16-manifest.json",
+            "4b506307a780cfac04b28cc226e46d13c0be4ceacd1e80e06211a2c7c8dde3dc",
+        ),
+        EvidenceFileSpec(
+            "task17",
+            "task-17-attempt-5/task-17-manifest.json",
+            "artifacts/task-17-manifest.json",
+            "7e97ec176d944709907e0675731d90ad8ad43f75e00d30f448578f0367b750cf",
+        ),
+        EvidenceFileSpec(
+            "task18",
+            "task-18-attempt-10-production/task-18-manifest.json",
+            "artifacts/task-18-manifest.json",
+            "d55a01faf3755658cca48750e40370aac72e83b87eb9a8fec9ce5f6bb5f77e84",
+        ),
+        EvidenceFileSpec(
+            "task18-verdict",
+            "F1-attempt-4/production-t18-validation/verdict-attempt-2.json",
+            "artifacts/task-18-execution-verdict.json",
+            "0d1606797281d525924f0ff85b15b9697b6bb11de91196704a6d334591baf689",
+        ),
+    ),
+    summaries=(
+        SummarySpec(
+            "fake-server",
+            "artifacts/g2-fake-server-run.json",
+            {
+                "failed": 0,
+                "passed": 24,
+                "secrets_retained": False,
+                "source_log_sha256": (
+                    "676ea1c0523b932618cd85d165be1dca541fb37fb0cf8e8c2443541e6f303f49"
+                ),
+            },
+            "c22f3131a15c35d465bbf61ca2044cba2c785eb86cee0ddeec8559333fb770c3",
+            ((
+                "task-17-attempt-3/green/task-17-green.log",
+                "676ea1c0523b932618cd85d165be1dca541fb37fb0cf8e8c2443541e6f303f49",
+            ),),
+        ),
+        SummarySpec(
+            "xpcshell",
+            "artifacts/g4-xpcshell-run.json",
+            {
+                "failed": 0,
+                "passed": 108,
+                "secrets_retained": False,
+                "source_log_sha256": (
+                    "c049c1124a4c623601203dc2d34a1acc928a7075b83345c3ed91badad53d12dd"
+                ),
+            },
+            "70d3fcf4d6116bb37330a3c5c13b4da819716378d39e54f9bb1cd2702351860b",
+            ((
+                "task-18-attempt-10-production/wider/"
+                "floorp-notes-xpcshell-post-production.log",
+                "c049c1124a4c623601203dc2d34a1acc928a7075b83345c3ed91badad53d12dd",
+            ),),
+        ),
+        SummarySpec(
+            "tps",
+            "artifacts/g4-tps-run.json",
+            {
+                "failed": 0,
+                "passed": 1,
+                "payload_retained": False,
+                "secrets_retained": False,
+                "source_log_sha256": (
+                    "95304333a2213d4cc5b0f3c918c0e09ac82faa68c56b53ae46fe95e1c1bd90ef"
+                ),
+                "source_summary_sha256": (
+                    "16e04d89d63aacf059bb7f559744d42002c2d63c1f1566e349bb611d01f080f8"
+                ),
+            },
+            "f173c9c7113539c3e46eb7b4cb6a8359c7ffbfc749ff0a64325b524ffa551424",
+            (
+                (
+                    "task-18-attempt-10-production/wider/"
+                    "tps-production-summary-headed-attempt-9.log",
+                    "95304333a2213d4cc5b0f3c918c0e09ac82faa68c56b53ae46fe95e1c1bd90ef",
+                ),
+                (
+                    "task-18-attempt-10-production/wider/"
+                    "tps-production-summary-headed-attempt-9.json",
+                    "16e04d89d63aacf059bb7f559744d42002c2d63c1f1566e349bb611d01f080f8",
+                ),
+            ),
+        ),
+    ),
+    release_assets=(
+        ReleaseAssetSpec(
+            "focus-xcframework",
+            "FocusRustComponents.xcframework.zip",
+            506076697,
+            "d996835e76b7b66e516c4b7ddf6c401d815a1ce60466fbbdca73edd2f2ff2b0a",
+            "task-17-attempt-4/wider/release-artifacts-4/"
+            "FocusRustComponents.xcframework.zip",
+            "captures/g2-FocusRustComponents.xcframework.zip",
+        ),
+        ReleaseAssetSpec(
+            "mozilla-xcframework",
+            "MozillaRustComponents.xcframework.zip",
+            506076696,
+            "579b00cd5823a94101145a4deef7df44e1eeb3929cbe849f53a0f6d008e6f268",
+            "task-17-attempt-4/wider/release-artifacts-4/"
+            "MozillaRustComponents.xcframework.zip",
+            "captures/g2-MozillaRustComponents.xcframework.zip",
+        ),
+        ReleaseAssetSpec(
+            "release-manifest",
+            "release-manifest.json",
+            506076698,
+            "387beac1bb8d4b204b9c8ebdc3797ea75e2466c507ec944b2b5188fea2d6b0dd",
+            "task-17-attempt-4/wider/release-artifacts-4/release-manifest.json",
+            "captures/g2-release-manifest.json",
+        ),
+        ReleaseAssetSpec(
+            "sha256sums",
+            "SHA256SUMS",
+            506076695,
+            "32db0711e7b5cf6d088ef95b290941be9ba22cfceeadfc35978fa97d05506b8c",
+            "task-17-attempt-4/wider/release-artifacts-4/SHA256SUMS",
+            "captures/g2-SHA256SUMS",
+        ),
+        ReleaseAssetSpec(
+            "swift-components",
+            "swift-components.tar.xz",
+            506076699,
+            "e9cdae3cbcd19c68d6a1eed78917862f2a6420e2b74fb52e6669f0d641f31433",
+            "task-17-attempt-4/wider/release-artifacts-4/swift-components.tar.xz",
+            "captures/g2-swift-components.tar.xz",
+        ),
+    ),
+    repository_files=(
+        RepositoryFileSpec(
+            "todo16-contract",
+            "Floorp-Projects/Floorp",
+            "floorp",
+            "18841c0c43d0eda428e1c88170769c1539543848",
+            "docs/development/floorp-notes-sync/prerequisites.json",
+            "metadata-json",
+            "43d6826903d49b65d71c593a6e4759eaf32d02a2",
+            "e8c99a574d1171f2ae8df55782e69bcfa0d517938aea0152ca11d587df33d6ba",
+            "captures/g1-todo16-contract.json",
+        ),
+        RepositoryFileSpec(
+            "ios-contract-source",
+            "Floorp-Projects/floorp-ios",
+            "ios",
+            None,
+            "docs/floorp-notes-sync-architecture.md",
+            "source-code",
+            "fb4b79d88c8b25872a03dfb6f1c0e8af8b0c5f6f",
+            "5d53eceec02433da317a95734bf424d2f279a13fa09e55fe22861ac4b12489b5",
+            "captures/g1-ios-contract-source.md",
+        ),
+        RepositoryFileSpec(
+            "desktop-contract-source",
+            "Floorp-Projects/Floorp",
+            "floorp",
+            "fc244eed70248796fa92ff5821c6046ecd576e7e",
+            "docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md",
+            "source-code",
+            "b2af06eee4342ae7a057976326da059f22455eb6",
+            "b420cc063489a51b3741063062532151d44bb4d81eda9d16cb3740652980d8d2",
+            "captures/g1-desktop-contract-source.md",
+        ),
+        RepositoryFileSpec(
+            "merge-fixture",
+            "Floorp-Projects/floorp-ios",
+            "ios",
+            None,
+            "sync-fixtures/floorp-notes/floorp-notes-merge-v1.json",
+            "metadata-json",
+            "fef8f5a0e0e303a3f9106e3ac5ac36a7a67cc6ad",
+            "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd",
+            "captures/g1-merge-fixture.json",
+        ),
+        RepositoryFileSpec(
+            "g4-attestation-source",
+            "Floorp-Projects/floorp-ios",
+            "ios",
+            None,
+            "docs/floorp-notes-sync-g4-attestation.json",
+            "metadata-json",
+            "9f634bba221d4bbc2b53d0c7439a946fd054f6f8",
+            "de1db28ae820f66afc367808f91391202053441d15a4ce017d6cacbc1a7e0dee",
+            "captures/g4-attestation-source.json",
+        ),
+    ),
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PreparationError(message)
+
+
+def canonical_bytes(value: Any) -> bytes:
+    if value is None:
+        return b"null"
+    if value is True:
+        return b"true"
+    if value is False:
+        return b"false"
+    if isinstance(value, int):
+        require(abs(value) <= MAX_SAFE_INTEGER, "canonical JSON integer is outside the safe range")
+        return str(value).encode("ascii")
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if isinstance(value, list):
+        return b"[" + b",".join(canonical_bytes(item) for item in value) + b"]"
+    if isinstance(value, dict):
+        require(all(isinstance(key, str) for key in value), "canonical JSON object keys must be strings")
+        keys = sorted(value, key=lambda key: key.encode("utf-16-be"))
+        return b"{" + b",".join(
+            canonical_bytes(key) + b":" + canonical_bytes(value[key]) for key in keys
+        ) + b"}"
+    raise PreparationError(f"unsupported canonical JSON value: {type(value).__name__}")
+
+
+def sha256_bytes(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def git_blob_sha(raw: bytes) -> str:
+    return hashlib.sha1(f"blob {len(raw)}\0".encode("ascii") + raw).hexdigest()
+
+
+def stable_snapshot(metadata: os.stat_result) -> tuple[int, int, int, int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_uid,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def open_regular(path: Path, label: str) -> tuple[int, os.stat_result]:
+    try:
+        lexical = path.lstat()
+    except OSError as error:
+        raise PreparationError(f"{label}: cannot inspect file ({error})") from error
+    require(not stat.S_ISLNK(lexical.st_mode), f"{label}: symlinks are forbidden")
+    require(stat.S_ISREG(lexical.st_mode), f"{label}: must be a regular file")
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise PreparationError(f"{label}: cannot open file ({error})") from error
+    opened = os.fstat(descriptor)
+    if not stat.S_ISREG(opened.st_mode) or (
+        lexical.st_dev,
+        lexical.st_ino,
+    ) != (opened.st_dev, opened.st_ino):
+        os.close(descriptor)
+        raise PreparationError(f"{label}: file identity changed while opening")
+    return descriptor, opened
+
+
+def hash_open_file(descriptor: int, before: os.stat_result, label: str) -> tuple[str, int]:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    digest = hashlib.sha256()
+    size = 0
+    while chunk := os.read(descriptor, READ_CHUNK_BYTES):
+        digest.update(chunk)
+        size += len(chunk)
+    after = os.fstat(descriptor)
+    require(stable_snapshot(before) == stable_snapshot(after), f"{label}: file changed while read")
+    require(size == before.st_size, f"{label}: file size changed while read")
+    return digest.hexdigest(), size
+
+
+def read_regular_bytes(path: Path, label: str, *, maximum: int = MAX_JSON_BYTES) -> bytes:
+    descriptor, before = open_regular(path, label)
+    try:
+        require(before.st_size <= maximum, f"{label}: file is too large")
+        raw = bytearray()
+        while chunk := os.read(descriptor, READ_CHUNK_BYTES):
+            raw.extend(chunk)
+        after = os.fstat(descriptor)
+        require(stable_snapshot(before) == stable_snapshot(after), f"{label}: file changed while read")
+        return bytes(raw)
+    finally:
+        os.close(descriptor)
+
+
+def reject_float(_: str) -> Any:
+    raise PreparationError("canonical JSON floating-point values are forbidden")
+
+
+def reject_constant(_: str) -> Any:
+    raise PreparationError("canonical JSON non-finite values are forbidden")
+
+
+def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        require(key not in result, f"canonical JSON contains duplicate key {key!r}")
+        result[key] = value
+    return result
+
+
+def parse_canonical_json(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    raw = read_regular_bytes(path, label)
+    try:
+        payload = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=unique_object,
+            parse_float=reject_float,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise PreparationError(f"{label}: malformed UTF-8 JSON ({error})") from error
+    require(isinstance(payload, dict), f"{label}: root must be an object")
+    require(raw == canonical_bytes(payload), f"{label}: input is not canonical JSON")
+    return payload, raw
+
+
+def parse_timestamp(value: Any, label: str) -> datetime:
+    require(isinstance(value, str) and TIMESTAMP_PATTERN.fullmatch(value) is not None, f"{label}: timestamp is malformed")
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError as error:
+        raise PreparationError(f"{label}: timestamp is invalid") from error
+
+
+def format_timestamp(value: datetime) -> str:
+    require(value.tzinfo is not None, "internal timestamp is timezone-naive")
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def exact_positive_integer(value: Any, label: str) -> int:
+    require(
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and 0 < value <= MAX_SAFE_INTEGER,
+        f"{label}: must be a positive safe integer",
+    )
+    return value
+
+
+def absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def ensure_private_directory(path: Path, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        try:
+            os.mkdir(path, 0o700)
+        except OSError as error:
+            raise PreparationError(f"{label}: cannot create private directory ({error})") from error
+        metadata = path.lstat()
+    except OSError as error:
+        raise PreparationError(f"{label}: cannot inspect directory ({error})") from error
+    require(not stat.S_ISLNK(metadata.st_mode), f"{label}: symlink directory is forbidden")
+    require(stat.S_ISDIR(metadata.st_mode), f"{label}: must be a directory")
+    require(metadata.st_uid == os.geteuid(), f"{label}: directory is not owned by this user")
+    require(stat.S_IMODE(metadata.st_mode) == 0o700, f"{label}: directory mode must be 0700")
+
+
+def ensure_private_tree(run_dir: Path, target_parent: Path) -> None:
+    require(run_dir != Path(run_dir.anchor), "run directory cannot be a filesystem root")
+    if not run_dir.exists():
+        require(run_dir.parent.is_dir(), "run directory parent does not exist")
+    ensure_private_directory(run_dir, "run directory")
+    relative = target_parent.relative_to(run_dir)
+    current = run_dir
+    for part in relative.parts:
+        require(part not in ("", ".", ".."), "output parent path is unsafe")
+        current /= part
+        ensure_private_directory(current, "output directory")
+
+
+def target_path(material_root: Path, relative: str) -> Path:
+    relative_path = Path(relative)
+    require(
+        not relative_path.is_absolute()
+        and bool(relative_path.parts)
+        and all(part not in ("", ".", "..") for part in relative_path.parts),
+        f"managed path is unsafe: {relative}",
+    )
+    target = material_root.joinpath(*relative_path.parts)
+    require(os.path.commonpath((material_root, target)) == os.fspath(material_root), "managed path escapes output root")
+    return target
+
+
+def verify_existing_mode(metadata: os.stat_result, label: str) -> None:
+    require(stat.S_ISREG(metadata.st_mode), f"{label}: existing target is not a regular file")
+    require(metadata.st_uid == os.geteuid(), f"{label}: existing target is not owned by this user")
+    require(stat.S_IMODE(metadata.st_mode) == 0o600, f"{label}: existing target mode must be 0600")
+
+
+def publish_bytes_exact(path: Path, raw: bytes, label: str) -> None:
+    if os.path.lexists(path):
+        descriptor, before = open_regular(path, label)
+        try:
+            verify_existing_mode(before, label)
+            require(before.st_size == len(raw), f"{label}: existing file does not match expected bytes")
+            existing = bytearray()
+            while chunk := os.read(descriptor, READ_CHUNK_BYTES):
+                existing.extend(chunk)
+            after = os.fstat(descriptor)
+            require(stable_snapshot(before) == stable_snapshot(after), f"{label}: existing file changed while read")
+            require(bytes(existing) == raw, f"{label}: existing file does not match expected bytes")
+            return
+        finally:
+            os.close(descriptor)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    created = False
+    try:
+        descriptor = os.open(path, flags, 0o600)
+        created = True
+        os.fchmod(descriptor, 0o600)
+        offset = 0
+        while offset < len(raw):
+            offset += os.write(descriptor, raw[offset:])
+        os.fsync(descriptor)
+        verify_existing_mode(os.fstat(descriptor), label)
+    except OSError as error:
+        raise PreparationError(f"{label}: no-clobber publication failed ({error})") from error
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if sys.exc_info()[0] is not None and created:
+            path.unlink(missing_ok=True)
+
+
+def compare_open_files(
+    source_fd: int,
+    source_before: os.stat_result,
+    target_fd: int,
+    target_before: os.stat_result,
+    label: str,
+) -> None:
+    require(source_before.st_size == target_before.st_size, f"{label}: existing file size differs")
+    os.lseek(source_fd, 0, os.SEEK_SET)
+    while True:
+        source_chunk = os.read(source_fd, READ_CHUNK_BYTES)
+        target_chunk = os.read(target_fd, READ_CHUNK_BYTES)
+        require(source_chunk == target_chunk, f"{label}: existing file does not match expected bytes")
+        if not source_chunk:
+            break
+    require(
+        stable_snapshot(source_before) == stable_snapshot(os.fstat(source_fd)),
+        f"{label}: source changed while comparing",
+    )
+    require(
+        stable_snapshot(target_before) == stable_snapshot(os.fstat(target_fd)),
+        f"{label}: existing target changed while comparing",
+    )
+
+
+def materialize_file(
+    source: Path,
+    target: Path,
+    label: str,
+    *,
+    expected_sha256: str | None,
+) -> str:
+    source_fd, source_before = open_regular(source, f"{label} source")
+    try:
+        actual_sha256, source_size = hash_open_file(source_fd, source_before, f"{label} source")
+        if expected_sha256 is not None:
+            require(SHA256_PATTERN.fullmatch(expected_sha256) is not None, f"{label}: configured SHA-256 is malformed")
+            require(actual_sha256 == expected_sha256, f"{label}: source SHA-256 mismatch")
+        if os.path.lexists(target):
+            target_fd, target_before = open_regular(target, label)
+            try:
+                verify_existing_mode(target_before, label)
+                compare_open_files(source_fd, source_before, target_fd, target_before, label)
+                return actual_sha256
+            finally:
+                os.close(target_fd)
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        target_fd = -1
+        created = False
+        try:
+            target_fd = os.open(target, flags, 0o600)
+            created = True
+            os.fchmod(target_fd, 0o600)
+            os.lseek(source_fd, 0, os.SEEK_SET)
+            copied_digest = hashlib.sha256()
+            copied_size = 0
+            while chunk := os.read(source_fd, READ_CHUNK_BYTES):
+                copied_digest.update(chunk)
+                copied_size += len(chunk)
+                offset = 0
+                while offset < len(chunk):
+                    offset += os.write(target_fd, chunk[offset:])
+            require(copied_size == source_size, f"{label}: source size changed while copying")
+            require(copied_digest.hexdigest() == actual_sha256, f"{label}: source changed while copying")
+            require(
+                stable_snapshot(source_before) == stable_snapshot(os.fstat(source_fd)),
+                f"{label}: source changed while copying",
+            )
+            os.fsync(target_fd)
+            target_after = os.fstat(target_fd)
+            verify_existing_mode(target_after, label)
+            require(target_after.st_size == source_size, f"{label}: published size mismatch")
+        except OSError as error:
+            raise PreparationError(f"{label}: no-clobber publication failed ({error})") from error
+        finally:
+            if target_fd >= 0:
+                os.close(target_fd)
+            if sys.exc_info()[0] is not None and created:
+                target.unlink(missing_ok=True)
+        return actual_sha256
+    finally:
+        os.close(source_fd)
+
+
+def git_command(worktree: Path, arguments: Iterable[str], label: str, *, accepted: tuple[int, ...] = (0,)) -> subprocess.CompletedProcess[bytes]:
+    try:
+        result = subprocess.run(
+            [GIT, "-C", os.fspath(worktree), *arguments],
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                "HOME": os.environ.get("HOME", ""),
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": "/usr/bin:/bin",
+            },
+        )
+    except OSError as error:
+        raise PreparationError(f"{label}: Git invocation failed ({error})") from error
+    require(result.returncode in accepted, f"{label}: Git command failed with exit {result.returncode}")
+    return result
+
+
+def git_text(worktree: Path, arguments: Iterable[str], label: str) -> str:
+    raw = git_command(worktree, arguments, label).stdout
+    try:
+        return raw.decode("utf-8").strip()
+    except UnicodeError as error:
+        raise PreparationError(f"{label}: Git output is not UTF-8") from error
+
+
+def validate_git_worktree(path: Path, label: str) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as error:
+        raise PreparationError(f"{label}: cannot inspect worktree ({error})") from error
+    require(not stat.S_ISLNK(metadata.st_mode), f"{label}: symlink worktree is forbidden")
+    require(stat.S_ISDIR(metadata.st_mode), f"{label}: worktree is not a directory")
+    require(git_text(path, ("rev-parse", "--is-inside-work-tree"), label) == "true", f"{label}: not a Git worktree")
+
+
+def validate_merged_worktree(
+    path: Path,
+    merged_oid: str,
+    contract: PreparationContract,
+) -> bytes:
+    validate_git_worktree(path, "merged iOS worktree")
+    head = git_text(path, ("rev-parse", "--verify", "HEAD"), "merged iOS worktree")
+    require(head == merged_oid, "merged iOS worktree: HEAD does not equal --merged-oid")
+    detached = git_command(
+        path,
+        ("symbolic-ref", "-q", "HEAD"),
+        "merged iOS worktree",
+        accepted=(0, 1),
+    )
+    require(detached.returncode == 1 and detached.stdout == b"", "merged iOS worktree: HEAD must be detached")
+    status = git_command(
+        path,
+        ("status", "--porcelain=v1", "--untracked-files=all"),
+        "merged iOS worktree",
+    ).stdout
+    require(status == b"", "merged iOS worktree: worktree is dirty")
+    parents = git_text(path, ("show", "-s", "--format=%P", merged_oid), "merged iOS worktree").split()
+    require(parents == [contract.base_oid], "merged iOS worktree: squash commit parent does not equal guarded base")
+    merged_tree = git_text(path, ("rev-parse", f"{merged_oid}^{{tree}}"), "merged iOS worktree")
+    reviewed_tree = git_text(
+        path,
+        ("rev-parse", f"{contract.reviewed_head_oid}^{{tree}}"),
+        "merged iOS worktree",
+    )
+    require(merged_tree == reviewed_tree, "merged iOS worktree: merged tree differs from reviewed head")
+    config = git_command(
+        path,
+        ("show", f"{merged_oid}:firefox-ios/Client/Configuration/FloorpRelease.xcconfig"),
+        "FloorpRelease.xcconfig",
+    ).stdout
+    try:
+        text = config.decode("utf-8")
+    except UnicodeError as error:
+        raise PreparationError("FloorpRelease.xcconfig: content is not UTF-8") from error
+    assignments = re.findall(r"(?m)^FLOORP_BUILD_NUMBER[ \t]*=[ \t]*([^\s#]+)[ \t]*$", text)
+    require(assignments == ["4"], "FloorpRelease.xcconfig: FLOORP_BUILD_NUMBER must be exactly 4")
+    return config
+
+
+def repository_blob(
+    worktree: Path,
+    commit_sha: str,
+    spec: RepositoryFileSpec,
+) -> bytes:
+    require(SHA1_PATTERN.fullmatch(commit_sha) is not None, f"{spec.role}: commit SHA is malformed")
+    resolved_commit = git_text(
+        worktree,
+        ("rev-parse", f"{commit_sha}^{{commit}}"),
+        f"{spec.role} repository source",
+    )
+    require(resolved_commit == commit_sha, f"{spec.role}: commit object mismatch")
+    blob = git_text(
+        worktree,
+        ("rev-parse", f"{commit_sha}:{spec.path}"),
+        f"{spec.role} repository source",
+    )
+    require(blob == spec.blob_sha, f"{spec.role}: Git blob SHA mismatch")
+    raw = git_command(
+        worktree,
+        ("cat-file", "blob", blob),
+        f"{spec.role} repository source",
+    ).stdout
+    require(git_blob_sha(raw) == spec.blob_sha, f"{spec.role}: computed Git blob SHA mismatch")
+    require(sha256_bytes(raw) == spec.sha256, f"{spec.role}: repository bytes SHA-256 mismatch")
+    if spec.role == "g4-attestation-source":
+        try:
+            parsed = json.loads(
+                raw.decode("utf-8"),
+                object_pairs_hook=unique_object,
+                parse_float=reject_float,
+                parse_constant=reject_constant,
+            )
+        except (UnicodeError, json.JSONDecodeError) as error:
+            raise PreparationError("g4-attestation-source: malformed canonical JSON") from error
+        require(raw == canonical_bytes(parsed), "g4-attestation-source: JSON is not canonical")
+    return raw
+
+
+def validate_run_payload(
+    payload: dict[str, Any],
+    *,
+    label: str,
+    repository: str,
+    run_id: int | None,
+    head_sha: str,
+    workflow_path: str,
+    event: str | None = None,
+    head_branch: str | None = None,
+) -> tuple[datetime, datetime]:
+    require(set(payload) == RUN_PAYLOAD_KEYS, f"{label}: fields are not exact")
+    exact_positive_integer(payload.get("id"), f"{label}.id")
+    exact_positive_integer(payload.get("run_attempt"), f"{label}.run_attempt")
+    if run_id is not None:
+        require(payload["id"] == run_id, f"{label}: run ID mismatch")
+    require(payload.get("repository") == repository, f"{label}: repository mismatch")
+    require(payload.get("head_sha") == head_sha, f"{label}: head SHA mismatch")
+    require(payload.get("workflow_path") == workflow_path, f"{label}: workflow path mismatch")
+    require(payload.get("status") == "completed", f"{label}: run is nonterminal")
+    require(payload.get("conclusion") == "success", f"{label}: run did not succeed")
+    require(isinstance(payload.get("event"), str) and bool(payload["event"]), f"{label}: event is malformed")
+    require(isinstance(payload.get("head_branch"), str) and bool(payload["head_branch"]), f"{label}: head branch is malformed")
+    if event is not None:
+        require(payload["event"] == event, f"{label}: event mismatch")
+    if head_branch is not None:
+        require(payload["head_branch"] == head_branch, f"{label}: head branch mismatch")
+    created = parse_timestamp(payload.get("created_at"), f"{label}.created_at")
+    updated = parse_timestamp(payload.get("updated_at"), f"{label}.updated_at")
+    require(updated >= created, f"{label}: updated_at precedes created_at")
+    return created, updated
+
+
+def local_source(role: str, path: str, policy: str, sha256: str) -> dict[str, Any]:
+    return {
+        "content_policy": policy,
+        "kind": "local-file",
+        "path": path,
+        "role": role,
+        "sha256": sha256,
+    }
+
+
+def repository_source(
+    spec: RepositoryFileSpec,
+    commit_sha: str,
+) -> dict[str, Any]:
+    return {
+        "blob_sha": spec.blob_sha,
+        "commit_sha": commit_sha,
+        "content_policy": spec.content_policy,
+        "kind": "github-repository-file",
+        "path": spec.path,
+        "repository": spec.repository,
+        "role": spec.role,
+        "sha256": spec.sha256,
+    }
+
+
+def run_source(role: str, payload: dict[str, Any], raw: bytes) -> dict[str, Any]:
+    return {
+        "content_policy": "metadata-json",
+        "head_sha": payload["head_sha"],
+        "kind": "github-actions-run",
+        "repository": payload["repository"],
+        "role": role,
+        "run_id": payload["id"],
+        "sha256": sha256_bytes(raw),
+        "workflow_path": payload["workflow_path"],
+    }
+
+
+def artifact_source(
+    role: str,
+    metadata: dict[str, Any],
+    repository: str,
+    sha256: str,
+) -> dict[str, Any]:
+    return {
+        "artifact_created_at": metadata["artifact_created_at"],
+        "artifact_expires_at": metadata["artifact_expires_at"],
+        "artifact_id": metadata["artifact_id"],
+        "artifact_name": metadata["artifact_name"],
+        "content_policy": "test-result-bundle",
+        "head_sha": metadata["head_sha"],
+        "kind": "github-actions-artifact",
+        "repository": repository,
+        "role": role,
+        "run_id": metadata["run_id"],
+        "sha256": sha256,
+    }
+
+
+def release_asset_source(
+    spec: ReleaseAssetSpec,
+    contract: PreparationContract,
+) -> dict[str, Any]:
+    return {
+        "asset_id": spec.asset_id,
+        "asset_name": spec.asset_name,
+        "content_policy": "release-binary",
+        "kind": "github-release-asset",
+        "release_id": contract.release_id,
+        "release_immutable": True,
+        "release_prerelease": True,
+        "release_published_at": contract.release_published_at,
+        "release_tag": contract.application_services_release_tag,
+        "repository": contract.application_services_repository,
+        "role": spec.role,
+        "sha256": spec.sha256,
+        "source_sha": contract.application_services_source_sha,
+    }
+
+
+def source_entry(bytes_path: str, descriptor: dict[str, Any]) -> dict[str, Any]:
+    return {"bytes_path": bytes_path, "descriptor": descriptor}
+
+
+def role_only(source: dict[str, Any], role: str) -> dict[str, Any]:
+    rebound = dict(source)
+    rebound["role"] = role
+    return rebound
+
+
+def integration_commands(contract: PreparationContract) -> list[dict[str, Any]]:
+    reviewed = contract.reviewed_head_oid
+    return [
+        {
+            "argv": [
+                "/opt/homebrew/bin/gh",
+                "pr",
+                "checks",
+                "83",
+                "--repo",
+                "Floorp-Projects/floorp-ios",
+            ],
+            "exit_code": 0,
+            "terminal": True,
+        },
+        {
+            "argv": ["/usr/bin/test", reviewed, "=", reviewed],
+            "exit_code": 0,
+            "terminal": True,
+        },
+        {
+            "argv": [
+                "/opt/homebrew/bin/gh",
+                "api",
+                "-X",
+                "PUT",
+                "repos/Floorp-Projects/floorp-ios/pulls/83/merge",
+                "-f",
+                f"sha={reviewed}",
+                "-f",
+                "merge_method=squash",
+            ],
+            "exit_code": 0,
+            "terminal": True,
+        },
+        {
+            "argv": [
+                "/opt/homebrew/bin/gh",
+                "api",
+                "repos/Floorp-Projects/floorp-ios/git/ref/heads/main",
+            ],
+            "exit_code": 0,
+            "terminal": True,
+        },
+    ]
+
+
+def build_release_inputs(
+    merged_oid: str,
+    contract: PreparationContract,
+) -> dict[str, Any]:
+    assets = {spec.role: spec.sha256 for spec in contract.release_assets}
+    require(set(assets) == set(GATE_SOURCE_ROLES["g2"][2:]), "release asset roles are not exact")
+    return {
+        "application_services": {
+            "artifacts": {
+                "focus_xcframework_sha256": assets["focus-xcframework"],
+                "mozilla_xcframework_sha256": assets["mozilla-xcframework"],
+                "release_manifest_sha256": assets["release-manifest"],
+                "sha256sums_sha256": assets["sha256sums"],
+                "swift_components_sha256": assets["swift-components"],
+            },
+            "release_tag": contract.application_services_release_tag,
+            "repository": contract.application_services_repository,
+            "source_sha": contract.application_services_source_sha,
+            "tree_sha": contract.application_services_tree_sha,
+        },
+        "contract": {
+            "case_set_sha256": contract.case_set_sha256,
+            "endpoint_policy_sha256": contract.endpoint_policy_sha256,
+            "fixture_sha256": contract.fixture_sha256,
+        },
+        "desktop": {
+            "build_number": contract.desktop_build_number,
+            "repository": contract.floorp_repository,
+            "source_sha": contract.desktop_source_sha,
+        },
+        "environment": {
+            "fxa_configuration": "FxAConfig.Server.release",
+            "fxa_hosts": [
+                "accounts.firefox.com",
+                "api.accounts.firefox.com",
+                "oauth.accounts.firefox.com",
+                "profile.accounts.firefox.com",
+                "static.accounts.firefox.com",
+            ],
+            "sync_hosts": [
+                "event-sync.services.mozilla.com",
+                "sync.services.mozilla.com",
+                "token.services.mozilla.com",
+            ],
+            "wire_protocol": "sync15",
+        },
+        "ios": {
+            "build_number": "4",
+            "configuration": "FloorpRelease",
+            "repository": contract.ios_repository,
+            "source_sha": merged_oid,
+        },
+        "runtime": {
+            "repository": contract.runtime_repository,
+            "source_sha": contract.runtime_source_sha,
+            "tree_sha": contract.runtime_tree_sha,
+        },
+    }
+
+
+def validate_artifact_metadata(
+    metadata: dict[str, Any],
+    g3_run: dict[str, Any],
+    merged_oid: str,
+) -> tuple[datetime, datetime]:
+    require(set(metadata) == ARTIFACT_METADATA_KEYS, "G3 artifact metadata: fields are not exact")
+    exact_positive_integer(metadata.get("artifact_id"), "G3 artifact metadata.artifact_id")
+    exact_positive_integer(metadata.get("run_id"), "G3 artifact metadata.run_id")
+    require(metadata["run_id"] == g3_run["id"], "G3 artifact metadata: run ID mismatch")
+    require(metadata.get("head_sha") == merged_oid, "G3 artifact metadata: head SHA mismatch")
+    require(
+        metadata.get("artifact_name") == "floorp-notes-sync-xcresult",
+        "G3 artifact metadata: artifact name mismatch",
+    )
+    created = parse_timestamp(metadata.get("artifact_created_at"), "G3 artifact created_at")
+    expires = parse_timestamp(metadata.get("artifact_expires_at"), "G3 artifact expires_at")
+    run_created = parse_timestamp(g3_run["created_at"], "G3 run created_at")
+    require(created >= run_created, "G3 artifact metadata: artifact predates its run")
+    require(expires > created, "G3 artifact metadata: expiry must be after creation")
+    require(
+        expires <= created + timedelta(days=7),
+        "G3 artifact metadata: expiry exceeds the seven-day evidence lifetime",
+    )
+    return created, expires
+
+
+def evidence_by_key(contract: PreparationContract) -> dict[str, EvidenceFileSpec]:
+    result = {spec.key: spec for spec in contract.evidence_files}
+    require(
+        set(result) == {"task16", "task17", "task18", "task18-verdict"},
+        "evidence-file contract is not exact",
+    )
+    return result
+
+
+def summary_by_key(contract: PreparationContract) -> dict[str, SummarySpec]:
+    result = {spec.key: spec for spec in contract.summaries}
+    require(set(result) == {"fake-server", "xpcshell", "tps"}, "summary contract is not exact")
+    return result
+
+
+def repository_by_role(contract: PreparationContract) -> dict[str, RepositoryFileSpec]:
+    result = {spec.role: spec for spec in contract.repository_files}
+    require(
+        set(result)
+        == {
+            "todo16-contract",
+            "ios-contract-source",
+            "desktop-contract-source",
+            "merge-fixture",
+            "g4-attestation-source",
+        },
+        "repository-file contract is not exact",
+    )
+    return result
+
+
+def prepare(
+    *,
+    run_dir: Path,
+    merged_ios_worktree: Path,
+    floorp_worktree: Path,
+    merged_oid: str,
+    g3_run_json: Path,
+    g3_artifact_metadata_json: Path,
+    g3_xcresult_zip: Path,
+    desktop_run_json: Path,
+    runtime_run_json: Path,
+    output_recipe: Path,
+    evidence_root: Path,
+    contract: PreparationContract,
+) -> dict[str, Any]:
+    require(SHA1_PATTERN.fullmatch(merged_oid) is not None, "--merged-oid is not a lowercase Git SHA")
+    for value, label in (
+        (contract.base_oid, "guarded base OID"),
+        (contract.reviewed_head_oid, "reviewed head OID"),
+    ):
+        require(SHA1_PATTERN.fullmatch(value) is not None, f"{label} is malformed")
+
+    run_root = absolute_path(run_dir)
+    recipe_path = absolute_path(output_recipe)
+    try:
+        common = os.path.commonpath((run_root, recipe_path))
+    except ValueError as error:
+        raise PreparationError("output recipe and run directory are on different filesystems") from error
+    require(common == os.fspath(run_root) and recipe_path != run_root, "--output-recipe must be under --run-dir")
+    material_root = recipe_path.parent
+    ensure_private_tree(run_root, material_root)
+    ensure_private_directory(target_path(material_root, "artifacts"), "artifacts directory")
+    ensure_private_directory(target_path(material_root, "captures"), "captures directory")
+
+    merged_worktree = absolute_path(merged_ios_worktree)
+    floorp_tree = absolute_path(floorp_worktree)
+    evidence = absolute_path(evidence_root)
+    validate_merged_worktree(merged_worktree, merged_oid, contract)
+    validate_git_worktree(floorp_tree, "Floorp worktree")
+
+    g3_run, g3_run_raw = parse_canonical_json(absolute_path(g3_run_json), "G3 run capture")
+    desktop_run, desktop_run_raw = parse_canonical_json(
+        absolute_path(desktop_run_json), "Desktop run capture"
+    )
+    runtime_run, runtime_run_raw = parse_canonical_json(
+        absolute_path(runtime_run_json), "Runtime run capture"
+    )
+    artifact_metadata, artifact_metadata_raw = parse_canonical_json(
+        absolute_path(g3_artifact_metadata_json), "G3 artifact metadata"
+    )
+
+    g3_created, _ = validate_run_payload(
+        g3_run,
+        label="G3 run capture",
+        repository=contract.ios_repository,
+        run_id=None,
+        head_sha=merged_oid,
+        workflow_path=".github/workflows/ci.yml",
+        event="push",
+        head_branch="main",
+    )
+    desktop_created, _ = validate_run_payload(
+        desktop_run,
+        label="Desktop run capture",
+        repository=contract.floorp_repository,
+        run_id=contract.desktop_run_id,
+        head_sha=contract.desktop_run_head_sha,
+        workflow_path=contract.desktop_workflow_path,
+    )
+    runtime_created, _ = validate_run_payload(
+        runtime_run,
+        label="Runtime run capture",
+        repository=contract.runtime_repository,
+        run_id=contract.runtime_run_id,
+        head_sha=contract.runtime_run_head_sha,
+        workflow_path=contract.runtime_workflow_path,
+    )
+    artifact_created, artifact_expires = validate_artifact_metadata(
+        artifact_metadata,
+        g3_run,
+        merged_oid,
+    )
+
+    g4_issued = max(desktop_created, runtime_created, g3_created)
+    g4_expires = min(
+        desktop_created + timedelta(days=30),
+        runtime_created + timedelta(days=30),
+        g3_created + timedelta(days=30),
+        artifact_expires,
+    )
+    require(g4_expires > g4_issued, "G4 evidence lifetime is already empty")
+    release_published = parse_timestamp(contract.release_published_at, "release published_at")
+    g1_issued = parse_timestamp(contract.g1_issued_at, "G1 issued_at")
+
+    evidence_specs = evidence_by_key(contract)
+    summary_specs = summary_by_key(contract)
+    repository_specs = repository_by_role(contract)
+    local_digests: dict[str, str] = {}
+    for key, spec in evidence_specs.items():
+        local_digests[key] = materialize_file(
+            evidence / spec.source_relative,
+            target_path(material_root, spec.target_relative),
+            f"{key} evidence",
+            expected_sha256=spec.sha256,
+        )
+
+    for key, spec in summary_specs.items():
+        for source_relative, expected_sha in spec.source_artifacts:
+            source_fd, source_before = open_regular(
+                evidence / source_relative,
+                f"{key} summary source artifact",
+            )
+            try:
+                actual, _ = hash_open_file(source_fd, source_before, f"{key} summary source artifact")
+            finally:
+                os.close(source_fd)
+            require(actual == expected_sha, f"{key} summary source artifact SHA-256 mismatch")
+        summary_raw = canonical_bytes(spec.payload)
+        require(sha256_bytes(summary_raw) == spec.sha256, f"{key} summary canonical SHA-256 mismatch")
+        publish_bytes_exact(
+            target_path(material_root, spec.target_relative),
+            summary_raw,
+            f"{key} summary",
+        )
+        local_digests[key] = spec.sha256
+
+    asset_specs = {spec.role: spec for spec in contract.release_assets}
+    require(tuple(asset_specs) == GATE_SOURCE_ROLES["g2"][2:], "release asset roles or order are not exact")
+    for spec in contract.release_assets:
+        materialize_file(
+            evidence / spec.source_relative,
+            target_path(material_root, spec.target_relative),
+            f"{spec.role} release asset",
+            expected_sha256=spec.sha256,
+        )
+
+    repository_descriptors: dict[str, dict[str, Any]] = {}
+    for spec in contract.repository_files:
+        require(spec.worktree in {"ios", "floorp"}, f"{spec.role}: unknown repository worktree")
+        selected_tree = merged_worktree if spec.worktree == "ios" else floorp_tree
+        commit_sha = merged_oid if spec.commit_sha is None else spec.commit_sha
+        raw = repository_blob(selected_tree, commit_sha, spec)
+        publish_bytes_exact(
+            target_path(material_root, spec.target_relative),
+            raw,
+            f"{spec.role} repository material",
+        )
+        repository_descriptors[spec.role] = repository_source(spec, commit_sha)
+
+    materialize_file(
+        absolute_path(g3_run_json),
+        target_path(material_root, "captures/g3-ci-run.json"),
+        "G3 run material",
+        expected_sha256=sha256_bytes(g3_run_raw),
+    )
+    materialize_file(
+        absolute_path(desktop_run_json),
+        target_path(material_root, "captures/g4-desktop-ci-run.json"),
+        "Desktop run material",
+        expected_sha256=sha256_bytes(desktop_run_raw),
+    )
+    materialize_file(
+        absolute_path(runtime_run_json),
+        target_path(material_root, "captures/g4-runtime-ci-run.json"),
+        "Runtime run material",
+        expected_sha256=sha256_bytes(runtime_run_raw),
+    )
+    materialize_file(
+        absolute_path(g3_artifact_metadata_json),
+        target_path(material_root, "captures/g3-xcresult-metadata.json"),
+        "G3 artifact metadata material",
+        expected_sha256=sha256_bytes(artifact_metadata_raw),
+    )
+    xcresult_sha256 = materialize_file(
+        absolute_path(g3_xcresult_zip),
+        target_path(material_root, "captures/g3-xcresult.zip"),
+        "G3 XCResult material",
+        expected_sha256=None,
+    )
+
+    release_inputs = build_release_inputs(merged_oid, contract)
+    commands = integration_commands(contract)
+    receipt = {
+        "commands": commands,
+        "repositories": [
+            {
+                "base_oid": contract.base_oid,
+                "head_oid": contract.reviewed_head_oid,
+                "merged_oid": merged_oid,
+                "name": "floorp-ios",
+            }
+        ],
+        "schema_version": 1,
+        "state": "integration_complete",
+        "task_id": 19,
+    }
+    receipt_raw = canonical_bytes(receipt)
+    receipt_relative = "artifacts/task-19-integration-receipt.json"
+    receipt_path = target_path(material_root, receipt_relative)
+    require(not os.path.lexists(receipt_path), "integration receipt already exists; only the assembler may create it")
+
+    g3_run_descriptor = run_source("ci-run", g3_run, g3_run_raw)
+    g3_artifact_descriptor = artifact_source(
+        "xcresult",
+        artifact_metadata,
+        contract.ios_repository,
+        xcresult_sha256,
+    )
+    desktop_run_descriptor = run_source("desktop-ci-run", desktop_run, desktop_run_raw)
+    runtime_run_descriptor = run_source("runtime-ci-run", runtime_run, runtime_run_raw)
+
+    g1_sources = [
+        source_entry(
+            evidence_specs["task16"].target_relative,
+            local_source(
+                "task-manifest",
+                evidence_specs["task16"].target_relative,
+                "metadata-json",
+                local_digests["task16"],
+            ),
+        ),
+        source_entry(repository_specs["todo16-contract"].target_relative, repository_descriptors["todo16-contract"]),
+        source_entry(repository_specs["ios-contract-source"].target_relative, repository_descriptors["ios-contract-source"]),
+        source_entry(repository_specs["desktop-contract-source"].target_relative, repository_descriptors["desktop-contract-source"]),
+        source_entry(repository_specs["merge-fixture"].target_relative, repository_descriptors["merge-fixture"]),
+    ]
+    g2_sources = [
+        source_entry(
+            evidence_specs["task17"].target_relative,
+            local_source(
+                "task-manifest",
+                evidence_specs["task17"].target_relative,
+                "metadata-json",
+                local_digests["task17"],
+            ),
+        ),
+        source_entry(
+            summary_specs["fake-server"].target_relative,
+            local_source(
+                "fake-server-run",
+                summary_specs["fake-server"].target_relative,
+                "metadata-json",
+                local_digests["fake-server"],
+            ),
+        ),
+        *[
+            source_entry(spec.target_relative, release_asset_source(spec, contract))
+            for spec in contract.release_assets
+        ],
+    ]
+    g3_sources = [
+        source_entry(
+            receipt_relative,
+            local_source(
+                "integration-receipt",
+                receipt_relative,
+                "metadata-json",
+                sha256_bytes(receipt_raw),
+            ),
+        ),
+        source_entry("captures/g3-ci-run.json", g3_run_descriptor),
+        source_entry("captures/g3-xcresult.zip", g3_artifact_descriptor),
+    ]
+    g4_sources = [
+        source_entry(
+            evidence_specs["task18"].target_relative,
+            local_source(
+                "task-manifest",
+                evidence_specs["task18"].target_relative,
+                "metadata-json",
+                local_digests["task18"],
+            ),
+        ),
+        source_entry(
+            evidence_specs["task18-verdict"].target_relative,
+            local_source(
+                "task18-execution-verdict",
+                evidence_specs["task18-verdict"].target_relative,
+                "metadata-json",
+                local_digests["task18-verdict"],
+            ),
+        ),
+        source_entry("captures/g4-desktop-ci-run.json", desktop_run_descriptor),
+        source_entry("captures/g4-runtime-ci-run.json", runtime_run_descriptor),
+        source_entry(
+            repository_specs["g4-attestation-source"].target_relative,
+            repository_descriptors["g4-attestation-source"],
+        ),
+        source_entry(
+            "captures/g3-ci-run.json",
+            role_only(g3_run_descriptor, "g4-attestation-ci-run"),
+        ),
+        source_entry(
+            "captures/g3-xcresult.zip",
+            role_only(g3_artifact_descriptor, "g4-attestation-xcresult"),
+        ),
+        source_entry(
+            summary_specs["xpcshell"].target_relative,
+            local_source(
+                "xpcshell-run",
+                summary_specs["xpcshell"].target_relative,
+                "metadata-json",
+                local_digests["xpcshell"],
+            ),
+        ),
+        source_entry(
+            summary_specs["tps"].target_relative,
+            local_source(
+                "tps-run",
+                summary_specs["tps"].target_relative,
+                "metadata-json",
+                local_digests["tps"],
+            ),
+        ),
+    ]
+    for gate_name, sources in (
+        ("g1", g1_sources),
+        ("g2", g2_sources),
+        ("g3", g3_sources),
+        ("g4", g4_sources),
+    ):
+        roles = tuple(entry["descriptor"]["role"] for entry in sources)
+        require(roles == GATE_SOURCE_ROLES[gate_name], f"{gate_name}: source roles or order drifted")
+
+    recipe = {
+        "build_contract_mode": "production-qa",
+        "g3_integration_commands": commands,
+        "gates": {
+            "g1": {
+                "issued_at": format_timestamp(g1_issued),
+                "sources": g1_sources,
+            },
+            "g2": {
+                "expires_at": format_timestamp(release_published + timedelta(days=30)),
+                "issued_at": format_timestamp(release_published),
+                "sources": g2_sources,
+            },
+            "g3": {
+                "expires_at": format_timestamp(artifact_expires),
+                "issued_at": format_timestamp(artifact_created),
+                "sources": g3_sources,
+            },
+            "g4": {
+                "expires_at": format_timestamp(g4_expires),
+                "issued_at": format_timestamp(g4_issued),
+                "sources": g4_sources,
+            },
+        },
+        "release_inputs": release_inputs,
+        "schema_version": 1,
+    }
+    publish_bytes_exact(recipe_path, canonical_bytes(recipe), "output recipe")
+    return recipe
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    parser.add_argument("--merged-ios-worktree", required=True, type=Path)
+    parser.add_argument("--floorp-worktree", required=True, type=Path)
+    parser.add_argument("--merged-oid", required=True)
+    parser.add_argument("--g3-run-json", required=True, type=Path)
+    parser.add_argument("--g3-artifact-metadata-json", required=True, type=Path)
+    parser.add_argument("--g3-xcresult-zip", required=True, type=Path)
+    parser.add_argument("--desktop-run-json", required=True, type=Path)
+    parser.add_argument("--runtime-run-json", required=True, type=Path)
+    parser.add_argument("--output-recipe", required=True, type=Path)
+    parser.add_argument(
+        "--evidence-root",
+        type=Path,
+        default=DEFAULT_EVIDENCE_ROOT,
+        help="existing orchestration evidence root (default: approved milestone evidence root)",
+    )
+    arguments = parser.parse_args(argv)
+    previous_umask = os.umask(0o077)
+    try:
+        prepare(
+            run_dir=arguments.run_dir,
+            merged_ios_worktree=arguments.merged_ios_worktree,
+            floorp_worktree=arguments.floorp_worktree,
+            merged_oid=arguments.merged_oid,
+            g3_run_json=arguments.g3_run_json,
+            g3_artifact_metadata_json=arguments.g3_artifact_metadata_json,
+            g3_xcresult_zip=arguments.g3_xcresult_zip,
+            desktop_run_json=arguments.desktop_run_json,
+            runtime_run_json=arguments.runtime_run_json,
+            output_recipe=arguments.output_recipe,
+            evidence_root=arguments.evidence_root,
+            contract=PRODUCTION_CONTRACT,
+        )
+        print(f"APPROVE: prepared canonical production-QA recipe at {absolute_path(arguments.output_recipe)}")
+        return 0
+    except PreparationError as error:
+        print(f"REJECT: {error}", file=sys.stderr)
+        return 1
+    except (OSError, UnicodeError) as error:
+        print(f"INPUT_ERROR: preparation dependency failed ({error})", file=sys.stderr)
+        return 2
+    finally:
+        os.umask(previous_umask)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
+++ b/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PREPARER_PATH = ROOT / "scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py"
+
+
+def load_preparer():
+    spec = importlib.util.spec_from_file_location("floorp_production_qa_preparer", PREPARER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load production-QA recipe preparer")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PREPARER = load_preparer()
+
+
+class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_owner = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temporary_owner.name)
+        self.run_dir = self.directory / "run"
+        self.run_dir.mkdir(mode=0o700)
+        self.evidence = self.directory / "evidence"
+        self.evidence.mkdir()
+        self.inputs = self.directory / "inputs"
+        self.inputs.mkdir()
+        self.ios = self.directory / "ios"
+        self.floorp = self.directory / "Floorp"
+        self.base_oid, self.merged_oid = self.make_ios_repository()
+        self.floorp_oid = self.make_floorp_repository()
+        self.contract = self.make_contract()
+        self.output = self.run_dir / "production-qa-recipe.json"
+        self.g3_run_path = self.inputs / "g3-run.json"
+        self.artifact_metadata_path = self.inputs / "g3-artifact.json"
+        self.xcresult_path = self.inputs / "g3-xcresult.zip"
+        self.desktop_run_path = self.inputs / "desktop-run.json"
+        self.runtime_run_path = self.inputs / "runtime-run.json"
+        self.write_captures()
+
+    def tearDown(self) -> None:
+        self.temporary_owner.cleanup()
+
+    def git(self, repository: Path, *arguments: str) -> str:
+        result = subprocess.run(
+            ["/usr/bin/git", "-C", str(repository), *arguments],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={
+                **os.environ,
+                "GIT_AUTHOR_NAME": "Recipe Test",
+                "GIT_AUTHOR_EMAIL": "recipe@example.invalid",
+                "GIT_COMMITTER_NAME": "Recipe Test",
+                "GIT_COMMITTER_EMAIL": "recipe@example.invalid",
+            },
+        )
+        return result.stdout.strip()
+
+    def write_repo_file(self, repository: Path, relative: str, raw: bytes) -> Path:
+        path = repository / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+        return path
+
+    def make_ios_repository(self) -> tuple[str, str]:
+        self.ios.mkdir()
+        self.git(self.ios, "init", "-q")
+        self.write_repo_file(self.ios, "base.txt", b"base\n")
+        self.git(self.ios, "add", "base.txt")
+        self.git(self.ios, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "base")
+        base = self.git(self.ios, "rev-parse", "HEAD")
+        self.write_repo_file(
+            self.ios,
+            "firefox-ios/Client/Configuration/FloorpRelease.xcconfig",
+            b"FLOORP_BUILD_NUMBER = 4\n",
+        )
+        self.write_repo_file(
+            self.ios,
+            "docs/floorp-notes-sync-architecture.md",
+            b"# synthetic architecture\n",
+        )
+        self.write_repo_file(
+            self.ios,
+            "sync-fixtures/floorp-notes/floorp-notes-merge-v1.json",
+            PREPARER.canonical_bytes({"fixture": 1}),
+        )
+        self.write_repo_file(
+            self.ios,
+            "docs/floorp-notes-sync-g4-attestation.json",
+            PREPARER.canonical_bytes({"schema_version": 1, "task_id": 18}),
+        )
+        self.git(self.ios, "add", ".")
+        self.git(self.ios, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "merged")
+        merged = self.git(self.ios, "rev-parse", "HEAD")
+        self.ios_branch = self.git(self.ios, "symbolic-ref", "--short", "HEAD")
+        self.git(self.ios, "checkout", "-q", "--detach", merged)
+        return base, merged
+
+    def make_floorp_repository(self) -> str:
+        self.floorp.mkdir()
+        self.git(self.floorp, "init", "-q")
+        self.write_repo_file(
+            self.floorp,
+            "docs/development/floorp-notes-sync/prerequisites.json",
+            PREPARER.canonical_bytes({"schema_version": 1}),
+        )
+        self.write_repo_file(
+            self.floorp,
+            "docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md",
+            b"# synthetic desktop contract\n",
+        )
+        self.git(self.floorp, "add", ".")
+        self.git(self.floorp, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "floorp")
+        return self.git(self.floorp, "rev-parse", "HEAD")
+
+    def blob_spec(
+        self,
+        role: str,
+        repository: str,
+        worktree_name: str,
+        repository_path: Path,
+        commit_sha: str | None,
+        path: str,
+        policy: str,
+        target: str,
+    ):
+        selected_commit = self.merged_oid if commit_sha is None else commit_sha
+        raw = subprocess.run(
+            ["/usr/bin/git", "-C", str(repository_path), "show", f"{selected_commit}:{path}"],
+            check=True,
+            stdout=subprocess.PIPE,
+        ).stdout
+        return PREPARER.RepositoryFileSpec(
+            role,
+            repository,
+            worktree_name,
+            commit_sha,
+            path,
+            policy,
+            PREPARER.git_blob_sha(raw),
+            hashlib.sha256(raw).hexdigest(),
+            target,
+        )
+
+    def evidence_spec(self, key: str, source: str, target: str, raw: bytes):
+        path = self.evidence / source
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+        return PREPARER.EvidenceFileSpec(key, source, target, hashlib.sha256(raw).hexdigest())
+
+    def make_summary(
+        self,
+        key: str,
+        target: str,
+        source_names: tuple[str, ...],
+        base_payload: dict[str, object],
+    ):
+        sources: list[tuple[str, str]] = []
+        payload = dict(base_payload)
+        for index, source_name in enumerate(source_names):
+            raw = f"{key}-source-{index}\n".encode()
+            source_path = self.evidence / source_name
+            source_path.parent.mkdir(parents=True, exist_ok=True)
+            source_path.write_bytes(raw)
+            digest = hashlib.sha256(raw).hexdigest()
+            sources.append((source_name, digest))
+        if key == "tps":
+            payload["source_log_sha256"] = sources[0][1]
+            payload["source_summary_sha256"] = sources[1][1]
+        else:
+            payload["source_log_sha256"] = sources[0][1]
+        raw = PREPARER.canonical_bytes(payload)
+        return PREPARER.SummarySpec(
+            key,
+            target,
+            payload,
+            hashlib.sha256(raw).hexdigest(),
+            tuple(sources),
+        )
+
+    def make_asset(self, role: str, name: str, asset_id: int):
+        source = f"assets/{name}"
+        raw = f"synthetic-{role}".encode()
+        path = self.evidence / source
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(raw)
+        return PREPARER.ReleaseAssetSpec(
+            role,
+            name,
+            asset_id,
+            hashlib.sha256(raw).hexdigest(),
+            source,
+            f"captures/g2-{name}",
+        )
+
+    def make_contract(self):
+        evidence_files = (
+            self.evidence_spec("task16", "task16.json", "artifacts/task-16-manifest.json", b'{"task":16}\n'),
+            self.evidence_spec("task17", "task17.json", "artifacts/task-17-manifest.json", b'{"task":17}\n'),
+            self.evidence_spec("task18", "task18.json", "artifacts/task-18-manifest.json", b'{"task":18}\n'),
+            self.evidence_spec(
+                "task18-verdict",
+                "verdict.json",
+                "artifacts/task-18-execution-verdict.json",
+                PREPARER.canonical_bytes({"verdict": "APPROVE"}),
+            ),
+        )
+        summaries = (
+            self.make_summary(
+                "fake-server",
+                "artifacts/g2-fake-server-run.json",
+                ("logs/fake.log",),
+                {"failed": 0, "passed": 24, "secrets_retained": False},
+            ),
+            self.make_summary(
+                "xpcshell",
+                "artifacts/g4-xpcshell-run.json",
+                ("logs/xpcshell.log",),
+                {"failed": 0, "passed": 108, "secrets_retained": False},
+            ),
+            self.make_summary(
+                "tps",
+                "artifacts/g4-tps-run.json",
+                ("logs/tps.log", "logs/tps.json"),
+                {
+                    "failed": 0,
+                    "passed": 1,
+                    "payload_retained": False,
+                    "secrets_retained": False,
+                },
+            ),
+        )
+        assets = (
+            self.make_asset("focus-xcframework", "FocusRustComponents.xcframework.zip", 506076697),
+            self.make_asset("mozilla-xcframework", "MozillaRustComponents.xcframework.zip", 506076696),
+            self.make_asset("release-manifest", "release-manifest.json", 506076698),
+            self.make_asset("sha256sums", "SHA256SUMS", 506076695),
+            self.make_asset("swift-components", "swift-components.tar.xz", 506076699),
+        )
+        repository_files = (
+            self.blob_spec(
+                "todo16-contract",
+                "Floorp-Projects/Floorp",
+                "floorp",
+                self.floorp,
+                self.floorp_oid,
+                "docs/development/floorp-notes-sync/prerequisites.json",
+                "metadata-json",
+                "captures/g1-todo16-contract.json",
+            ),
+            self.blob_spec(
+                "ios-contract-source",
+                "Floorp-Projects/floorp-ios",
+                "ios",
+                self.ios,
+                None,
+                "docs/floorp-notes-sync-architecture.md",
+                "source-code",
+                "captures/g1-ios-contract-source.md",
+            ),
+            self.blob_spec(
+                "desktop-contract-source",
+                "Floorp-Projects/Floorp",
+                "floorp",
+                self.floorp,
+                self.floorp_oid,
+                "docs/development/floorp-notes-sync/ADR-001-floorp-notes-sync-contract.md",
+                "source-code",
+                "captures/g1-desktop-contract-source.md",
+            ),
+            self.blob_spec(
+                "merge-fixture",
+                "Floorp-Projects/floorp-ios",
+                "ios",
+                self.ios,
+                None,
+                "sync-fixtures/floorp-notes/floorp-notes-merge-v1.json",
+                "metadata-json",
+                "captures/g1-merge-fixture.json",
+            ),
+            self.blob_spec(
+                "g4-attestation-source",
+                "Floorp-Projects/floorp-ios",
+                "ios",
+                self.ios,
+                None,
+                "docs/floorp-notes-sync-g4-attestation.json",
+                "metadata-json",
+                "captures/g4-attestation-source.json",
+            ),
+        )
+        return replace(
+            PREPARER.PRODUCTION_CONTRACT,
+            base_oid=self.base_oid,
+            reviewed_head_oid=self.merged_oid,
+            todo16_source_sha=self.floorp_oid,
+            desktop_source_sha=self.floorp_oid,
+            desktop_run_head_sha="a" * 40,
+            runtime_run_head_sha="b" * 40,
+            runtime_source_sha="c" * 40,
+            runtime_tree_sha="d" * 40,
+            evidence_files=evidence_files,
+            summaries=summaries,
+            release_assets=assets,
+            repository_files=repository_files,
+        )
+
+    def write_json(self, path: Path, value: object, *, canonical: bool = True) -> None:
+        raw = PREPARER.canonical_bytes(value) if canonical else json.dumps(value, indent=2).encode()
+        path.write_bytes(raw)
+        path.chmod(0o600)
+
+    def run_payload(
+        self,
+        repository: str,
+        run_id: int,
+        head_sha: str,
+        workflow: str,
+        created_at: str,
+        *,
+        event: str = "workflow_dispatch",
+        branch: str = "main",
+    ) -> dict[str, object]:
+        created = datetime.strptime(created_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        return {
+            "conclusion": "success",
+            "created_at": created_at,
+            "event": event,
+            "head_branch": branch,
+            "head_sha": head_sha,
+            "id": run_id,
+            "repository": repository,
+            "run_attempt": 1,
+            "status": "completed",
+            "updated_at": (created + timedelta(minutes=30)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "workflow_path": workflow,
+        }
+
+    def write_captures(self) -> None:
+        self.g3_run = self.run_payload(
+            self.contract.ios_repository,
+            400000003,
+            self.merged_oid,
+            ".github/workflows/ci.yml",
+            "2026-08-10T00:00:00Z",
+            event="push",
+        )
+        self.desktop_run = self.run_payload(
+            self.contract.floorp_repository,
+            self.contract.desktop_run_id,
+            self.contract.desktop_run_head_sha,
+            self.contract.desktop_workflow_path,
+            "2026-08-09T22:00:00Z",
+        )
+        self.runtime_run = self.run_payload(
+            self.contract.runtime_repository,
+            self.contract.runtime_run_id,
+            self.contract.runtime_run_head_sha,
+            self.contract.runtime_workflow_path,
+            "2026-08-09T21:00:00Z",
+        )
+        self.artifact_metadata = {
+            "artifact_created_at": "2026-08-10T00:31:00Z",
+            "artifact_expires_at": "2026-08-17T00:31:00Z",
+            "artifact_id": 500000003,
+            "artifact_name": "floorp-notes-sync-xcresult",
+            "head_sha": self.merged_oid,
+            "run_id": self.g3_run["id"],
+        }
+        self.write_json(self.g3_run_path, self.g3_run)
+        self.write_json(self.desktop_run_path, self.desktop_run)
+        self.write_json(self.runtime_run_path, self.runtime_run)
+        self.write_json(self.artifact_metadata_path, self.artifact_metadata)
+        self.xcresult_path.write_bytes(b"synthetic-xcresult-zip")
+        self.xcresult_path.chmod(0o600)
+
+    def arguments(self, *, merged_oid: str | None = None, output: Path | None = None) -> list[str]:
+        return [
+            "--run-dir",
+            str(self.run_dir),
+            "--merged-ios-worktree",
+            str(self.ios),
+            "--floorp-worktree",
+            str(self.floorp),
+            "--merged-oid",
+            self.merged_oid if merged_oid is None else merged_oid,
+            "--g3-run-json",
+            str(self.g3_run_path),
+            "--g3-artifact-metadata-json",
+            str(self.artifact_metadata_path),
+            "--g3-xcresult-zip",
+            str(self.xcresult_path),
+            "--desktop-run-json",
+            str(self.desktop_run_path),
+            "--runtime-run-json",
+            str(self.runtime_run_path),
+            "--output-recipe",
+            str(self.output if output is None else output),
+            "--evidence-root",
+            str(self.evidence),
+        ]
+
+    def invoke(self, **kwargs) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(PREPARER, "PRODUCTION_CONTRACT", self.contract),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = PREPARER.main(self.arguments(**kwargs))
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def rewrite_canonical(self, path: Path, payload: dict[str, object]) -> None:
+        self.write_json(path, payload)
+
+    def test_prepares_exact_canonical_recipe_and_idempotently_resumes(self):
+        result, stdout, stderr = self.invoke()
+        self.assertEqual(result, 0, stderr)
+        self.assertIn("APPROVE", stdout)
+        raw = self.output.read_bytes()
+        recipe = json.loads(raw)
+        self.assertEqual(raw, PREPARER.canonical_bytes(recipe))
+        self.assertFalse(raw.endswith(b"\n"))
+        self.assertEqual(stat.S_IMODE(self.output.stat().st_mode), 0o600)
+        self.assertEqual(stat.S_IMODE((self.run_dir / "artifacts").stat().st_mode), 0o700)
+        self.assertEqual(stat.S_IMODE((self.run_dir / "captures").stat().st_mode), 0o700)
+        for gate_name, roles in PREPARER.GATE_SOURCE_ROLES.items():
+            self.assertEqual(
+                tuple(entry["descriptor"]["role"] for entry in recipe["gates"][gate_name]["sources"]),
+                roles,
+            )
+        receipt_path = self.run_dir / "artifacts/task-19-integration-receipt.json"
+        self.assertFalse(receipt_path.exists())
+        receipt = {
+            "commands": recipe["g3_integration_commands"],
+            "repositories": [
+                {
+                    "base_oid": self.base_oid,
+                    "head_oid": self.merged_oid,
+                    "merged_oid": self.merged_oid,
+                    "name": "floorp-ios",
+                }
+            ],
+            "schema_version": 1,
+            "state": "integration_complete",
+            "task_id": 19,
+        }
+        receipt_source = recipe["gates"]["g3"]["sources"][0]["descriptor"]
+        self.assertEqual(receipt_source["sha256"], hashlib.sha256(PREPARER.canonical_bytes(receipt)).hexdigest())
+        g3_run = recipe["gates"]["g3"]["sources"][1]
+        g4_run = recipe["gates"]["g4"]["sources"][5]
+        self.assertEqual({**g4_run["descriptor"], "role": "ci-run"}, g3_run["descriptor"])
+        self.assertEqual(g4_run["bytes_path"], g3_run["bytes_path"])
+        before = {path: path.stat().st_mtime_ns for path in self.run_dir.rglob("*") if path.is_file()}
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 0, stderr)
+        after = {path: path.stat().st_mtime_ns for path in self.run_dir.rglob("*") if path.is_file()}
+        self.assertEqual(before, after)
+
+    def test_rejects_mismatch_symlink_and_wrong_mode_without_clobbering(self):
+        artifacts = self.run_dir / "artifacts"
+        artifacts.mkdir(mode=0o700)
+        target = artifacts / "task-16-manifest.json"
+        target.write_bytes(b"existing-mismatch")
+        target.chmod(0o600)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertTrue("does not match" in stderr or "size differs" in stderr, stderr)
+        self.assertEqual(target.read_bytes(), b"existing-mismatch")
+
+        target.unlink()
+        target.symlink_to(self.evidence / "task16.json")
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("symlink", stderr.lower())
+        self.assertTrue(target.is_symlink())
+
+        target.unlink()
+        raw = (self.evidence / "task16.json").read_bytes()
+        target.write_bytes(raw)
+        target.chmod(0o644)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("0600", stderr)
+        self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o644)
+
+    def test_rejects_dirty_wrong_head_and_attached_worktree(self):
+        (self.ios / "untracked.txt").write_text("dirty", encoding="utf-8")
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("dirty", stderr)
+        (self.ios / "untracked.txt").unlink()
+
+        result, _, stderr = self.invoke(merged_oid=self.base_oid)
+        self.assertEqual(result, 1)
+        self.assertIn("HEAD", stderr)
+
+        self.git(self.ios, "checkout", "-q", self.ios_branch)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("detached", stderr)
+
+    def test_rejects_noncanonical_run_and_run_identity_mismatch(self):
+        self.write_json(self.g3_run_path, self.g3_run, canonical=False)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("canonical", stderr)
+
+        wrong = dict(self.g3_run)
+        wrong["event"] = "workflow_dispatch"
+        self.rewrite_canonical(self.g3_run_path, wrong)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("event mismatch", stderr)
+
+        self.rewrite_canonical(self.g3_run_path, self.g3_run)
+        wrong_desktop = dict(self.desktop_run)
+        wrong_desktop["id"] = self.contract.desktop_run_id + 1
+        self.rewrite_canonical(self.desktop_run_path, wrong_desktop)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("run ID mismatch", stderr)
+
+    def test_rejects_artifact_identity_and_time_errors(self):
+        wrong = dict(self.artifact_metadata)
+        wrong["artifact_name"] = "not-the-canonical-artifact"
+        self.rewrite_canonical(self.artifact_metadata_path, wrong)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("artifact name", stderr)
+
+        wrong = dict(self.artifact_metadata)
+        wrong["artifact_expires_at"] = "2026-08-17T00:31:01Z"
+        self.rewrite_canonical(self.artifact_metadata_path, wrong)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("seven-day", stderr)
+
+        self.rewrite_canonical(self.artifact_metadata_path, self.artifact_metadata)
+        future_desktop = dict(self.desktop_run)
+        future_desktop["created_at"] = "2026-08-18T00:00:00Z"
+        future_desktop["updated_at"] = "2026-08-18T00:30:00Z"
+        self.rewrite_canonical(self.desktop_run_path, future_desktop)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("G4 evidence lifetime", stderr)
+
+    def test_verifies_summary_sources_before_writing_summary(self):
+        summary = next(spec for spec in self.contract.summaries if spec.key == "fake-server")
+        source = self.evidence / summary.source_artifacts[0][0]
+        source.write_bytes(source.read_bytes() + b"tampered")
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("summary source artifact SHA-256", stderr)
+        self.assertFalse((self.run_dir / summary.target_relative).exists())
+
+    def test_rejects_output_outside_run_dir_and_existing_receipt(self):
+        outside = self.directory / "outside-recipe.json"
+        result, _, stderr = self.invoke(output=outside)
+        self.assertEqual(result, 1)
+        self.assertIn("under --run-dir", stderr)
+        self.assertFalse(outside.exists())
+
+        receipt = self.run_dir / "artifacts/task-19-integration-receipt.json"
+        receipt.parent.mkdir(mode=0o700)
+        receipt.write_bytes(b"assembler-owned")
+        receipt.chmod(0o600)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("only the assembler", stderr)
+        self.assertEqual(receipt.read_bytes(), b"assembler-owned")
+
+    def test_rejects_repository_blob_drift_and_wrong_build_number(self):
+        repository_files = list(self.contract.repository_files)
+        repository_files[0] = replace(repository_files[0], blob_sha="0" * 40)
+        self.contract = replace(self.contract, repository_files=tuple(repository_files))
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("Git blob SHA mismatch", stderr)
+
+        self.contract = self.make_contract()
+        self.git(self.ios, "checkout", "-q", self.ios_branch)
+        config = self.ios / "firefox-ios/Client/Configuration/FloorpRelease.xcconfig"
+        config.write_text("FLOORP_BUILD_NUMBER = 5\n", encoding="utf-8")
+        self.git(self.ios, "add", str(config.relative_to(self.ios)))
+        self.git(self.ios, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "wrong build")
+        wrong_oid = self.git(self.ios, "rev-parse", "HEAD")
+        self.git(self.ios, "checkout", "-q", "--detach", wrong_oid)
+        self.contract = replace(
+            self.contract,
+            base_oid=self.merged_oid,
+            reviewed_head_oid=wrong_oid,
+        )
+        result, _, stderr = self.invoke(merged_oid=wrong_oid)
+        self.assertEqual(result, 1)
+        self.assertIn("FLOORP_BUILD_NUMBER", stderr)
+
+    def test_cli_has_no_test_bypass_and_production_constants_match_contract(self):
+        source = PREPARER_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("test_", source)
+        self.assertNotIn("urllib", source)
+        self.assertNotIn("requests", source)
+        self.assertEqual(
+            PREPARER.PRODUCTION_CONTRACT.release_published_at,
+            "2026-08-08T05:41:30Z",
+        )
+        self.assertEqual(
+            tuple(spec.role for spec in PREPARER.PRODUCTION_CONTRACT.release_assets),
+            PREPARER.GATE_SOURCE_ROLES["g2"][2:],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
+++ b/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
@@ -111,6 +111,12 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
             "docs/floorp-notes-sync-g4-attestation.json",
             PREPARER.canonical_bytes({"schema_version": 1, "task_id": 18}),
         )
+        executable = self.write_repo_file(
+            self.ios,
+            "scripts/fixture-executable.sh",
+            b"#!/bin/sh\nexit 0\n",
+        )
+        executable.chmod(0o755)
         self.git(self.ios, "add", ".")
         self.git(self.ios, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "merged")
         merged = self.git(self.ios, "rev-parse", "HEAD")
@@ -542,10 +548,12 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
 
     def test_rejects_dirty_wrong_head_and_attached_worktree(self):
         (self.ios / "untracked.txt").write_text("dirty", encoding="utf-8")
+        (self.ios / ".git/info/exclude").write_text("untracked.txt\n", encoding="utf-8")
         result, _, stderr = self.invoke()
         self.assertEqual(result, 1)
         self.assertIn("dirty", stderr)
         (self.ios / "untracked.txt").unlink()
+        (self.ios / ".git/info/exclude").write_text("", encoding="utf-8")
 
         result, _, stderr = self.invoke(merged_oid=self.base_oid)
         self.assertEqual(result, 1)
@@ -575,6 +583,28 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
                 self.git(self.ios, "update-index", disable, "base.txt")
                 self.git(self.ios, "checkout", "--", "base.txt")
 
+    def test_rejects_staged_content_and_owner_execute_mode_drift(self):
+        target = self.ios / "base.txt"
+        target.write_text("staged content\n", encoding="utf-8")
+        self.git(self.ios, "add", "base.txt")
+        with self.assertRaisesRegex(PREPARER.PreparationError, "dirty staged"):
+            PREPARER.validate_merged_worktree(
+                self.ios,
+                self.merged_oid,
+                self.contract,
+            )
+        self.git(self.ios, "reset", "-q", "HEAD", "--", "base.txt")
+        self.git(self.ios, "checkout", "--", "base.txt")
+
+        executable = self.ios / "scripts/fixture-executable.sh"
+        executable.chmod(0o655)
+        with self.assertRaisesRegex(PREPARER.PreparationError, "executable"):
+            PREPARER.validate_merged_worktree(
+                self.ios,
+                self.merged_oid,
+                self.contract,
+            )
+
     def test_repository_fsmonitor_config_cannot_execute_helper(self):
         marker = self.directory / "fsmonitor-executed"
         self.git(
@@ -585,6 +615,43 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         )
         PREPARER.validate_merged_worktree(self.ios, self.merged_oid, self.contract)
         self.assertFalse(marker.exists(), "repository core.fsmonitor helper executed")
+
+    def test_rejects_tracked_changes_without_running_repository_clean_filter(self):
+        marker = self.directory / "clean-filter-executed"
+        filter_script = self.directory / "clean-filter.sh"
+        filter_script.write_text(
+            f"#!/bin/sh\n/usr/bin/touch {marker}\n/bin/cat\n",
+            encoding="utf-8",
+        )
+        filter_script.chmod(0o700)
+        target = self.ios / "base.txt"
+        attributes = self.ios / ".git/info/attributes"
+        attributes.write_text("base.txt filter=audit\n", encoding="utf-8")
+        self.git(self.ios, "config", "filter.audit.clean", str(filter_script))
+        self.git(self.ios, "config", "filter.audit.required", "true")
+        self.git(self.ios, "config", "core.trustctime", "false")
+        self.git(self.ios, "config", "core.checkStat", "minimal")
+
+        for restore_cached_mtime in (False, True):
+            with self.subTest(restore_cached_mtime=restore_cached_mtime):
+                target.write_bytes(b"base\n")
+                self.git(self.ios, "status", "--porcelain=v1")
+                marker.unlink(missing_ok=True)
+                cached = target.stat()
+                target.write_bytes(b"evil\n")
+                if restore_cached_mtime:
+                    os.utime(
+                        target,
+                        ns=(cached.st_atime_ns, cached.st_mtime_ns),
+                    )
+
+                with self.assertRaisesRegex(PREPARER.PreparationError, "dirty"):
+                    PREPARER.validate_merged_worktree(
+                        self.ios,
+                        self.merged_oid,
+                        self.contract,
+                    )
+                self.assertFalse(marker.exists(), "repository clean filter executed")
 
     def test_every_git_invocation_uses_offline_hardened_configuration(self):
         real_run = subprocess.run

--- a/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
+++ b/scripts/ci/tests/test_prepare_floorp_notes_sync_production_qa_recipe.py
@@ -55,6 +55,7 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         self.xcresult_path = self.inputs / "g3-xcresult.zip"
         self.desktop_run_path = self.inputs / "desktop-run.json"
         self.runtime_run_path = self.inputs / "runtime-run.json"
+        self.integration_capture_path = self.inputs / "integration-execution.json"
         self.write_captures()
 
     def tearDown(self) -> None:
@@ -394,6 +395,37 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         self.write_json(self.artifact_metadata_path, self.artifact_metadata)
         self.xcresult_path.write_bytes(b"synthetic-xcresult-zip")
         self.xcresult_path.chmod(0o600)
+        self.integration_capture = {
+            "commands": [
+                {"argv": list(argv), "exit_code": 0, "terminal": True}
+                for argv in PREPARER.integration_command_argv(self.contract)
+            ],
+            "main_ref": {
+                "ref": "refs/heads/main",
+                "sha": self.merged_oid,
+            },
+            "merge_response": {
+                "merged": True,
+                "sha": self.merged_oid,
+            },
+            "pull_request": {
+                "base_oid": self.base_oid,
+                "head_oid": self.merged_oid,
+                "number": 83,
+            },
+            "pr_checks": [
+                {"conclusion": "success", "name": "Adaptive sidebar UI (iPad (A16))"},
+                {"conclusion": "success", "name": "Adaptive sidebar UI (iPhone 17)"},
+                {"conclusion": "success", "name": "Build and unit test"},
+                {"conclusion": "success", "name": "Notes UI (iPad (A16), en-US)"},
+                {"conclusion": "success", "name": "Notes UI (iPad (A16), ja-JP)"},
+                {"conclusion": "success", "name": "Notes UI (iPhone 17, en-US)"},
+                {"conclusion": "success", "name": "Notes UI (iPhone 17, ja-JP)"},
+                {"conclusion": "success", "name": "Validate workflows"},
+            ],
+            "schema_version": 1,
+        }
+        self.write_json(self.integration_capture_path, self.integration_capture)
 
     def arguments(self, *, merged_oid: str | None = None, output: Path | None = None) -> list[str]:
         return [
@@ -415,6 +447,8 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
             str(self.desktop_run_path),
             "--runtime-run-json",
             str(self.runtime_run_path),
+            "--integration-execution-capture",
+            str(self.integration_capture_path),
             "--output-recipe",
             str(self.output if output is None else output),
             "--evidence-root",
@@ -522,6 +556,62 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         self.assertEqual(result, 1)
         self.assertIn("detached", stderr)
 
+    def test_rejects_assume_unchanged_and_skip_worktree_hidden_modifications(self):
+        target = self.ios / "base.txt"
+        cases = (
+            ("--assume-unchanged", "--no-assume-unchanged", "assume-unchanged"),
+            ("--skip-worktree", "--no-skip-worktree", "skip-worktree"),
+        )
+        for enable, disable, expected in cases:
+            with self.subTest(flag=expected):
+                self.git(self.ios, "update-index", enable, "base.txt")
+                target.write_text(f"hidden by {expected}\n", encoding="utf-8")
+                with self.assertRaisesRegex(PREPARER.PreparationError, expected):
+                    PREPARER.validate_merged_worktree(
+                        self.ios,
+                        self.merged_oid,
+                        self.contract,
+                    )
+                self.git(self.ios, "update-index", disable, "base.txt")
+                self.git(self.ios, "checkout", "--", "base.txt")
+
+    def test_repository_fsmonitor_config_cannot_execute_helper(self):
+        marker = self.directory / "fsmonitor-executed"
+        self.git(
+            self.ios,
+            "config",
+            "core.fsmonitor",
+            f"/usr/bin/touch {marker}",
+        )
+        PREPARER.validate_merged_worktree(self.ios, self.merged_oid, self.contract)
+        self.assertFalse(marker.exists(), "repository core.fsmonitor helper executed")
+
+    def test_every_git_invocation_uses_offline_hardened_configuration(self):
+        real_run = subprocess.run
+        observed: list[tuple[list[str], dict[str, str]]] = []
+
+        def recording_run(command, **kwargs):
+            observed.append((command, kwargs["env"]))
+            return real_run(command, **kwargs)
+
+        with mock.patch.object(PREPARER.subprocess, "run", side_effect=recording_run):
+            PREPARER.validate_merged_worktree(self.ios, self.merged_oid, self.contract)
+
+        self.assertTrue(observed)
+        for command, environment in observed:
+            self.assertEqual(command[0], "/usr/bin/git")
+            self.assertIn("core.fsmonitor=false", command)
+            self.assertIn("core.hooksPath=/dev/null", command)
+            self.assertIn("core.bare=false", command)
+            self.assertIn(f"core.worktree={self.ios}", command)
+            self.assertEqual(environment["GIT_CONFIG_NOSYSTEM"], "1")
+            self.assertEqual(environment["GIT_CONFIG_GLOBAL"], "/dev/null")
+            self.assertEqual(environment["GIT_NO_LAZY_FETCH"], "1")
+            self.assertEqual(environment["GIT_NO_REPLACE_OBJECTS"], "1")
+            self.assertEqual(environment["GIT_ALLOW_PROTOCOL"], "")
+            self.assertEqual(environment["GIT_TERMINAL_PROMPT"], "0")
+            self.assertEqual(environment["GIT_ASKPASS"], "/usr/bin/false")
+
     def test_rejects_noncanonical_run_and_run_identity_mismatch(self):
         self.write_json(self.g3_run_path, self.g3_run, canonical=False)
         result, _, stderr = self.invoke()
@@ -566,6 +656,123 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         result, _, stderr = self.invoke()
         self.assertEqual(result, 1)
         self.assertIn("G4 evidence lifetime", stderr)
+
+    def test_integration_capture_is_materialized_and_drives_recipe_commands(self):
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 0, stderr)
+        capture_target = self.run_dir / "captures/integration-execution-capture.json"
+        self.assertEqual(capture_target.read_bytes(), self.integration_capture_path.read_bytes())
+        self.assertEqual(stat.S_IMODE(capture_target.stat().st_mode), 0o600)
+        recipe = json.loads(self.output.read_bytes())
+        self.assertEqual(recipe["g3_integration_commands"], self.integration_capture["commands"])
+        for command in recipe["g3_integration_commands"]:
+            self.assertEqual(set(command), {"argv", "exit_code", "terminal"})
+
+    def test_rejects_missing_mismatched_and_nonterminal_integration_capture(self):
+        original = self.arguments()
+        option = original.index("--integration-execution-capture")
+        without_capture = original[:option] + original[option + 2 :]
+        with (
+            contextlib.redirect_stderr(io.StringIO()),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            PREPARER.main(without_capture)
+        self.assertEqual(raised.exception.code, 2)
+
+        cases: list[tuple[str, dict[str, object], str]] = []
+        missing = dict(self.integration_capture)
+        missing.pop("pr_checks")
+        cases.append(("missing", missing, "fields"))
+
+        extra = dict(self.integration_capture)
+        extra["untrusted"] = True
+        cases.append(("extra", extra, "fields"))
+
+        wrong_pr = json.loads(json.dumps(self.integration_capture))
+        wrong_pr["pull_request"]["head_oid"] = "f" * 40
+        cases.append(("wrong-pr", wrong_pr, "head"))
+
+        missing_check = json.loads(json.dumps(self.integration_capture))
+        missing_check["pr_checks"].pop()
+        cases.append(("missing-check", missing_check, "pr checks"))
+
+        extra_check = json.loads(json.dumps(self.integration_capture))
+        extra_check["pr_checks"].append(
+            {"conclusion": "success", "name": "Unexpected check"}
+        )
+        cases.append(("extra-check", extra_check, "pr checks"))
+
+        duplicate_check = json.loads(json.dumps(self.integration_capture))
+        duplicate_check["pr_checks"][-1] = dict(duplicate_check["pr_checks"][0])
+        cases.append(("duplicate-check", duplicate_check, "duplicate"))
+
+        failed_check = json.loads(json.dumps(self.integration_capture))
+        failed_check["pr_checks"][0]["conclusion"] = "failure"
+        cases.append(("failed-check", failed_check, "pr checks"))
+
+        reordered_checks = json.loads(json.dumps(self.integration_capture))
+        reordered_checks["pr_checks"][0:2] = reversed(reordered_checks["pr_checks"][0:2])
+        cases.append(("reordered-checks", reordered_checks, "sorted"))
+
+        wrong_argv = json.loads(json.dumps(self.integration_capture))
+        wrong_argv["commands"][0]["argv"].append("--watch")
+        cases.append(("wrong-argv", wrong_argv, "argv"))
+
+        failed_command = json.loads(json.dumps(self.integration_capture))
+        failed_command["commands"][0]["exit_code"] = 1
+        cases.append(("failed-command", failed_command, "exit_code"))
+
+        boolean_exit = json.loads(json.dumps(self.integration_capture))
+        boolean_exit["commands"][0]["exit_code"] = False
+        cases.append(("boolean-exit", boolean_exit, "exit_code"))
+
+        nonterminal = json.loads(json.dumps(self.integration_capture))
+        nonterminal["commands"][0]["terminal"] = False
+        cases.append(("nonterminal", nonterminal, "terminal"))
+
+        command_extra = json.loads(json.dumps(self.integration_capture))
+        command_extra["commands"][0]["output"] = "fabricated"
+        cases.append(("command-extra", command_extra, "fields"))
+
+        wrong_merge = json.loads(json.dumps(self.integration_capture))
+        wrong_merge["merge_response"]["merged"] = False
+        cases.append(("wrong-merge", wrong_merge, "merge"))
+
+        wrong_merge_sha = json.loads(json.dumps(self.integration_capture))
+        wrong_merge_sha["merge_response"]["sha"] = "d" * 40
+        cases.append(("wrong-merge-sha", wrong_merge_sha, "merge response sha"))
+
+        wrong_main = json.loads(json.dumps(self.integration_capture))
+        wrong_main["main_ref"]["sha"] = "e" * 40
+        cases.append(("wrong-main", wrong_main, "main ref"))
+
+        for name, capture, expected in cases:
+            with self.subTest(name=name):
+                self.write_json(self.integration_capture_path, capture)
+                result, _, stderr = self.invoke()
+                self.assertEqual(result, 1, stderr)
+                self.assertIn(expected, stderr.lower())
+
+    def test_rejects_malformed_noncanonical_and_clashing_integration_capture(self):
+        self.integration_capture_path.write_bytes(b"{")
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("malformed", stderr)
+
+        self.write_json(self.integration_capture_path, self.integration_capture, canonical=False)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertIn("canonical", stderr)
+
+        self.write_json(self.integration_capture_path, self.integration_capture)
+        target = self.run_dir / "captures/integration-execution-capture.json"
+        target.parent.mkdir(mode=0o700, exist_ok=True)
+        target.write_bytes(b"mismatched-capture")
+        target.chmod(0o600)
+        result, _, stderr = self.invoke()
+        self.assertEqual(result, 1)
+        self.assertTrue("does not match" in stderr or "size differs" in stderr, stderr)
+        self.assertEqual(target.read_bytes(), b"mismatched-capture")
 
     def test_verifies_summary_sources_before_writing_summary(self):
         summary = next(spec for spec in self.contract.summaries if spec.key == "fake-server")
@@ -629,6 +836,11 @@ class FloorpNotesSyncProductionQaRecipePreparerTests(unittest.TestCase):
         self.assertEqual(
             tuple(spec.role for spec in PREPARER.PRODUCTION_CONTRACT.release_assets),
             PREPARER.GATE_SOURCE_ROLES["g2"][2:],
+        )
+        self.assertEqual(len(PREPARER.PR_CHECK_NAMES), 8)
+        self.assertEqual(
+            PREPARER.PR_CHECK_NAMES,
+            tuple(sorted(PREPARER.PR_CHECK_NAMES, key=lambda name: name.encode("utf-8"))),
         )
 
 


### PR DESCRIPTION
## 正規 production-QA レシピ準備ヘルパー（offline, no-clobber）

PR #83 マージ後の Todo 19 post-merge 証拠を組み立てるための、ネットワーク非依存の canonical レシピ準備 CLI を追加します。

- `scripts/ci/prepare-floorp-notes-sync-production-qa-recipe.py`: G1/G2/G4 の既存証拠・release assets・リポジトリ blob・CI run キャプチャを検証し、G3 統合実行キャプチャ（PR #83 の checks/view/merge/ref 4 コマンド、全 exit 0 + terminal）を束縛した正規レシピ JSON を no-clobber で生成。統合レシートは assembler のみが作成。
- 検証: helper モジュール 17/17、scripts/ci 154/154。
