### PR TITLE
fix(sync): accept GitHub artifact xcresult shape and drop octet-stream header

### DIFF
--- a/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
@@ -303,6 +303,21 @@ def synthetic_xcresult_zip(
     return output.getvalue()
 
 
+def contents_root_xcresult_zip(
+    summary: bytes = b"synthetic-only test metadata",
+) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_STORED) as archive:
+        for path, raw in (
+            ("Info.plist", b"<?xml version='1.0'?><plist version='1.0'><dict/></plist>"),
+            ("Data/test-summary", summary),
+        ):
+            info = zipfile.ZipInfo(path, date_time=(2026, 8, 10, 0, 0, 0))
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, raw)
+    return output.getvalue()
+
+
 TEST_SOURCE_BYTES = {
     "todo16-contract": canonical_bytes(
         {
@@ -1137,6 +1152,37 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
     def test_valid_production_qa_g1_g4_evidence_passes(self):
         result = self.run_validator(make_production_qa_evidence())
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_xcresult_archive_accepts_artifact_contents_root(self):
+        for raw in (
+            contents_root_xcresult_zip(),
+            synthetic_xcresult_zip(),
+        ):
+            with self.subTest(shape=raw[:8]):
+                VALIDATOR_MODULE.validate_xcresult_archive(
+                    io.BytesIO(raw),
+                    "xcresult",
+                )
+
+    def test_xcresult_archive_rejects_unexpected_roots(self):
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_STORED) as archive:
+            for path, raw in (
+                ("Info.plist", b"x"),
+                ("Data/test-summary", b"y"),
+                ("Junk/extra", b"z"),
+            ):
+                info = zipfile.ZipInfo(path, date_time=(2026, 8, 10, 0, 0, 0))
+                info.external_attr = 0o100644 << 16
+                archive.writestr(info, raw)
+        with self.assertRaisesRegex(
+            VALIDATOR_MODULE.ValidationError,
+            "root is not one xcresult",
+        ):
+            VALIDATOR_MODULE.validate_xcresult_archive(
+                io.BytesIO(output.getvalue()),
+                "xcresult",
+            )
 
     def test_g3_rejects_completed_terminal_manifest_as_integration_receipt(self):
         evidence = make_production_qa_evidence()

--- a/scripts/ci/validate-floorp-notes-sync-release.py
+++ b/scripts/ci/validate-floorp-notes-sync-release.py
@@ -671,8 +671,6 @@ def gh_api_download_digest(
                     TRUSTED_GITHUB_HOST,
                     "--method",
                     "GET",
-                    "-H",
-                    "Accept: application/octet-stream",
                     endpoint,
                 ],
                 stdout=output,

--- a/scripts/ci/validate-floorp-notes-sync-release.py
+++ b/scripts/ci/validate-floorp-notes-sync-release.py
@@ -766,10 +766,20 @@ def validate_xcresult_archive(
     except (OSError, RuntimeError, EOFError, zipfile.BadZipFile, zipfile.LargeZipFile) as error:
         raise ValidationError(f"{label}: artifact is not a valid xcresult ZIP") from error
     roots = {path.split("/", 1)[0] for path in paths}
-    check(len(roots) == 1 and next(iter(roots)).endswith(".xcresult"), f"{label}: ZIP root is not one xcresult")
-    root = next(iter(roots))
-    check(f"{root}/Info.plist" in paths, f"{label}: xcresult ZIP is missing Info.plist")
-    check(any(path.startswith(f"{root}/Data/") for path in paths), f"{label}: xcresult ZIP is missing Data")
+    if len(roots) == 1 and next(iter(roots)).endswith(".xcresult"):
+        root = next(iter(roots))
+        prefix = f"{root}/"
+    elif roots <= {"Data", "Info.plist"}:
+        # actions/upload-artifact archives a single directory as its
+        # contents, so a live GitHub artifact of an xcresult bundle has
+        # Data/ and Info.plist at the ZIP root instead of a .xcresult
+        # wrapper directory. The bundle content is identical.
+        root = ""
+        prefix = ""
+    else:
+        check(False, f"{label}: ZIP root is not one xcresult")
+    check(f"{prefix}Info.plist" in paths, f"{label}: xcresult ZIP is missing Info.plist")
+    check(any(path.startswith(f"{prefix}Data/") for path in paths), f"{label}: xcresult ZIP is missing Data")
     if required_test is not None:
         if test_results is None:
             test_results = xcresult_test_results(archive, root, label)


### PR DESCRIPTION
Live production-qa validation of the canonical G1-G4 evidence exposed two latent defects in the validator's live artifact path (previously only exercised through mock gh):

1. The artifact download sent `Accept: application/octet-stream`, which the GitHub API rejects with HTTP 415 (the ZIP endpoint serves the archive with the default Accept).
2. `actions/upload-artifact` archives a single directory as its contents, so a live GitHub artifact of an XCResult bundle has `Data/` and `Info.plist` at the ZIP root instead of a `.xcresult` wrapper directory. The shape check now accepts both the wrapped single-.xcresult-root shape and the artifact-contents root shape (roots subset of {Data, Info.plist}); any other root set is rejected.

Bundle semantics are unchanged: Info.plist presence, Data presence, secret-marker scans, member sizes, and required XCTest results via xcresulttool.

Tests: +2 shape tests (positive both shapes, negative unexpected root); full scripts/ci suite 157/157.