### PR TITLE
fix(sync): octet-stream Accept only for release-asset downloads

### DIFF
--- a/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
@@ -14,6 +14,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import textwrap
 import unittest
 import zipfile
 from pathlib import Path
@@ -1183,6 +1184,40 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
                 io.BytesIO(output.getvalue()),
                 "xcresult",
             )
+
+    def test_download_digest_headers_differ_for_artifact_and_release_asset(self):
+        record = self.key_dir / "download-args.jsonl"
+        fake_gh = self.key_dir / "fake-gh-download"
+        fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/python3
+                import json, os, sys
+                with open(os.environ["FAKE_GH_RECORD"], "a") as handle:
+                    handle.write(json.dumps(sys.argv[1:]) + "\\n")
+                """
+            ),
+            encoding="utf-8",
+        )
+        fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IXUSR)
+        environment = {"FAKE_GH_RECORD": str(record)}
+        VALIDATOR_MODULE.gh_api_download_digest(
+            fake_gh,
+            "repos/F/repos/a/actions/artifacts/1/zip",
+            "artifact",
+            environment,
+        )
+        VALIDATOR_MODULE.gh_api_download_digest(
+            fake_gh,
+            "repos/F/repos/a/releases/assets/1",
+            "asset",
+            environment,
+            release_asset=True,
+        )
+        calls = [json.loads(line) for line in record.read_text().splitlines()]
+        self.assertEqual(len(calls), 2)
+        self.assertNotIn("Accept: application/octet-stream", calls[0])
+        self.assertIn("Accept: application/octet-stream", calls[1])
 
     def test_g3_rejects_completed_terminal_manifest_as_integration_receipt(self):
         evidence = make_production_qa_evidence()

--- a/scripts/ci/validate-floorp-notes-sync-release.py
+++ b/scripts/ci/validate-floorp-notes-sync-release.py
@@ -658,21 +658,29 @@ def gh_api_download_digest(
     label: str,
     environment: Mapping[str, str],
     *,
+    release_asset: bool = False,
     require_xcresult: bool = False,
     required_xcresult_test: str | None = None,
 ) -> str:
     with tempfile.TemporaryFile() as output:
+        command = [
+            str(gh_bin),
+            "api",
+            "--hostname",
+            TRUSTED_GITHUB_HOST,
+            "--method",
+            "GET",
+        ]
+        if release_asset:
+            # The release-asset endpoint serves the binary only when the
+            # octet-stream Accept header is sent; the Actions artifact ZIP
+            # endpoint rejects that header with HTTP 415 and is fetched
+            # without it.
+            command += ["-H", "Accept: application/octet-stream"]
+        command.append(endpoint)
         try:
             result = subprocess.run(
-                [
-                    str(gh_bin),
-                    "api",
-                    "--hostname",
-                    TRUSTED_GITHUB_HOST,
-                    "--method",
-                    "GET",
-                    endpoint,
-                ],
+                command,
                 stdout=output,
                 stderr=subprocess.PIPE,
                 stdin=subprocess.DEVNULL,
@@ -1679,6 +1687,7 @@ def verify_github_release_asset(
         f"repos/{source['repository']}/releases/assets/{source['asset_id']}",
         label,
         gh_environment,
+        release_asset=True,
     )
 
 


### PR DESCRIPTION
The live production-qa validation reached the g2 gate after PR #86 and exposed a second endpoint asymmetry:

- The release-asset endpoint (`releases/assets/{id}`) serves the binary only with `Accept: application/octet-stream`.
- The Actions artifact ZIP endpoint rejects that header with HTTP 415.

`gh_api_download_digest` now takes a `release_asset` flag and sends the header only for release assets. A fake-gh test locks the per-endpoint header behavior. Full scripts/ci suite 158/158.