### PR TITLE
test(sync): harden two-client evidence gate

### DIFF
--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -128,6 +128,22 @@ expires no later than the earliest source or notarization-artifact deadline.
 The post-build clock dispatch passes the canonical workflow file name
 `floorp-notes-sync-validation-clock.yml` to the public clock client.
 
+## G5 two-client evidence boundary
+
+G5 is valid only when a successful, manually dispatched `main` run of
+`.github/workflows/ci.yml` publishes
+`floorp-notes-sync-two-client-xcresult`. The archive must contain a passing
+`FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()` node;
+renaming an ordinary FloorpCI result does not satisfy this requirement.
+
+The public records are exact metadata-only summaries. Account isolation must
+prove two isolated accounts, post-upload base advancement, cleanup, rollback,
+and local-only fallback against the pinned fixture. Network evidence must prove
+the pinned endpoint policy, approved hosts, port 443, TLS verification without
+interception, and no retained payload or secret. A G5 operation record has
+`state: g5_completed`; it is not the terminal Todo 20 manifest and cannot claim
+completion before the separately validated G6 signatures.
+
 ## App integration interface
 
 The generated xcconfig provides these build settings:

--- a/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
@@ -360,6 +360,10 @@ TEST_SOURCE_BYTES = {
         b"ClientTests/FloorpNotesSyncEngineSelectionTests/"
         b"testG4AttestationBindsTask18Evidence()"
     ),
+    "g5-xcresult": synthetic_xcresult_zip(
+        b"XCUITests/FloorpNotesSyncTwoClientMatrixTests/"
+        b"testTwoClientProductionMatrix()"
+    ),
     "task18-execution-verdict": canonical_bytes(
         {
             "errors": [],
@@ -374,12 +378,29 @@ TEST_SOURCE_BYTES = {
     "tps-run": canonical_bytes(
         {"failed": 0, "passed": 1, "payload_retained": False, "secrets_retained": False}
     ),
-    "account-isolation-run": canonical_bytes({"accounts": 2, "isolated": True, "payload_retained": False}),
+    "account-isolation-run": canonical_bytes(
+        {
+            "accounts": 2,
+            "base_advanced_after_upload": True,
+            "cleanup_completed": True,
+            "fixture_sha256": "2597e5311c7c4ea4bb9d6a806ffa183aae3b3bd7380893b664b02ac829d665fd",
+            "isolated": True,
+            "local_only_fallback_succeeded": True,
+            "payload_retained": False,
+            "rollback_succeeded": True,
+            "secrets_retained": False,
+        }
+    ),
     "proxy-trace": canonical_bytes(
         {
+            "endpoint_policy_sha256": "af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca",
             "hosts": ["accounts.firefox.com", "sync.services.mozilla.com"],
             "metadata_only": True,
-            "status_codes": [200],
+            "payload_retained": False,
+            "port": 443,
+            "secrets_retained": False,
+            "tls_interception": False,
+            "tls_verified": True,
         }
     ),
 }
@@ -484,7 +505,6 @@ def task_manifest_bytes(task_id: int, inputs: dict[str, object]) -> bytes:
             {
                 "base_oid": inputs["ios"]["source_sha"],
                 "head_oid": inputs["ios"]["source_sha"],
-                "merged_oid": inputs["ios"]["source_sha"],
                 "name": "floorp-ios",
             }
         ],
@@ -500,7 +520,7 @@ def task_manifest_bytes(task_id: int, inputs: dict[str, object]) -> bytes:
             ],
             "repositories": repositories_by_task[task_id],
             "schema_version": 1,
-            "state": "completed",
+            "state": "g5_completed" if task_id == 20 else "completed",
             "task_id": task_id,
         }
     )
@@ -726,7 +746,7 @@ def make_gate_sources(inputs: dict[str, object]) -> dict[str, list[dict[str, obj
             500000005,
             "floorp-notes-sync-two-client-xcresult",
             inputs["ios"]["source_sha"],
-            TEST_SOURCE_BYTES["xcresult"],
+            TEST_SOURCE_BYTES["g5-xcresult"],
         ),
         local_source(
             "account-isolation-run",
@@ -895,7 +915,11 @@ def test_materials(evidence: dict[str, object]) -> tuple[dict[str, bytes], dict[
                     )
                 )
             elif kind == "github-actions-artifact":
-                raw = TEST_SOURCE_BYTES["xcresult"]
+                raw = (
+                    TEST_SOURCE_BYTES["g5-xcresult"]
+                    if gate_name == "g5" and role == "xcresult"
+                    else TEST_SOURCE_BYTES["xcresult"]
+                )
             else:
                 raw = TEST_SOURCE_BYTES[role]
             if kind == "local-file":
@@ -1071,6 +1095,7 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
         g6_trust_bundle: dict[str, bytes] | None = None,
         local_artifact_overrides: dict[str, bytes] | None = None,
         remote_artifact_overrides: dict[str, bytes] | None = None,
+        test_xcresult_results: dict[str, str | list[str]] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as temporary:
             directory = Path(temporary)
@@ -1120,11 +1145,15 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
                     test_gh_bin=self.mock_gh,
                     test_gh_environment={"MOCK_GH_SCENARIO": gh_scenario},
                     test_remote_artifacts=remote_artifacts,
-                    test_xcresult_results={
+                    test_xcresult_results=test_xcresult_results or {
                         (
                             "FloorpNotesSyncEngineSelectionTests/"
                             "testG4AttestationBindsTask18Evidence()"
-                        ): "Passed"
+                        ): "Passed",
+                        (
+                            "FloorpNotesSyncTwoClientMatrixTests/"
+                            "testTwoClientProductionMatrix()"
+                        ): "Passed",
                     },
                     test_g6_trust_bundle=g6_trust_bundle,
                     test_ssh_keygen=SSH_KEYGEN if g6_trust_bundle is not None else None,
@@ -1149,6 +1178,150 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
     def test_valid_release_enabled_g1_g5_evidence_passes_without_g6_files(self):
         result = self.run_validator()
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_g5_rejects_a_terminal_todo20_completion_claim(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][0]
+        manifest = json.loads(task_manifest_bytes(20, evidence["release_inputs"]))
+        manifest["state"] = "completed"
+        raw = canonical_bytes(manifest)
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            local_artifact_overrides={source["path"]: raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("state is not g5_completed", result.stderr)
+
+    def test_g5_rejects_an_unverified_todo20_merged_oid_claim(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][0]
+        manifest = json.loads(task_manifest_bytes(20, evidence["release_inputs"]))
+        manifest["repositories"][0]["merged_oid"] = evidence["release_inputs"]["ios"]["source_sha"]
+        raw = canonical_bytes(manifest)
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            local_artifact_overrides={source["path"]: raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must not claim a merged OID", result.stderr)
+
+    def test_g5_rejects_missing_cleanup_rollback_or_local_only_fallback_proof(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][3]
+        payload = json.loads(TEST_SOURCE_BYTES["account-isolation-run"])
+        del payload["cleanup_completed"]
+        raw = canonical_bytes(payload)
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["account_isolation_run_sha256"] = source["sha256"]
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            local_artifact_overrides={source["path"]: raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("cleanup, rollback, or local-only fallback", result.stderr)
+
+    def test_g5_rejects_tls_interception_or_unbound_endpoint_policy(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][4]
+        payload = json.loads(TEST_SOURCE_BYTES["proxy-trace"])
+        payload["tls_interception"] = True
+        raw = canonical_bytes(payload)
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["proxy_trace_sha256"] = source["sha256"]
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            local_artifact_overrides={source["path"]: raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("metadata-only TLS evidence", result.stderr)
+
+    def test_g5_requires_a_sync_service_host_in_the_proxy_evidence(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][4]
+        payload = json.loads(TEST_SOURCE_BYTES["proxy-trace"])
+        payload["hosts"] = ["accounts.firefox.com"]
+        raw = canonical_bytes(payload)
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["proxy_trace_sha256"] = source["sha256"]
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            local_artifact_overrides={source["path"]: raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not prove an approved Sync host", result.stderr)
+
+    def test_g5_rejects_noninteractive_ci_run(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][1]
+        raw = canonical_bytes(
+            actions_run_payload(
+                source["repository"],
+                source["run_id"],
+                source["workflow_path"],
+                source["head_sha"],
+                event="push",
+                head_branch="main",
+            )
+        )
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            remote_artifact_overrides={source_identity_key(source): raw},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not an explicit main dispatch", result.stderr)
+
+    def test_g5_requires_the_dedicated_two_client_xcresult_node(self):
+        evidence = make_evidence()
+        source = evidence["gates"]["g5"]["artifact"]["sources"][2]
+        raw = TEST_SOURCE_BYTES["xcresult"]
+        source["sha256"] = hashlib.sha256(raw).hexdigest()
+        evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+            evidence["gates"]["g5"]["artifact"]["sources"]
+        )
+        rehash(evidence)
+        result = self.run_validator(
+            evidence,
+            remote_artifact_overrides={source_identity_key(source): raw},
+            test_xcresult_results={
+                (
+                    "FloorpNotesSyncEngineSelectionTests/"
+                    "testG4AttestationBindsTask18Evidence()"
+                ): "Passed",
+                (
+                    "FloorpNotesSyncTwoClientMatrixTests/"
+                    "testTwoClientProductionMatrix()"
+                ): "Failed",
+            },
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("required XCTest did not have Passed result nodes", result.stderr)
 
     def test_valid_production_qa_g1_g4_evidence_passes(self):
         result = self.run_validator(make_production_qa_evidence())

--- a/scripts/ci/validate-floorp-notes-sync-release.py
+++ b/scripts/ci/validate-floorp-notes-sync-release.py
@@ -178,6 +178,10 @@ G4_ATTESTATION_XCRESULT_TEST = (
     "FloorpNotesSyncEngineSelectionTests/"
     "testG4AttestationBindsTask18Evidence()"
 )
+G5_TWO_CLIENT_XCRESULT_TEST = (
+    "FloorpNotesSyncTwoClientMatrixTests/"
+    "testTwoClientProductionMatrix()"
+)
 EXPECTED_FXA_HOSTS = (
     "accounts.firefox.com",
     "api.accounts.firefox.com",
@@ -1754,6 +1758,8 @@ def verify_github_actions_artifact(
         required_xcresult_test=(
             G4_ATTESTATION_XCRESULT_TEST
             if source.get("role") == "g4-attestation-xcresult"
+            else G5_TWO_CLIENT_XCRESULT_TEST
+            if source.get("artifact_name") == "floorp-notes-sync-two-client-xcresult"
             else None
         ),
     )
@@ -1784,6 +1790,8 @@ def verify_artifact_source(
             required_test = (
                 G4_ATTESTATION_XCRESULT_TEST
                 if source.get("role") == "g4-attestation-xcresult"
+                else G5_TWO_CLIENT_XCRESULT_TEST
+                if source.get("artifact_name") == "floorp-notes-sync-two-client-xcresult"
                 else None
             )
             validate_xcresult_archive(
@@ -1870,7 +1878,11 @@ def validate_task_manifest(
     label = f"{gate_name} task manifest"
     check(isinstance(manifest, dict), f"{label}: root must be an object")
     check(manifest.get("task_id") == TASK_BY_GATE[gate_name], f"{label}: wrong task ID")
-    check(manifest.get("state") == "completed", f"{label}: task is not completed")
+    expected_state = "g5_completed" if gate_name == "g5" else "completed"
+    check(
+        manifest.get("state") == expected_state,
+        f"{label}: state is not {expected_state}",
+    )
     validate_terminal_commands(manifest, label)
     if gate_name == "g1":
         floorp = manifest_repository(manifest, "Floorp", label)
@@ -1889,9 +1901,10 @@ def validate_task_manifest(
     elif gate_name == "g5":
         ios = manifest_repository(manifest, "floorp-ios", label)
         check(
-            inputs["ios"]["source_sha"] in (ios.get("head_oid"), ios.get("merged_oid")),
-            f"{label}: iOS provenance mismatch",
+            ios.get("head_oid") == inputs["ios"]["source_sha"],
+            f"{label}: iOS candidate provenance mismatch",
         )
+        check("merged_oid" not in ios, f"{label}: G5 operation must not claim a merged OID")
     return manifest
 
 
@@ -2312,23 +2325,59 @@ def validate_gate_source_semantics(
             xcresult["artifact_name"] == "floorp-notes-sync-two-client-xcresult",
             f"{label}: two-client xcresult artifact name is not canonical",
         )
+        ci_run_payload = payloads["ci-run"]
+        check(isinstance(ci_run_payload, dict), f"{label}: two-client CI run metadata is malformed")
+        check(
+            (ci_run_payload.get("event"), ci_run_payload.get("head_branch"))
+            == ("workflow_dispatch", "main"),
+            f"{label}: two-client CI run is not an explicit main dispatch",
+        )
         isolation = require_source(sources, "account-isolation-run", ("local-file",), "metadata-json", label)
         proxy = require_source(sources, "proxy-trace", ("local-file",), "network-metadata-json", label)
         check(isolation["sha256"] == gate["account_isolation_run_sha256"], f"{label}: isolation digest mismatch")
         check(proxy["sha256"] == gate["proxy_trace_sha256"], f"{label}: proxy digest mismatch")
         isolation_payload = payloads["account-isolation-run"]
         check(isinstance(isolation_payload, dict), f"{label}: isolation summary is malformed")
-        check(isolation_payload.get("accounts") == 2, f"{label}: exactly two accounts were not proven")
-        check(isolation_payload.get("isolated") is True, f"{label}: account isolation was not proven")
-        check(isolation_payload.get("payload_retained") is False, f"{label}: Notes payload-retention proof is missing")
+        expected_isolation = {
+            "accounts": 2,
+            "base_advanced_after_upload": True,
+            "cleanup_completed": True,
+            "fixture_sha256": EXPECTED_FIXTURE_SHA256,
+            "isolated": True,
+            "local_only_fallback_succeeded": True,
+            "payload_retained": False,
+            "rollback_succeeded": True,
+            "secrets_retained": False,
+        }
+        check(
+            isolation_payload == expected_isolation,
+            f"{label}: isolation, cleanup, rollback, or local-only fallback proof is incomplete",
+        )
         proxy_payload = payloads["proxy-trace"]
         check(isinstance(proxy_payload, dict), f"{label}: proxy summary is malformed")
-        check(proxy_payload.get("metadata_only") is True, f"{label}: proxy trace is not metadata-only")
         hosts = proxy_payload.get("hosts")
         check(isinstance(hosts, list) and bool(hosts), f"{label}: proxy hosts are missing")
         check(
             set(hosts) <= set(EXPECTED_FXA_HOSTS) | set(EXPECTED_SYNC_HOSTS),
             f"{label}: proxy trace contains an unapproved host",
+        )
+        check(
+            "sync.services.mozilla.com" in hosts,
+            f"{label}: proxy trace does not prove an approved Sync host",
+        )
+        expected_proxy = {
+            "endpoint_policy_sha256": EXPECTED_ENDPOINT_POLICY_SHA256,
+            "hosts": hosts,
+            "metadata_only": True,
+            "payload_retained": False,
+            "port": 443,
+            "secrets_retained": False,
+            "tls_interception": False,
+            "tls_verified": True,
+        }
+        check(
+            proxy_payload == expected_proxy,
+            f"{label}: proxy trace lacks exact metadata-only TLS evidence",
         )
 
 


### PR DESCRIPTION
## Scope

Hardens the G5 evidence validator so a release-enabled record requires a dedicated two-client XCTest, an explicit main workflow dispatch, strict cleanup/rollback/TLS metadata, an observed Sync host, and a non-terminal Todo 20 operation record.

## Does not do

This PR does not run production FxA/Sync, create accounts, enable release behavior, or claim G5/Todo 20 completion. The genuine protected CI harness and Desktop package prerequisites remain separate work.

## Validation

- `python3 -m unittest scripts.ci.tests.test_validate_floorp_notes_sync_release` (108 tests)
- `python3 -m unittest discover scripts/ci/tests` (165 tests)
- `python3 -m py_compile scripts/ci/validate-floorp-notes-sync-release.py scripts/ci/tests/test_validate_floorp_notes_sync_release.py`
- `git diff --check`