### PR TITLE
test(sync): add production QA test product foundation

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */; };
 		F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00272F50000100000001 /* FloorpBrandingUITests.swift */; };
 		F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */; };
+		F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2814,6 +2815,7 @@
 		F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpPrivateHeaderBrandingUITests.swift; sourceTree = "<group>"; };
 		F10A00272F50000100000001 /* FloorpBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpBrandingUITests.swift; sourceTree = "<group>"; };
 		F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesLocalV1UITests.swift; sourceTree = "<group>"; };
+		F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncProductionQAConfigurationTests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13562,6 +13564,7 @@
 				F10A00232F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift */,
 				F10A00272F50000100000001 /* FloorpBrandingUITests.swift */,
 				F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */,
+				F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19604,6 +19607,7 @@
 				F10A00222F50000100000001 /* FloorpPrivateHeaderBrandingUITests.swift in Sources */,
 				F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */,
 				F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */,
+				F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,
@@ -30211,6 +30215,23 @@
 			};
 			name = FirefoxBeta;
 		};
+		F20A20012F52000100000001 /* FloorpRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
+				INFOPLIST_FILE = "firefox-ios-tests/Tests/XCUITests/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/firefox-ios-tests/Tests/XCUITests/XCUITests-Bridging-Header.h";
+				SWIFT_VERSION = 6.0;
+				TEST_TARGET_NAME = Client;
+			};
+			name = FloorpRelease;
+		};
 		4354D3E124EEEEC5001184F6 /* Fennec */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -34052,6 +34073,7 @@
 				3BFE4B0F1D342FB900DDF53F /* Firefox */,
 				3BFE4B101D342FB900DDF53F /* FirefoxBeta */,
 				5A9F8FE02D91C3A60019C311 /* FirefoxStaging */,
+				F20A20012F52000100000001 /* FloorpRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Fennec;

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncQA.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncQA.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+               BuildableName = "Client.app"
+               BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "FloorpRelease"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      language = "en"
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "FloorpRelease"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "FloorpRelease"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "FloorpRelease">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "FloorpRelease"
+      revealArchiveInOrganizer = "NO">
+   </ArchiveAction>
+</Scheme>

--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -502,7 +502,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -230,7 +230,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "6E68F7F9-92AB-48FE-8013-4A33A6B2E023",
+      "name" : "Floorp Notes Sync QA",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en-US",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "FloorpNotesSyncProductionQAConfigurationTests/testReleaseBuildConfigurationIsExplicit()"
+      ],
+      "target" : {
+        "containerPath" : "container:Client.xcodeproj",
+        "identifier" : "3BFE4B061D342FB800DDF53F",
+        "name" : "XCUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -356,7 +356,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -172,7 +172,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -662,7 +662,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -193,7 +193,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOff()",
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
-        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()"
+        "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncProductionQAConfigurationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncProductionQAConfigurationTests.swift
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+
+/// Guards the separate, manually authorized production-QA XCUITest route.
+///
+/// This is deliberately not the G5 two-client matrix. It only proves that a
+/// caller selected the isolated FloorpRelease test scheme intentionally; the
+/// future matrix must still prove actual iOS/Desktop behavior separately.
+@MainActor
+final class FloorpNotesSyncProductionQAConfigurationTests: XCTestCase {
+    func testReleaseBuildConfigurationIsExplicit() {
+        XCTAssertEqual(
+            ProcessInfo.processInfo.environment["FLOORP_NOTES_SYNC_PRODUCTION_QA"],
+            "1",
+            "Production-QA XCUITests require an explicit, protected-environment opt-in."
+        )
+        XCTAssertNil(
+            ProcessInfo.processInfo.environment["FIREFOX_USE_STAGE_SERVER"],
+            "Production-QA XCUITests must not use a staging FxA override."
+        )
+    }
+}

--- a/scripts/ci/tests/test_floorp_notes_sync_production_qa_xctest_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_production_qa_xctest_contract.py
@@ -1,0 +1,137 @@
+"""Contract tests for the isolated Floorp Notes production-QA XCUITest route.
+
+This route is intentionally separate from the normal Fennec_Testing UI suite.
+It prepares a release-configuration test target for a manually authorized
+production-QA run; it is not G5 evidence and it must not run on PR/push CI.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+PROJECT = ROOT / "firefox-ios/Client.xcodeproj/project.pbxproj"
+SCHEME = ROOT / "firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncQA.xcscheme"
+TEST_PLAN = ROOT / "firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan"
+TEST_SOURCE = (
+    ROOT
+    / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
+    "FloorpNotesSyncProductionQAConfigurationTests.swift"
+)
+TEST_PLAN_DIRECTORY = ROOT / "firefox-ios/firefox-ios-tests/Tests"
+
+XCUITESTS_TARGET_ID = "3BFE4B061D342FB800DDF53F"
+XCUITESTS_CONFIGURATION_LIST_ID = "3BFE4B201D342FB900DDF53F"
+PRODUCTION_QA_TEST = (
+    "FloorpNotesSyncProductionQAConfigurationTests/"
+    "testReleaseBuildConfigurationIsExplicit()"
+)
+FLOORP_RELEASE_CONFIGURATION_ID = "F20A20012F52000100000001"
+FLOORP_RELEASE_BUILD_FILE_ID = "F20A20022F52000100000001"
+FLOORP_RELEASE_FILE_REFERENCE_ID = "F20A20032F52000100000001"
+
+
+class FloorpNotesSyncProductionQaXCTestContractTests(unittest.TestCase):
+    def test_scheme_uses_release_configuration_and_dedicated_plan(self):
+        tree = ET.parse(SCHEME)
+        root = tree.getroot()
+        test_action = root.find("TestAction")
+        self.assertIsNotNone(test_action)
+        assert test_action is not None
+        self.assertEqual(test_action.attrib.get("buildConfiguration"), "FloorpRelease")
+        self.assertEqual(
+            [reference.attrib.get("reference") for reference in test_action.findall("./TestPlans/TestPlanReference")],
+            ["container:firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan"],
+        )
+        self.assertNotIn("Fennec_Testing", SCHEME.read_text())
+
+    def test_plan_selects_only_the_explicit_production_qa_configuration_test(self):
+        plan = json.loads(TEST_PLAN.read_text())
+        self.assertEqual(plan["version"], 1)
+        self.assertEqual(
+            plan["configurations"],
+            [
+                {
+                    "id": "6E68F7F9-92AB-48FE-8013-4A33A6B2E023",
+                    "name": "Floorp Notes Sync QA",
+                    "options": {},
+                }
+            ],
+        )
+        self.assertEqual(plan["defaultOptions"], {"language": "en-US", "region": "US"})
+        self.assertEqual(len(plan["testTargets"]), 1)
+        target = plan["testTargets"][0]
+        self.assertEqual(
+            target["target"],
+            {
+                "containerPath": "container:Client.xcodeproj",
+                "identifier": XCUITESTS_TARGET_ID,
+                "name": "XCUITests",
+            },
+        )
+        self.assertEqual(target["selectedTests"], [PRODUCTION_QA_TEST])
+
+    def test_xcui_target_has_an_unsigned_floorp_release_configuration(self):
+        project = PROJECT.read_text()
+        configuration_list_start = project.index(
+            f'{XCUITESTS_CONFIGURATION_LIST_ID} /* Build configuration list for PBXNativeTarget "XCUITests" */ = {{'
+        )
+        configuration_list_end = project.index("\n\t\t};", configuration_list_start)
+        configuration_list = project[configuration_list_start:configuration_list_end]
+        self.assertTrue(
+            f"{FLOORP_RELEASE_CONFIGURATION_ID} /* FloorpRelease */," in configuration_list,
+            "XCUITests must expose FloorpRelease rather than falling back to Fennec_Testing",
+        )
+        configuration_start = project.index(
+            f"{FLOORP_RELEASE_CONFIGURATION_ID} /* FloorpRelease */ = {{"
+        )
+        configuration_end = project.index("\n\t\t};", configuration_start)
+        body = project[configuration_start:configuration_end]
+        self.assertIn('CODE_SIGN_ENTITLEMENTS = "";', body)
+        self.assertIn('CODE_SIGN_IDENTITY = "";', body)
+        self.assertIn("CODE_SIGNING_ALLOWED = NO;", body)
+        self.assertIn('INFOPLIST_FILE = "firefox-ios-tests/Tests/XCUITests/Info.plist";', body)
+        self.assertIn("TEST_TARGET_NAME = Client;", body)
+
+    def test_configuration_test_is_compiled_by_xcui_target_and_requires_explicit_opt_in(self):
+        project = PROJECT.read_text()
+        self.assertTrue(
+            f"{FLOORP_RELEASE_BUILD_FILE_ID} /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */"
+            in project,
+            "production-QA test source must be in the XCUITests Sources phase",
+        )
+        self.assertTrue(
+            f"{FLOORP_RELEASE_FILE_REFERENCE_ID} /* FloorpNotesSyncProductionQAConfigurationTests.swift */"
+            in project,
+            "production-QA test source must have a project file reference",
+        )
+        source = TEST_SOURCE.read_text()
+        self.assertIn("final class FloorpNotesSyncProductionQAConfigurationTests", source)
+        self.assertIn("func testReleaseBuildConfigurationIsExplicit()", source)
+        self.assertIn("FLOORP_NOTES_SYNC_PRODUCTION_QA", source)
+        self.assertNotIn("StageServer", source)
+
+    def test_non_dedicated_full_suite_plans_explicitly_skip_production_qa_test(self):
+        for plan_path in sorted(TEST_PLAN_DIRECTORY.glob("*.xctestplan")):
+            if plan_path == TEST_PLAN:
+                continue
+            plan = json.loads(plan_path.read_text())
+            for target in plan["testTargets"]:
+                if target["target"].get("name") != "XCUITests":
+                    continue
+                # Selected-test plans cannot accidentally discover a newly
+                # compiled XCTest. Plans without that allowlist run every
+                # XCUITest not explicitly skipped and must reject this route.
+                if "selectedTests" not in target:
+                    self.assertTrue(
+                        PRODUCTION_QA_TEST in target.get("skippedTests", []),
+                        f"{plan_path.name} could run the protected production-QA XCTest",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/staging/build-floorp-notes-sync-ios.sh
+++ b/scripts/staging/build-floorp-notes-sync-ios.sh
@@ -60,12 +60,14 @@ Usage:
     --source-sha SHA --output-dir PATH --manifest PATH \
     [--evidence PATH --validation-clock-manifest PATH] \
     [--schema PATH] [--endpoint-matrix PATH] \
-    [--action build|archive] [--archive-path PATH] \
+    [--action build|build-for-testing|archive] [--archive-path PATH] \
     [--destination DESTINATION] [--allow-signing]
 
 Modes:
   production-qa   Requires validated G1-G4 evidence and a validation clock.
                   Uses production FxA/Sync, but refuses archive and signing.
+                  build-for-testing creates an unsigned, external-xcconfig-bound
+                  XCTest product only; it does not run or establish G5/G6.
   release-disabled
                   Builds ordinary FloorpRelease with no evidence and an
                   effective false gate. Signing is refused.
@@ -124,7 +126,7 @@ case "$MODE" in
     *) fail "unsupported mode: $MODE" ;;
 esac
 case "$ACTION" in
-    build|archive) ;;
+    build|build-for-testing|archive) ;;
     *) fail "unsupported action: $ACTION" ;;
 esac
 [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "source-sha must be a lowercase 40-character Git SHA"
@@ -181,8 +183,12 @@ PY
     || fail "manifest already exists; build manifests are append-only: $MANIFEST"
 
 if [[ "$MODE" == "production-qa" ]]; then
-    [[ "$ACTION" == "build" ]] || fail "production-qa refuses archive actions"
+    [[ "$ACTION" == "build" || "$ACTION" == "build-for-testing" ]] \
+        || fail "production-qa refuses archive actions"
     [[ "$ALLOW_SIGNING" -eq 0 ]] || fail "production-qa refuses signing"
+fi
+if [[ "$ACTION" == "build-for-testing" && "$MODE" != "production-qa" ]]; then
+    fail "build-for-testing requires production-qa mode"
 fi
 if [[ "$MODE" == "release-disabled" ]]; then
     [[ -z "$EVIDENCE" && -z "$VALIDATION_CLOCK" ]] \
@@ -191,7 +197,7 @@ else
     [[ -n "$EVIDENCE" ]] || fail "$MODE requires --evidence"
     [[ -n "$VALIDATION_CLOCK" ]] || fail "$MODE requires --validation-clock-manifest"
 fi
-if [[ "$ACTION" == "build" && -n "$ARCHIVE_PATH" ]]; then
+if [[ "$ACTION" != "archive" && -n "$ARCHIVE_PATH" ]]; then
     fail "--archive-path is only valid with --action archive"
 fi
 if [[ "$ACTION" == "archive" ]]; then
@@ -211,6 +217,10 @@ fi
 DESTINATION="${DESTINATION:-generic/platform=iOS Simulator}"
 if [[ "$ACTION" == "archive" && "$DESTINATION_SET" -eq 0 ]]; then
     DESTINATION="generic/platform=iOS"
+fi
+if [[ "$ACTION" == "build-for-testing" ]]; then
+    [[ "$DESTINATION" == *"platform=iOS Simulator"* ]] \
+        || fail "build-for-testing requires an iOS Simulator destination"
 fi
 if [[ "$ALLOW_SIGNING" -eq 1 ]]; then
     [[ "$MODE" == "release-enabled" && "$ACTION" == "archive" ]] \
@@ -308,6 +318,15 @@ XC_CONFIG="$CONTRACT_DIR/FloorpNotesSyncBuild.xcconfig"
 COMMAND_JSON="$CONTRACT_DIR/xcodebuild-command.json"
 XCODE_VERSION_FILE="$CONTRACT_DIR/xcode-version.txt"
 TOOLCHAIN_RECORD="$CONTRACT_DIR/xcode-toolchain.json"
+XCODE_SCHEME="Floorp"
+TEST_PLAN=""
+TEST_PRODUCTS=""
+XCTESTRUN=""
+if [[ "$ACTION" == "build-for-testing" ]]; then
+    XCODE_SCHEME="FloorpNotesSyncQA"
+    TEST_PLAN="FloorpNotesSyncQA"
+    TEST_PRODUCTS="$OUTPUT_DIR/FloorpNotesSyncQA.xctestproducts"
+fi
 EVIDENCE_RESOURCE=""
 EVIDENCE_SNAPSHOT=""
 VALIDATION_CLOCK_SNAPSHOT=""
@@ -1796,7 +1815,7 @@ PY
 XCODE_ARGS=(
     "$ACTION"
     -project "$PROJECT"
-    -scheme Floorp
+    -scheme "$XCODE_SCHEME"
     -configuration FloorpRelease
     -destination "$DESTINATION"
     -derivedDataPath "$DERIVED_DATA"
@@ -1817,6 +1836,9 @@ XCODE_ARGS=(
 )
 if [[ "$ACTION" == "archive" ]]; then
     XCODE_ARGS+=( -archivePath "$ARCHIVE_PATH" )
+fi
+if [[ "$ACTION" == "build-for-testing" ]]; then
+    XCODE_ARGS+=( -testPlan "$TEST_PLAN" -testProductsPath "$TEST_PRODUCTS" )
 fi
 if [[ "$ALLOW_SIGNING" -eq 0 ]]; then
     XCODE_ARGS+=( CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO )
@@ -1865,6 +1887,59 @@ else
 fi
 [[ -n "$APP" && -d "$APP" ]] || fail "built Client.app was not found"
 APP="$(absolute_path "$APP")"
+
+if [[ "$ACTION" == "build-for-testing" ]]; then
+    [[ -d "$TEST_PRODUCTS" && ! -L "$TEST_PRODUCTS" ]] \
+        || fail "build-for-testing did not create a regular test-products directory"
+    XCTESTRUN="$("$PYTHON_BIN" - "$TEST_PRODUCTS" <<'PY'
+import sys
+from pathlib import Path
+
+raw_root = Path(sys.argv[1])
+
+
+def reject(message):
+    print(f"build-floorp-notes-sync-ios: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+if raw_root.is_symlink():
+    reject("test-products output may not be a symlink")
+try:
+    root = raw_root.resolve(strict=True)
+except OSError as error:
+    reject(f"test-products output is unavailable ({error})")
+if not root.is_dir():
+    reject("test-products output is not a directory")
+for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+    if not path.is_symlink():
+        continue
+    try:
+        target = path.resolve(strict=True)
+    except OSError as error:
+        reject(f"test-products symlink is dangling ({error})")
+    try:
+        target.relative_to(root)
+    except ValueError:
+        reject("test-products symlink escapes its isolated test-products output")
+candidates = sorted(
+    (
+        path
+        for path in root.rglob("*.xctestrun")
+        if path.is_file() and not path.is_symlink()
+    ),
+    key=lambda item: item.relative_to(root).as_posix(),
+)
+if len(candidates) != 1:
+    reject("build-for-testing did not create exactly one regular .xctestrun file")
+print(candidates[0])
+PY
+)" || exit $?
+    [[ -n "$XCTESTRUN" && -f "$XCTESTRUN" && ! -L "$XCTESTRUN" ]] \
+        || fail "build-for-testing did not create exactly one regular .xctestrun file"
+    TEST_PRODUCTS="$(absolute_path "$TEST_PRODUCTS")"
+    XCTESTRUN="$(absolute_path "$XCTESTRUN")"
+fi
 
 SOURCE_STATUS_AFTER="$("$GIT_BIN" -C "$ROOT" status --porcelain=v1 --untracked-files=all)"
 [[ "$SOURCE_STATUS_AFTER" == "$SOURCE_STATUS_BEFORE" && -z "$SOURCE_STATUS_AFTER" ]] \
@@ -2074,7 +2149,8 @@ fi
 
 MANIFEST_TMP="$MANIFEST.tmp.$$"
 "$PYTHON_BIN" - "$APP" "$ARCHIVE_PATH" "$MANIFEST_TMP" "$MODE" "$SOURCE_SHA" "$ACTUAL_TREE" \
-    "$ACTION" "$DESTINATION" "$ALLOW_SIGNING" "$OUTPUT_DIR" "$BUILD_LOG" "$XC_CONFIG" \
+    "$ACTION" "$XCODE_SCHEME" "$TEST_PLAN" "$TEST_PRODUCTS" "$XCTESTRUN" "$DESTINATION" \
+    "$ALLOW_SIGNING" "$OUTPUT_DIR" "$BUILD_LOG" "$XC_CONFIG" \
     "$FINAL_EVIDENCE_RESOURCE" "$EVIDENCE_DIGEST" "$FINAL_VALIDATOR" "$FINAL_SCHEMA" "$FINAL_PREFLIGHT" \
     "$XCODE_VERSION_FILE" "$COMMAND_JSON" "$ENTITLEMENTS_SOURCE" "$SNAPSHOT_RECORD" \
     "$SNAPSHOT_RECORD_SHA256" "$FINAL_SNAPSHOT_RECORD" "$FINAL_SNAPSHOT_RECORD_SHA256" \
@@ -2101,6 +2177,10 @@ from pathlib import Path
     source_sha,
     source_tree,
     action,
+    scheme,
+    test_plan,
+    test_products_raw,
+    xctestrun_raw,
     destination,
     allow_signing_raw,
     output_raw,
@@ -2132,6 +2212,8 @@ from pathlib import Path
 app = Path(app_raw).resolve()
 manifest_path = Path(manifest_raw).resolve()
 archive = Path(archive_raw).resolve() if archive_raw else None
+test_products = Path(test_products_raw).resolve() if test_products_raw else None
+xctestrun = Path(xctestrun_raw).resolve() if xctestrun_raw else None
 output = Path(output_raw).resolve()
 build_log = Path(build_log_raw).resolve()
 xcconfig = Path(xcconfig_raw).resolve()
@@ -2213,6 +2295,60 @@ def merkle_digest(root):
             continue
         digest.update(row.encode("utf-8"))
     return digest.hexdigest()
+
+
+try:
+    xcodebuild_arguments = json.loads(command_json_path.read_text())
+except (OSError, json.JSONDecodeError) as error:
+    reject(f"xcodebuild command record is unreadable ({error})")
+if not isinstance(xcodebuild_arguments, list) or not xcodebuild_arguments:
+    reject("xcodebuild command record is not a nonempty argument list")
+if xcodebuild_arguments[0] != action:
+    reject("xcodebuild command action does not match the manifest action")
+
+
+def command_option_value(option):
+    indexes = [
+        index for index, value in enumerate(xcodebuild_arguments) if value == option
+    ]
+    if len(indexes) != 1 or indexes[0] + 1 >= len(xcodebuild_arguments):
+        reject(f"xcodebuild command has no unique {option} option")
+    return xcodebuild_arguments[indexes[0] + 1]
+
+
+if command_option_value("-scheme") != scheme:
+    reject("xcodebuild command scheme does not match the manifest scheme")
+if command_option_value("-xcconfig") != str(xcconfig):
+    reject("xcodebuild command is not bound to the generated external xcconfig")
+if action == "build-for-testing":
+    expected_test_products = output / "FloorpNotesSyncQA.xctestproducts"
+    if mode != "production-qa":
+        reject("build-for-testing is only valid for production-qa")
+    if "platform=iOS Simulator" not in destination:
+        reject("build-for-testing destination is not an iOS Simulator")
+    if scheme != "FloorpNotesSyncQA" or test_plan != "FloorpNotesSyncQA":
+        reject("build-for-testing must use the dedicated Floorp Notes Sync QA scheme")
+    if test_products is None or xctestrun is None:
+        reject("build-for-testing has no test-products or xctestrun output")
+    if test_products != expected_test_products:
+        reject("build-for-testing test-products path is outside its isolated output")
+    if Path(test_products_raw).is_symlink() or not test_products.is_dir():
+        reject("build-for-testing test-products output is not a regular directory")
+    if Path(xctestrun_raw).is_symlink() or not xctestrun.is_file():
+        reject("build-for-testing xctestrun output is not a regular file")
+    if xctestrun.suffix != ".xctestrun" or not xctestrun.is_relative_to(test_products):
+        reject("build-for-testing xctestrun is not contained by its test-products output")
+    if command_option_value("-testPlan") != test_plan:
+        reject("xcodebuild command test plan does not match the manifest")
+    if command_option_value("-testProductsPath") != str(test_products):
+        reject("xcodebuild command test-products path does not match the manifest")
+    if "CODE_SIGNING_ALLOWED=NO" not in xcodebuild_arguments:
+        reject("build-for-testing must remain unsigned")
+else:
+    if scheme != "Floorp" or test_plan or test_products is not None or xctestrun is not None:
+        reject("non-test build has unexpected test-products metadata")
+    if "-testPlan" in xcodebuild_arguments or "-testProductsPath" in xcodebuild_arguments:
+        reject("non-test build unexpectedly requested test-products output")
 
 
 info_path = app / "Info.plist"
@@ -2555,7 +2691,8 @@ manifest = {
     },
     "build": {
         "action": action,
-        "scheme": "Floorp",
+        "scheme": scheme,
+        "test_plan": test_plan or None,
         "configuration": "FloorpRelease",
         "destination": destination,
         "marketing_version": str(info.get("CFBundleShortVersionString", "")),
@@ -2567,12 +2704,14 @@ manifest = {
         "provisioning_profile": provisioning_profile_record,
         "xcode_version": xcode_version_path.read_text().splitlines(),
         "toolchain": json.loads(toolchain_record_path.read_text()),
-        "xcodebuild_arguments": json.loads(command_json_path.read_text()),
+        "xcodebuild_arguments": xcodebuild_arguments,
     },
     "paths": {
         "output": str(output),
         "app": str(app),
         "archive": str(archive) if archive else None,
+        "test_products": str(test_products) if test_products else None,
+        "xctestrun": str(xctestrun) if xctestrun else None,
         "build_log": str(build_log),
     },
     "contract_inputs": {
@@ -2633,6 +2772,12 @@ manifest = {
     },
     "artifacts": {
         "app_merkle_sha256": merkle_digest(app),
+        "test_products_merkle_sha256": (
+            merkle_digest(test_products) if test_products else None
+        ),
+        "xctestrun": file_record(xctestrun, base=test_products)
+        if xctestrun
+        else None,
         "executable": file_record(executable, base=app),
         "info_plist": file_record(info_path, base=app),
         "entitlements": {
@@ -2728,10 +2873,42 @@ try:
     manifest = json.loads(payload)
     app = Path(manifest["paths"]["app"]).resolve(strict=True)
     expected_app_digest = manifest["artifacts"]["app_merkle_sha256"]
+    action = manifest["build"]["action"]
+    test_products_raw = manifest["paths"]["test_products"]
+    xctestrun_raw = manifest["paths"]["xctestrun"]
+    expected_test_products_digest = manifest["artifacts"]["test_products_merkle_sha256"]
+    expected_xctestrun_digest = manifest["artifacts"]["xctestrun"]["sha256"] \
+        if manifest["artifacts"]["xctestrun"] is not None else None
 except (KeyError, OSError, TypeError, ValueError, json.JSONDecodeError) as error:
     reject(f"temporary manifest artifact binding is invalid ({error})")
 if not app.is_dir() or app.is_symlink():
     reject("built app is unavailable immediately before publication")
+if action == "build-for-testing":
+    if not isinstance(test_products_raw, str) or not isinstance(xctestrun_raw, str):
+        reject("build-for-testing manifest has no test-products paths")
+    raw_test_products = Path(test_products_raw)
+    raw_xctestrun = Path(xctestrun_raw)
+    if raw_test_products.is_symlink() or raw_xctestrun.is_symlink():
+        reject("build-for-testing manifest test-products paths may not be symlinks")
+    try:
+        test_products = raw_test_products.resolve(strict=True)
+        xctestrun = raw_xctestrun.resolve(strict=True)
+    except OSError as error:
+        reject(f"build-for-testing output is unavailable before publication ({error})")
+    if (
+        not test_products.is_dir()
+        or not xctestrun.is_file()
+        or xctestrun.suffix != ".xctestrun"
+        or not xctestrun.is_relative_to(test_products)
+    ):
+        reject("build-for-testing output is invalid before publication")
+elif (
+    test_products_raw is not None
+    or xctestrun_raw is not None
+    or expected_test_products_digest is not None
+    or expected_xctestrun_digest is not None
+):
+    reject("non-test build manifest has unexpected test-products metadata")
 
 
 def sha256(path):
@@ -2761,6 +2938,11 @@ def merkle_digest(root):
 
 if merkle_digest(app) != expected_app_digest:
     reject("built app changed after release validation")
+if action == "build-for-testing":
+    if merkle_digest(test_products) != expected_test_products_digest:
+        reject("test-products changed after release validation")
+    if sha256(xctestrun) != expected_xctestrun_digest:
+        reject("xctestrun changed after release validation")
 parent = target.parent.resolve(strict=True)
 parent_flags = (
     os.O_RDONLY

--- a/scripts/staging/tests/test_build_floorp_notes_sync_ios.py
+++ b/scripts/staging/tests/test_build_floorp_notes_sync_ios.py
@@ -163,6 +163,7 @@ class FloorpNotesSyncBuildContractTests(unittest.TestCase):
             '    FAKE_MUTATE_GENERATED_MANIFEST="${FAKE_MUTATE_GENERATED_MANIFEST:-0}" \\\n'
             '    FAKE_MUTATE_GENERATED_SOURCE="${FAKE_MUTATE_GENERATED_SOURCE:-0}" \\\n'
             '    FAKE_MUTATE_LOCAL_SNAPSHOT="${FAKE_MUTATE_LOCAL_SNAPSHOT:-0}" \\\n'
+            '    FAKE_XCTESTRUN_MODE="${FAKE_XCTESTRUN_MODE:-valid}" \\\n'
             '    FAKE_G6_EMBEDDING="${FAKE_G6_EMBEDDING:-}" \\\n'
             '    FAKE_SIGNING_MODE="${FAKE_SIGNING_MODE:-valid}" \\\n'
             '    "$XCODEBUILD_BIN" "${XCODE_ARGS[@]}"'
@@ -368,6 +369,11 @@ class FloorpNotesSyncBuildContractTests(unittest.TestCase):
                 if "publication-inputs" in evidence.parts:
                     app_binary = pathlib.Path(os.environ["FAKE_APP_TO_MUTATE"])
                     app_binary.write_bytes(app_binary.read_bytes() + b"mutated")
+            if os.environ.get("FAKE_MUTATE_TEST_PRODUCTS_AFTER_FINAL_VALIDATION") == "1":
+                evidence = pathlib.Path(sys.argv[sys.argv.index("--evidence") + 1])
+                if "publication-inputs" in evidence.parts:
+                    xctestrun = pathlib.Path(os.environ["FAKE_XCTESTRUN_TO_MUTATE"])
+                    xctestrun.write_bytes(xctestrun.read_bytes() + b"mutated")
             raise SystemExit(int(os.environ.get("FAKE_VALIDATOR_EXIT", "0")))
         """))
 
@@ -562,6 +568,26 @@ class FloorpNotesSyncBuildContractTests(unittest.TestCase):
             else:
                 derived = pathlib.Path(args[args.index("-derivedDataPath") + 1])
                 app = derived / "Build/Products/FloorpRelease-iphonesimulator/Client.app"
+            if args[0] == "build-for-testing":
+                test_products = pathlib.Path(
+                    args[args.index("-testProductsPath") + 1]
+                )
+                test_products.mkdir(parents=True)
+                xctestrun = test_products / "FloorpNotesSyncQA.xctestrun"
+                xctestrun_mode = os.environ.get("FAKE_XCTESTRUN_MODE", "valid")
+                if xctestrun_mode == "valid":
+                    xctestrun.write_text("synthetic test products")
+                elif xctestrun_mode == "outside-symlink":
+                    escaped = test_products.parent / "escaped.xctestrun"
+                    escaped.write_text("escaped test products")
+                    xctestrun.symlink_to(escaped)
+                elif xctestrun_mode == "internal-relative-symlink":
+                    xctestrun.write_text("synthetic test products")
+                    (test_products / "internal-relative-link").symlink_to(
+                        "FloorpNotesSyncQA.xctestrun"
+                    )
+                else:
+                    raise SystemExit("unsupported FAKE_XCTESTRUN_MODE: " + xctestrun_mode)
             app.mkdir(parents=True)
             generated_manifest = pathlib.Path(
                 next(
@@ -1315,6 +1341,106 @@ class FloorpNotesSyncBuildContractTests(unittest.TestCase):
                 self.assertIn("production-qa", result.stderr)
                 self.assertFalse(xcode_record.exists())
 
+    def test_production_qa_build_for_testing_binds_external_xcconfig(self):
+        result, manifest_path, _, xcode_record, output = self.run_script(
+            "production-qa", extra=["--action", "build-for-testing"]
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        xcode_args = json.loads(xcode_record.read_text().splitlines()[0])
+        self.assertEqual(xcode_args[0], "build-for-testing")
+        self.assertEqual(xcode_args[xcode_args.index("-scheme") + 1], "FloorpNotesSyncQA")
+        self.assertEqual(
+            xcode_args[xcode_args.index("-testPlan") + 1], "FloorpNotesSyncQA"
+        )
+        test_products = Path(
+            xcode_args[xcode_args.index("-testProductsPath") + 1]
+        ).resolve()
+        self.assertTrue(test_products.is_relative_to(output.resolve()))
+        self.assertIn("-xcconfig", xcode_args)
+        self.assertIn("CODE_SIGNING_ALLOWED=NO", xcode_args)
+
+        manifest = json.loads(manifest_path.read_text())
+        self.assertEqual(manifest["build"]["action"], "build-for-testing")
+        self.assertEqual(manifest["build"]["scheme"], "FloorpNotesSyncQA")
+        self.assertEqual(manifest["build"]["test_plan"], "FloorpNotesSyncQA")
+        xcconfig = Path(manifest["contract_inputs"]["xcconfig_path"])
+        self.assertEqual(xcode_args[xcode_args.index("-xcconfig") + 1], str(xcconfig))
+        self.assertEqual(
+            manifest["contract_inputs"]["xcconfig_sha256"],
+            hashlib.sha256(xcconfig.read_bytes()).hexdigest(),
+        )
+        self.assertEqual(Path(manifest["paths"]["test_products"]), test_products)
+        xctestrun = Path(manifest["paths"]["xctestrun"])
+        self.assertTrue(xctestrun.is_file())
+        self.assertTrue(xctestrun.is_relative_to(test_products))
+        self.assertEqual(
+            manifest["artifacts"]["xctestrun"]["sha256"],
+            hashlib.sha256(xctestrun.read_bytes()).hexdigest(),
+        )
+        test_products_digest = hashlib.sha256()
+        test_products_digest.update(
+            (
+                "F\0FloorpNotesSyncQA.xctestrun\0"
+                f"{xctestrun.stat().st_size}\0"
+                f"{hashlib.sha256(xctestrun.read_bytes()).hexdigest()}\n"
+            ).encode("utf-8")
+        )
+        self.assertEqual(
+            manifest["artifacts"]["test_products_merkle_sha256"],
+            test_products_digest.hexdigest(),
+        )
+        self.assertEqual(manifest["paths"]["archive"], None)
+        self.assertEqual(manifest["gate"], {"requested": True, "effective": True})
+
+    def test_build_for_testing_requires_production_qa(self):
+        for mode in ("release-disabled", "release-enabled"):
+            with self.subTest(mode=mode):
+                result, _, _, xcode_record, _ = self.run_script(
+                    mode, extra=["--action", "build-for-testing"]
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("build-for-testing", result.stderr)
+                self.assertFalse(xcode_record.exists())
+
+    def test_build_for_testing_refuses_archive_signing_and_device_destination(self):
+        cases = (
+            (
+                ["--archive-path", str(self.root / "unexpected.xcarchive")],
+                "archive-path",
+            ),
+            (["--allow-signing"], "production-qa"),
+            (["--destination", "generic/platform=iOS"], "iOS Simulator"),
+        )
+        for extra, expected_error in cases:
+            with self.subTest(extra=extra):
+                result, _, _, xcode_record, _ = self.run_script(
+                    "production-qa",
+                    extra=["--action", "build-for-testing", *extra],
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_error, result.stderr)
+                self.assertFalse(xcode_record.exists())
+
+    def test_build_for_testing_rejects_test_products_symlink_escape(self):
+        result, manifest, _, xcode_record, _ = self.run_script(
+            "production-qa",
+            extra=["--action", "build-for-testing"],
+            env={"FAKE_XCTESTRUN_MODE": "outside-symlink"},
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("escapes its isolated test-products output", result.stderr)
+        self.assertTrue(xcode_record.exists())
+        self.assertFalse(manifest.exists())
+
+    def test_build_for_testing_allows_internal_relative_test_products_symlink(self):
+        result, manifest, _, _, _ = self.run_script(
+            "production-qa",
+            extra=["--action", "build-for-testing"],
+            env={"FAKE_XCTESTRUN_MODE": "internal-relative-symlink"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(manifest.exists())
+
     def test_release_enabled_archive_binds_g1_g5_and_all_artifacts(self):
         archive_parent = self.root / "final-output"
         archive_parent.mkdir(mode=0o700)
@@ -1610,6 +1736,26 @@ class FloorpNotesSyncBuildContractTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertEqual(len(validator_record.read_text().splitlines()), 2)
         self.assertIn("changed after release validation", result.stderr.lower())
+        self.assertFalse(manifest.exists())
+
+    def test_test_products_mutation_after_final_validation_fails_before_publication(self):
+        next_output = self.root / f"output-{self.run_index + 1}"
+        xctestrun = (
+            next_output
+            / "FloorpNotesSyncQA.xctestproducts/FloorpNotesSyncQA.xctestrun"
+        )
+        result, manifest, validator_record, _, _ = self.run_script(
+            "production-qa",
+            extra=["--action", "build-for-testing"],
+            env={
+                "FAKE_MUTATE_TEST_PRODUCTS_AFTER_FINAL_VALIDATION": "1",
+                "FAKE_XCTESTRUN_TO_MUTATE": str(xctestrun),
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(len(validator_record.read_text().splitlines()), 2)
+        self.assertIn("test-products changed after release validation", result.stderr.lower())
         self.assertFalse(manifest.exists())
 
     def test_allow_signing_requires_release_enabled_device_archive(self):


### PR DESCRIPTION
## Summary

- Adds a dedicated unsigned FloorpRelease XCUITest scheme and explicit production-QA opt-in configuration test.
- Keeps normal full XCUITest plans isolated by explicitly skipping that protected test.
- Adds a production-qa-only, unsigned, simulator-only build-for-testing action with fixed test-products output, external-xcconfig binding, symlink containment, manifest digests, and pre-publication integrity revalidation.

## Validation

- `python3 -m unittest scripts.staging.tests.test_build_floorp_notes_sync_ios` (66 passed)
- `python3 -m unittest scripts.ci.tests.test_floorp_notes_sync_production_qa_xctest_contract` (5 passed)
- dedicated FloorpNotesSyncQA `xcodebuild build-for-testing` and XCUITest opt-in run passed locally
- SwiftLint and `git diff --check` passed

## Scope

This is G5 execution foundation only. It does not run a live FxA/Sync two-client matrix, establish G5 or G6, handle credentials, sign or archive an app, or perform App Store actions.