### PR TITLE
test(sync): add content-free Notes evidence snapshot

### DIFF
--- a/firefox-ios/Floorp/FloorpNotes.swift
+++ b/firefox-ios/Floorp/FloorpNotes.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/
 
+import CryptoKit
 import Foundation
 
 // MARK: - Note model
@@ -707,6 +708,19 @@ struct FloorpNotesSyncContext: Equatable, Sendable {
     let applicationServicesState: FloorpNotesApplicationServicesState?
 }
 
+/// Content-free local persistence state for two-client QA evidence.
+///
+/// This is an observation of one device's archive only. It does not establish
+/// network activity, cross-client equality, or a successful Sync operation.
+struct FloorpNotesSyncEvidenceSnapshot: Equatable, Sendable {
+    let archiveSHA256: String
+    let noteCount: Int
+    let revision: UInt64
+    let hasSyncOwner: Bool
+    let hasSyncBaseState: Bool
+    let hasApplicationServicesAssociation: Bool
+}
+
 enum FloorpNotesPersistenceAccountAvailability: Equatable, Sendable {
     case available
     case accountMismatch
@@ -1086,6 +1100,25 @@ final class FloorpNotesPersistenceCore: @unchecked Sendable {
             ownerAccountID: archive.syncOwnerAccountID,
             baseState: archive.syncBaseState,
             applicationServicesState: archive.applicationServicesState
+        )
+    }
+
+    func loadSyncEvidenceSnapshot() throws -> FloorpNotesSyncEvidenceSnapshot {
+        let archive = try loadArchive()
+        let archiveSHA256 = SHA256.hash(data: try encodedArchiveData(archive))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let applicationServicesState = archive.applicationServicesState
+        let hasApplicationServicesAssociation = applicationServicesState?.globalSyncID != nil
+            && applicationServicesState?.collectionSyncID != nil
+
+        return FloorpNotesSyncEvidenceSnapshot(
+            archiveSHA256: archiveSHA256,
+            noteCount: archive.notes.count,
+            revision: archive.revision,
+            hasSyncOwner: archive.syncOwnerAccountID != nil,
+            hasSyncBaseState: archive.syncBaseState != nil,
+            hasApplicationServicesAssociation: hasApplicationServicesAssociation
         )
     }
 
@@ -1862,6 +1895,10 @@ actor FloorpNotesStore {
 
     func loadSyncContext() throws -> FloorpNotesSyncContext {
         try syncPersistenceCore.withLock { try syncPersistenceCore.loadSyncContext() }
+    }
+
+    func loadSyncEvidenceSnapshot() throws -> FloorpNotesSyncEvidenceSnapshot {
+        try syncPersistenceCore.withLock { try syncPersistenceCore.loadSyncEvidenceSnapshot() }
     }
 
     nonisolated func syncAccountAvailability(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesSyncTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesSyncTests.swift
@@ -1971,6 +1971,11 @@ final class FloorpNotesPrefsSyncDelegateTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(context.ownerAccountID, "account-a")
         XCTAssertEqual(context.baseState, FloorpNotesSyncBaseState(accountID: "account-a", notes: [local]))
         XCTAssertEqual(context.applicationServicesState?.lastModifiedMillis, 42)
+        let evidence = try await restarted.loadSyncEvidenceSnapshot()
+        XCTAssertTrue(evidence.hasSyncOwner)
+        XCTAssertTrue(evidence.hasSyncBaseState)
+        XCTAssertTrue(evidence.hasApplicationServicesAssociation)
+        XCTAssertEqual(evidence.noteCount, 1)
         let restartedNotes = try await restarted.loadNotes()
         XCTAssertEqual(restartedNotes, [local])
     }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesTests.swift
@@ -95,6 +95,40 @@ final class FloorpNotesStoreTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(emptyNotes, [])
     }
 
+    func testSyncEvidenceSnapshotIsContentFreeStableAcrossRestartAndTracksArchiveState() async throws {
+        let location = try makeTemporaryArchiveLocation()
+        defer { try? FileManager.default.removeItem(at: location.directory) }
+
+        let store = FloorpNotesStore(fileURL: location.archive)
+        let empty = try await store.loadSyncEvidenceSnapshot()
+
+        XCTAssertEqual(empty.noteCount, 0)
+        XCTAssertEqual(empty.revision, 0)
+        XCTAssertFalse(empty.hasSyncOwner)
+        XCTAssertFalse(empty.hasSyncBaseState)
+        XCTAssertFalse(empty.hasApplicationServicesAssociation)
+        XCTAssertNotNil(
+            empty.archiveSHA256.range(
+                of: "^[0-9a-f]{64}$",
+                options: .regularExpression
+            )
+        )
+
+        _ = try await store.createNote(title: "One", content: "One")
+        let afterWrite = try await store.loadSyncEvidenceSnapshot()
+
+        XCTAssertEqual(afterWrite.noteCount, 1)
+        XCTAssertGreaterThan(afterWrite.revision, empty.revision)
+        XCTAssertNotEqual(afterWrite.archiveSHA256, empty.archiveSHA256)
+        XCTAssertFalse(afterWrite.hasSyncOwner)
+        XCTAssertFalse(afterWrite.hasSyncBaseState)
+        XCTAssertFalse(afterWrite.hasApplicationServicesAssociation)
+
+        let restartedStore = FloorpNotesStore(fileURL: location.archive)
+        let afterRestart = try await restartedStore.loadSyncEvidenceSnapshot()
+        XCTAssertEqual(afterRestart, afterWrite)
+    }
+
     func testConcurrentUpdatesToDifferentNotesDoNotOverwriteEachOther() async throws {
         let location = try makeTemporaryArchiveLocation()
         defer { try? FileManager.default.removeItem(at: location.directory) }

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -302,6 +302,7 @@
         "FloorpNotesStoreTests/testRichContentWithImageIsReadOnlyAndDoesNotExposeSource()",
         "FloorpNotesStoreTests/testRichDocumentPreflightUsesWholeArchiveBudgetWithoutWriting()",
         "FloorpNotesStoreTests/testRichEditorProjectionPreservesMeaningfulWhitespace()",
+        "FloorpNotesStoreTests/testSyncEvidenceSnapshotIsContentFreeStableAcrossRestartAndTracksArchiveState()",
         "FloorpNotesStoreTests/testStaleEditIsRejectedAndTimestampAdvancesWhenClockDoesNot()",
         "FloorpNotesStoreTests/testTipTapProjectionSupportsParagraphs()",
         "FloorpNotesStoreTests/testUnsupportedNewerSchemaIsLeftByteForByteUntouched()",


### PR DESCRIPTION
## Summary

- Reapply the reviewed content-free Notes persistence observation patch after PR #90 was squash-merged.
- Add a `FloorpNotesSyncEvidenceSnapshot` consisting only of archive SHA-256, note count, revision, and boolean presence flags.
- Select the regression in `FloorpCI`; it neither enables Sync nor creates UI, network, credential, telemetry, or account paths.

## Provenance

- Base: `2a185e12540985aa5f0952e80927ddf054ffa9db` (PR #90 squash result).
- Head: `ad4a8f6fb1879baf0b1a4833bf58e0c89f232fca`.
- The patch byte sequence and resulting tree are identical to the earlier reviewed commit `1518ef7e3da08d34fa8212793b68409ad449e54a`.

## Verification

- Swift parse: passed for all three changed Swift sources.
- SwiftLint 0.62.2 (`--strict --no-cache`): zero violations.
- FloorpCI selection and `git diff --check`: passed.
- The local XcodeBuildMCP targeted test attempt timed out without an xcresult, so it is explicitly not counted as a pass or failure. The required PR CI is the execution gate.
- Independent static scope review: GO, no P0/P1/P2 findings.

## Scope boundary

This is a static, local observation foundation only. It does not launch a client, access FxA/Sync, handle credentials, collect traffic, execute G5, create G6, enable release behavior, or complete Todo 20.
