### PR TITLE
test(sync): add fail-closed G5 admission boundary

### DIFF
--- a/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_release.py
@@ -1272,6 +1272,30 @@ class FloorpNotesSyncReleaseValidatorTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("does not prove an approved Sync host", result.stderr)
 
+    def test_g5_rejects_duplicate_or_non_string_proxy_hosts(self):
+        for hosts in (
+            ["sync.services.mozilla.com", "sync.services.mozilla.com"],
+            [{"host": "sync.services.mozilla.com"}],
+        ):
+            with self.subTest(hosts=hosts):
+                evidence = make_evidence()
+                source = evidence["gates"]["g5"]["artifact"]["sources"][4]
+                payload = json.loads(TEST_SOURCE_BYTES["proxy-trace"])
+                payload["hosts"] = hosts
+                raw = canonical_bytes(payload)
+                source["sha256"] = hashlib.sha256(raw).hexdigest()
+                evidence["gates"]["g5"]["proxy_trace_sha256"] = source["sha256"]
+                evidence["gates"]["g5"]["artifact"] = artifact_bundle(
+                    evidence["gates"]["g5"]["artifact"]["sources"]
+                )
+                rehash(evidence)
+                result = self.run_validator(
+                    evidence,
+                    local_artifact_overrides={source["path"]: raw},
+                )
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("proxy hosts", result.stderr)
+
     def test_g5_rejects_noninteractive_ci_run(self):
         evidence = make_evidence()
         source = evidence["gates"]["g5"]["artifact"]["sources"][1]

--- a/scripts/ci/validate-floorp-notes-sync-release.py
+++ b/scripts/ci/validate-floorp-notes-sync-release.py
@@ -182,6 +182,12 @@ G5_TWO_CLIENT_XCRESULT_TEST = (
     "FloorpNotesSyncTwoClientMatrixTests/"
     "testTwoClientProductionMatrix()"
 )
+G5_CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+G5_CI_EVENT = "workflow_dispatch"
+G5_CI_HEAD_BRANCH = "main"
+G5_XCRESULT_ARTIFACT_NAME = "floorp-notes-sync-two-client-xcresult"
+G5_XCRESULT_ARTIFACT_KIND = "github-actions-artifact"
+G5_REQUIRED_SYNC_HOST = "sync.services.mozilla.com"
 EXPECTED_FXA_HOSTS = (
     "accounts.firefox.com",
     "api.accounts.firefox.com",
@@ -2106,7 +2112,7 @@ def validate_gate_source_semantics(
         )
         check(
             (ci_run["repository"], ci_run["head_sha"], ci_run["workflow_path"])
-            == (inputs["ios"]["repository"], inputs["ios"]["source_sha"], ".github/workflows/ci.yml"),
+            == (inputs["ios"]["repository"], inputs["ios"]["source_sha"], G5_CI_WORKFLOW_PATH),
             f"{label}: iOS CI run is not bound to the candidate",
         )
         xcresult = require_source(
@@ -2298,7 +2304,7 @@ def validate_gate_source_semantics(
         ci_run = require_source(sources, "ci-run", ("github-actions-run",), "metadata-json", label)
         check(
             (ci_run["repository"], ci_run["head_sha"], ci_run["workflow_path"])
-            == (inputs["ios"]["repository"], inputs["ios"]["source_sha"], ".github/workflows/ci.yml"),
+            == (inputs["ios"]["repository"], inputs["ios"]["source_sha"], G5_CI_WORKFLOW_PATH),
             f"{label}: two-client CI run is not bound to the candidate",
         )
         xcresult = require_source(
@@ -2322,14 +2328,14 @@ def validate_gate_source_semantics(
             f"{label}: xcresult artifact is not bound to the two-client CI run",
         )
         check(
-            xcresult["artifact_name"] == "floorp-notes-sync-two-client-xcresult",
+            xcresult["artifact_name"] == G5_XCRESULT_ARTIFACT_NAME,
             f"{label}: two-client xcresult artifact name is not canonical",
         )
         ci_run_payload = payloads["ci-run"]
         check(isinstance(ci_run_payload, dict), f"{label}: two-client CI run metadata is malformed")
         check(
             (ci_run_payload.get("event"), ci_run_payload.get("head_branch"))
-            == ("workflow_dispatch", "main"),
+            == (G5_CI_EVENT, G5_CI_HEAD_BRANCH),
             f"{label}: two-client CI run is not an explicit main dispatch",
         )
         isolation = require_source(sources, "account-isolation-run", ("local-file",), "metadata-json", label)
@@ -2356,13 +2362,19 @@ def validate_gate_source_semantics(
         proxy_payload = payloads["proxy-trace"]
         check(isinstance(proxy_payload, dict), f"{label}: proxy summary is malformed")
         hosts = proxy_payload.get("hosts")
-        check(isinstance(hosts, list) and bool(hosts), f"{label}: proxy hosts are missing")
+        check(
+            isinstance(hosts, list)
+            and bool(hosts)
+            and all(isinstance(host, str) for host in hosts)
+            and len(hosts) == len(set(hosts)),
+            f"{label}: proxy hosts are malformed or duplicated",
+        )
         check(
             set(hosts) <= set(EXPECTED_FXA_HOSTS) | set(EXPECTED_SYNC_HOSTS),
             f"{label}: proxy trace contains an unapproved host",
         )
         check(
-            "sync.services.mozilla.com" in hosts,
+            G5_REQUIRED_SYNC_HOST in hosts,
             f"{label}: proxy trace does not prove an approved Sync host",
         )
         expected_proxy = {

--- a/scripts/staging/floorp_notes_sync_g5_admission.py
+++ b/scripts/staging/floorp_notes_sync_g5_admission.py
@@ -1,0 +1,272 @@
+"""Fail-closed static admission checks for future G5 evidence collection.
+
+This module does not launch clients, receive credentials, invoke a runner, or
+emit G5 evidence. It only validates an explicit non-executing contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_VALIDATOR_PATH = REPOSITORY_ROOT / "scripts" / "ci" / "validate-floorp-notes-sync-release.py"
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+FORBIDDEN_FIELD_PARTS = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "credential",
+        "key",
+        "password",
+        "payload",
+        "secret",
+        "session",
+        "token",
+    }
+)
+
+
+def load_release_validator() -> Any:
+    specification = importlib.util.spec_from_file_location(
+        "floorp_notes_sync_release_validator_for_g5_admission",
+        RELEASE_VALIDATOR_PATH,
+    )
+    if specification is None or specification.loader is None:
+        raise RuntimeError("cannot load the repository release-evidence validator")
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+RELEASE_VALIDATOR = load_release_validator()
+IOS_REPOSITORY = RELEASE_VALIDATOR.EXPECTED_REPOSITORY
+G5_TEST = RELEASE_VALIDATOR.G5_TWO_CLIENT_XCRESULT_TEST
+CI_WORKFLOW_PATH = RELEASE_VALIDATOR.G5_CI_WORKFLOW_PATH
+G5_CI_EVENT = RELEASE_VALIDATOR.G5_CI_EVENT
+G5_CI_HEAD_BRANCH = RELEASE_VALIDATOR.G5_CI_HEAD_BRANCH
+G5_ARTIFACT_NAME = RELEASE_VALIDATOR.G5_XCRESULT_ARTIFACT_NAME
+G5_ARTIFACT_KIND = RELEASE_VALIDATOR.G5_XCRESULT_ARTIFACT_KIND
+G5_REQUIRED_SYNC_HOST = RELEASE_VALIDATOR.G5_REQUIRED_SYNC_HOST
+FXA_HOSTS = frozenset(RELEASE_VALIDATOR.EXPECTED_FXA_HOSTS)
+SYNC_HOSTS = frozenset(RELEASE_VALIDATOR.EXPECTED_SYNC_HOSTS)
+
+
+class AdmissionError(ValueError):
+    """The contract is insufficient or unsafe for future G5 collection."""
+
+
+def reject(message: str) -> None:
+    raise AdmissionError(message)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        reject(message)
+
+
+def normalized_field_parts(name: str) -> tuple[str, ...]:
+    expanded = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower().replace("-", "_")
+    return tuple(part for part in expanded.split("_") if part)
+
+
+def reject_sensitive_fields(
+    value: Any,
+    label: str,
+    *,
+    allowed_paths: frozenset[tuple[str, ...]],
+    path: tuple[str, ...] = (),
+) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            require(isinstance(key, str), f"{label} contains a non-string field")
+            parts = normalized_field_parts(key)
+            child_path = (*path, key)
+            require(
+                child_path in allowed_paths
+                or not any(part in FORBIDDEN_FIELD_PARTS for part in parts),
+                f"{label} contains a forbidden secret/content field",
+            )
+            reject_sensitive_fields(
+                child,
+                label,
+                allowed_paths=allowed_paths,
+                path=child_path,
+            )
+    elif isinstance(value, list):
+        for child in value:
+            reject_sensitive_fields(
+                child,
+                label,
+                allowed_paths=allowed_paths,
+                path=path,
+            )
+
+
+def require_exact_keys(value: Any, keys: frozenset[str], label: str) -> dict[str, Any]:
+    require(isinstance(value, dict), f"{label} must be an object")
+    require(set(value) == keys, f"{label} fields are not exact")
+    return value
+
+
+def validate_admission_contract(contract: Any) -> dict[str, str]:
+    root = require_exact_keys(
+        contract,
+        frozenset(
+            {
+                "artifact_contract",
+                "boundary",
+                "candidate",
+                "isolation_contract",
+                "network_contract",
+                "schema_version",
+                "workflow",
+            }
+        ),
+        "G5 admission contract",
+    )
+    require(root["schema_version"] == 1, "G5 admission contract schema is unsupported")
+
+    candidate = require_exact_keys(
+        root["candidate"],
+        frozenset({"head_sha", "repository"}),
+        "candidate",
+    )
+    require(candidate["repository"] == IOS_REPOSITORY, "candidate repository is not floorp-ios")
+    require(
+        isinstance(candidate["head_sha"], str) and re.fullmatch(r"[0-9a-f]{40}", candidate["head_sha"]),
+        "candidate head SHA is invalid",
+    )
+
+    workflow = require_exact_keys(
+        root["workflow"],
+        frozenset({"event", "head_branch", "path"}),
+        "workflow",
+    )
+    require(
+        workflow
+        == {
+            "event": G5_CI_EVENT,
+            "head_branch": G5_CI_HEAD_BRANCH,
+            "path": CI_WORKFLOW_PATH,
+        },
+        "workflow is not an explicit main dispatch",
+    )
+
+    artifact = require_exact_keys(
+        root["artifact_contract"],
+        frozenset({"artifact_kind", "artifact_name", "required_test", "retrieval"}),
+        "artifact contract",
+    )
+    require(artifact["artifact_kind"] == G5_ARTIFACT_KIND, "artifact kind is not GitHub Actions")
+    require(artifact["artifact_name"] == G5_ARTIFACT_NAME, "artifact name is not canonical")
+    require(artifact["required_test"] == G5_TEST, "artifact test is not the G5 matrix test")
+    require(artifact["retrieval"] == "required-after-run", "artifact retrieval may not be omitted")
+
+    boundary = require_exact_keys(
+        root["boundary"],
+        frozenset(
+            {
+                "credential_delivery",
+                "execution_authorization",
+                "g5_result",
+                "runner_receipts_accepted",
+            }
+        ),
+        "boundary",
+    )
+    require(boundary["credential_delivery"] == "protected-environment-only", "credential boundary is not protected-environment-only")
+    require(boundary["execution_authorization"] == "not-authorized", "admission boundary must not authorize execution")
+    require(boundary["g5_result"] == "not-assessed", "admission boundary must not claim G5")
+    require(boundary["runner_receipts_accepted"] is False, "arbitrary runner receipts are forbidden")
+
+    isolation = require_exact_keys(
+        root["isolation_contract"],
+        frozenset(
+            {
+                "accounts",
+                "cleanup_required",
+                "local_only_fallback_required",
+                "payload_retained",
+                "rollback_required",
+                "secrets_retained",
+            }
+        ),
+        "isolation contract",
+    )
+    require(
+        isolation
+        == {
+            "accounts": 2,
+            "cleanup_required": True,
+            "local_only_fallback_required": True,
+            "payload_retained": False,
+            "rollback_required": True,
+            "secrets_retained": False,
+        },
+        "isolation contract lacks cleanup, rollback, or retention guarantees",
+    )
+
+    network = require_exact_keys(
+        root["network_contract"],
+        frozenset(
+            {
+                "hosts",
+                "metadata_only",
+                "payload_retained",
+                "port",
+                "secrets_retained",
+                "tls_interception",
+                "tls_verified",
+            }
+        ),
+        "network contract",
+    )
+    hosts = network["hosts"]
+    require(
+        isinstance(hosts, list)
+        and all(isinstance(host, str) for host in hosts)
+        and len(hosts) == len(set(hosts))
+        and bool(hosts)
+        and set(hosts) <= FXA_HOSTS | SYNC_HOSTS
+        and G5_REQUIRED_SYNC_HOST in hosts,
+        "network hosts are not an approved policy with Sync proof",
+    )
+    require(
+        network
+        == {
+            "hosts": hosts,
+            "metadata_only": True,
+            "payload_retained": False,
+            "port": 443,
+            "secrets_retained": False,
+            "tls_interception": False,
+            "tls_verified": True,
+        },
+        "network contract lacks metadata-only TLS guarantees",
+    )
+    reject_sensitive_fields(
+        root,
+        "G5 admission contract",
+        allowed_paths=frozenset(
+            {
+                ("boundary", "credential_delivery"),
+                ("boundary", "execution_authorization"),
+                ("isolation_contract", "payload_retained"),
+                ("isolation_contract", "secrets_retained"),
+                ("network_contract", "payload_retained"),
+                ("network_contract", "secrets_retained"),
+            }
+        ),
+    )
+
+    return {
+        "artifact_retrieval": "required-after-run",
+        "cleanup_boundary": "not-established",
+        "execution_authorization": "not-authorized",
+        "g5_result": "not-assessed",
+        "status": "admission-contract-valid",
+    }

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_admission.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_admission.py
@@ -1,0 +1,177 @@
+"""TDD contract for the fail-closed G5 evidence-admission boundary."""
+
+from __future__ import annotations
+
+import copy
+import unittest
+
+from scripts.staging.floorp_notes_sync_g5_admission import (
+    AdmissionError,
+    CI_WORKFLOW_PATH,
+    G5_CI_EVENT,
+    G5_CI_HEAD_BRANCH,
+    G5_ARTIFACT_NAME,
+    G5_ARTIFACT_KIND,
+    G5_REQUIRED_SYNC_HOST,
+    RELEASE_VALIDATOR,
+    validate_admission_contract,
+)
+
+
+IOS_REPOSITORY = "Floorp-Projects/floorp-ios"
+G5_TEST = "FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()"
+FXA_HOSTS = [
+    "accounts.firefox.com",
+    "api.accounts.firefox.com",
+    "oauth.accounts.firefox.com",
+    "profile.accounts.firefox.com",
+    "static.accounts.firefox.com",
+]
+SYNC_HOSTS = [
+    "event-sync.services.mozilla.com",
+    "sync.services.mozilla.com",
+    "token.services.mozilla.com",
+]
+
+
+def valid_admission_contract() -> dict[str, object]:
+    return {
+        "artifact_contract": {
+            "artifact_kind": "github-actions-artifact",
+            "artifact_name": "floorp-notes-sync-two-client-xcresult",
+            "required_test": G5_TEST,
+            "retrieval": "required-after-run",
+        },
+        "boundary": {
+            "credential_delivery": "protected-environment-only",
+            "execution_authorization": "not-authorized",
+            "g5_result": "not-assessed",
+            "runner_receipts_accepted": False,
+        },
+        "candidate": {
+            "head_sha": "a" * 40,
+            "repository": IOS_REPOSITORY,
+        },
+        "isolation_contract": {
+            "accounts": 2,
+            "cleanup_required": True,
+            "local_only_fallback_required": True,
+            "payload_retained": False,
+            "rollback_required": True,
+            "secrets_retained": False,
+        },
+        "network_contract": {
+            "hosts": sorted(FXA_HOSTS + SYNC_HOSTS),
+            "metadata_only": True,
+            "payload_retained": False,
+            "port": 443,
+            "secrets_retained": False,
+            "tls_interception": False,
+            "tls_verified": True,
+        },
+        "schema_version": 1,
+        "workflow": {
+            "event": "workflow_dispatch",
+            "head_branch": "main",
+            "path": ".github/workflows/ci.yml",
+        },
+    }
+
+
+class FloorpNotesSyncG5AdmissionTests(unittest.TestCase):
+    def test_binds_g5_protocol_constants_to_release_validator(self) -> None:
+        self.assertEqual(CI_WORKFLOW_PATH, RELEASE_VALIDATOR.G5_CI_WORKFLOW_PATH)
+        self.assertEqual(G5_CI_EVENT, RELEASE_VALIDATOR.G5_CI_EVENT)
+        self.assertEqual(G5_CI_HEAD_BRANCH, RELEASE_VALIDATOR.G5_CI_HEAD_BRANCH)
+        self.assertEqual(G5_ARTIFACT_NAME, RELEASE_VALIDATOR.G5_XCRESULT_ARTIFACT_NAME)
+        self.assertEqual(G5_ARTIFACT_KIND, RELEASE_VALIDATOR.G5_XCRESULT_ARTIFACT_KIND)
+        self.assertEqual(G5_REQUIRED_SYNC_HOST, RELEASE_VALIDATOR.G5_REQUIRED_SYNC_HOST)
+
+    def test_exact_contract_is_not_execution_authorization(self) -> None:
+        decision = validate_admission_contract(valid_admission_contract())
+
+        self.assertEqual(decision["status"], "admission-contract-valid")
+        self.assertEqual(decision["execution_authorization"], "not-authorized")
+        self.assertEqual(decision["g5_result"], "not-assessed")
+        self.assertEqual(decision["cleanup_boundary"], "not-established")
+        self.assertEqual(decision["artifact_retrieval"], "required-after-run")
+
+    def test_rejects_arbitrary_runner_receipt_and_execution_authorization(self) -> None:
+        for key, value in (
+            ("runner", "/usr/local/bin/untrusted-runner"),
+            ("runnerReceipt", {"g5": "passed"}),
+            ("execution_authorization", "authorized"),
+        ):
+            with self.subTest(key=key):
+                contract = valid_admission_contract()
+                if key == "execution_authorization":
+                    contract["boundary"][key] = value
+                else:
+                    contract[key] = value
+                with self.assertRaises(AdmissionError):
+                    validate_admission_contract(contract)
+
+    def test_rejects_non_main_dispatch_missing_artifact_and_missing_sync_host(self) -> None:
+        mutations = (
+            (("workflow", "head_branch"), "agent/untrusted", "non-main dispatch"),
+            (("artifact_contract", "retrieval"), "not-required", "artifact omission"),
+            (("network_contract", "hosts"), FXA_HOSTS, "missing Sync host"),
+        )
+        for path, value, label in mutations:
+            with self.subTest(label=label):
+                contract = valid_admission_contract()
+                target: dict[str, object] = contract
+                for key in path[:-1]:
+                    target = target[key]
+                target[path[-1]] = value
+                with self.assertRaises(AdmissionError):
+                    validate_admission_contract(contract)
+
+    def test_rejects_malformed_or_duplicate_network_hosts(self) -> None:
+        malformed_hosts = (
+            [["sync.services.mozilla.com"]],
+            [{"host": "sync.services.mozilla.com"}],
+            valid_admission_contract()["network_contract"]["hosts"] + ["sync.services.mozilla.com"],
+        )
+        for hosts in malformed_hosts:
+            with self.subTest(hosts=hosts):
+                contract = valid_admission_contract()
+                contract["network_contract"]["hosts"] = hosts
+                with self.assertRaises(AdmissionError):
+                    validate_admission_contract(contract)
+
+    def test_accepts_validator_permitted_approved_host_subset(self) -> None:
+        contract = valid_admission_contract()
+        contract["network_contract"]["hosts"] = ["sync.services.mozilla.com"]
+
+        decision = validate_admission_contract(contract)
+
+        self.assertEqual(decision["status"], "admission-contract-valid")
+
+    def test_rejects_secret_aliases_and_unproved_cleanup(self) -> None:
+        aliases = (
+            "authorizationHeader",
+            "authorization-header",
+            "authorization_header",
+            "notePayload",
+            "note-payload",
+            "note_payload",
+            "rawSyncKey",
+            "raw-sync-key",
+            "raw_sync_key",
+        )
+        for alias in aliases:
+            with self.subTest(alias=alias):
+                contract = valid_admission_contract()
+                contract["network_contract"][alias] = "not-a-secret"
+                with self.assertRaises(AdmissionError):
+                    validate_admission_contract(contract)
+
+        contract = copy.deepcopy(valid_admission_contract())
+        contract["isolation_contract"]["cleanup_required"] = False
+        with self.assertRaises(AdmissionError):
+            validate_admission_contract(contract)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Reapply the reviewed G5 evidence-admission boundary after the content-free observation foundation was squash-merged in PR #91.
- Bind future G5 admission to the canonical validator constants and reject malformed/duplicate hosts, sensitive fields, arbitrary runner receipts, and unproved cleanup.
- Add contract tests for a main-only future workflow, dedicated artifact shape, two-account isolation, rollback/local fallback, approved hosts, and TLS non-interception.

## Provenance

- Base: `92b4ea2081eb79ec5330014e9df208cd38d29c26` (PR #91 squash result).
- Head: `1488b6ed4d0ab20819893292fbba1b959dbd154b`.
- The patch byte sequence and resulting tree are identical to the previously reviewed commit `d32b8266c71a71dd9d5fc48771c47e11f9729e4e`.

## Verification

- 7 G5 admission-boundary tests: passed.
- 109 release-validator tests: passed.
- Python compilation, AST no-launch/no-network audit, and `git diff --check`: passed.
- Independent scope and publication reviews: GO, no P0/P1/P2 findings.

## Scope boundary

This PR is a static fail-closed admission contract only. It sets `execution_authorization=not-authorized` and `g5_result=not-assessed`. It does not launch clients, access FxA/Sync, receive credentials, retrieve artifacts, collect traffic, perform cleanup, create G5/G6 evidence, enable release behavior, or complete Todo 20.
