### PR TITLE
test(sync): add compile-only G5 test product route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,30 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             | tee "$RUNNER_TEMP/build.log"
 
+      # Compile only: normal PR/main CI has no production-QA authorization,
+      # credentials, or G5 evidence role.
+      - name: Compile release-disabled G5 XCTest route
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing -quiet \
+            -project "$PROJECT_PATH" \
+            -scheme FloorpNotesSyncG5 \
+            -configuration FloorpRelease \
+            -destination "$DESTINATION" \
+            -testPlan FloorpNotesSyncG5 \
+            -only-testing:XCUITests/FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix \
+            -derivedDataPath "$RUNNER_TEMP/G5RouteCompileDerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/g5-route-compile.log"
+
       - name: Run unit tests
         timeout-minutes: 30
         run: |

--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -136,6 +136,11 @@ G5 is valid only when a successful, manually dispatched `main` run of
 `FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()` node;
 renaming an ordinary FloorpCI result does not satisfy this requirement.
 
+Ordinary PR/main CI compiles the protected selector without executing its protected selector.
+This compile-only output has no production-QA
+authorization, credentials, artifact upload, or operational evidence and
+cannot satisfy G5 evidence.
+
 The public records are exact metadata-only summaries. Account isolation must
 prove two isolated accounts, post-upload base advancement, cleanup, rollback,
 and local-only fallback against the pinned fixture. Network evidence must prove

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A00272F50000100000001 /* FloorpBrandingUITests.swift */; };
 		F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */; };
 		F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */; };
+		F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2816,6 +2817,7 @@
 		F10A00272F50000100000001 /* FloorpBrandingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpBrandingUITests.swift; sourceTree = "<group>"; };
 		F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesLocalV1UITests.swift; sourceTree = "<group>"; };
 		F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncProductionQAConfigurationTests.swift; sourceTree = "<group>"; };
+		F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncTwoClientMatrixTests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13565,6 +13567,7 @@
 				F10A00272F50000100000001 /* FloorpBrandingUITests.swift */,
 				F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */,
 				F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */,
+				F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19608,6 +19611,7 @@
 				F10A00262F50000100000001 /* FloorpBrandingUITests.swift in Sources */,
 				F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */,
 				F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */,
+				F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncG5.xcscheme
+++ b/firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncG5.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+               BuildableName = "Client.app"
+               BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "FloorpRelease"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      language = "en"
+      region = "US">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:firefox-ios-tests/Tests/FloorpNotesSyncG5.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "FloorpRelease"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "FloorpRelease"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "FloorpRelease">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "FloorpRelease"
+      revealArchiveInOrganizer = "NO">
+   </ArchiveAction>
+</Scheme>

--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -503,7 +503,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -231,7 +231,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncG5.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncG5.xctestplan
@@ -1,0 +1,28 @@
+{
+  "configurations" : [
+    {
+      "id" : "5F3476F1-6A1B-49F6-88B6-1C6E0DC0CDE5",
+      "name" : "Floorp Notes Sync G5",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en-US",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()"
+      ],
+      "target" : {
+        "containerPath" : "container:Client.xcodeproj",
+        "identifier" : "3BFE4B061D342FB800DDF53F",
+        "name" : "XCUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -357,7 +357,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -173,7 +173,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -663,7 +663,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -194,7 +194,8 @@
         "ZoomingTestsTAE\/testZoomForceCloseFirefox_tabTrayExperimentOn()",
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
-        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()"
+        "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncTwoClientMatrixTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncTwoClientMatrixTests.swift
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+import XCTest
+
+/// Protected-run preflight only. The separate operational runner owns actual
+/// iOS/Desktop behavior, account isolation, cleanup, and network evidence.
+@MainActor
+final class FloorpNotesSyncTwoClientMatrixTests: XCTestCase {
+    func testTwoClientProductionMatrix() {
+        let environment = ProcessInfo.processInfo.environment
+
+        guard environment["FLOORP_NOTES_SYNC_G5_RUN"] == "1" else {
+            XCTFail("G5 preflight was not explicitly authorized.")
+            return
+        }
+        guard environment["FLOORP_NOTES_SYNC_PRODUCTION_QA"] == "1" else {
+            XCTFail("G5 preflight requires the protected production-QA route.")
+            return
+        }
+        guard environment["FIREFOX_USE_STAGE_SERVER"] == nil else {
+            XCTFail("G5 preflight rejects a staging server override.")
+            return
+        }
+    }
+}

--- a/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
@@ -1,0 +1,236 @@
+"""TDD contract for the compile-only Floorp Notes Sync G5 test product.
+
+The route proves only that the protected XCTest can be built by normal CI.
+It must not execute the selector, access accounts or Sync, accept credentials,
+or publish something that could be mistaken for G5 evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github/workflows/ci.yml"
+BUILD_CONTRACT = ROOT / "docs/floorp-notes-sync-build-contract.md"
+PROJECT = ROOT / "firefox-ios/Client.xcodeproj/project.pbxproj"
+SCHEME = ROOT / "firefox-ios/Client.xcodeproj/xcshareddata/xcschemes/FloorpNotesSyncG5.xcscheme"
+TEST_PLAN = ROOT / "firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncG5.xctestplan"
+TEST_SOURCE = (
+    ROOT
+    / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
+    "FloorpNotesSyncTwoClientMatrixTests.swift"
+)
+QA_TEST_PLAN = ROOT / "firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan"
+TEST_PLAN_DIRECTORY = ROOT / "firefox-ios/firefox-ios-tests/Tests"
+RUBY = "/usr/bin/ruby"
+
+XCUITESTS_TARGET_ID = "3BFE4B061D342FB800DDF53F"
+G5_TEST = "FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()"
+QA_TEST = "FloorpNotesSyncProductionQAConfigurationTests/testReleaseBuildConfigurationIsExplicit()"
+G5_BUILD_FILE_ID = "F20A20122F52000100000001"
+G5_FILE_REFERENCE_ID = "F20A20132F52000100000001"
+CANONICAL_G5_ARTIFACT = "floorp-notes-sync-two-client-xcresult"
+
+
+class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        result = subprocess.run(
+            [
+                RUBY,
+                "-rjson",
+                "-ryaml",
+                "-e",
+                "print JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true))",
+                str(WORKFLOW),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"failed to parse ci.yml: {result.stderr}")
+        cls.workflow: dict[str, Any] = json.loads(result.stdout)
+        cls.jobs: dict[str, Any] = cls.workflow["jobs"]
+
+    @staticmethod
+    def named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+        for step in job["steps"]:
+            if step.get("name") == name:
+                return step
+        raise AssertionError(f"missing step: {name}")
+
+    def test_scheme_uses_unsigned_floorp_release_and_dedicated_g5_plan(self) -> None:
+        self.assertTrue(SCHEME.is_file(), "the G5 route needs a dedicated shared scheme")
+        if not SCHEME.is_file():
+            return
+        tree = ET.parse(SCHEME)
+        test_action = tree.getroot().find("TestAction")
+        self.assertIsNotNone(test_action)
+        assert test_action is not None
+        self.assertEqual(test_action.attrib.get("buildConfiguration"), "FloorpRelease")
+        self.assertEqual(
+            [
+                reference.attrib.get("reference")
+                for reference in test_action.findall("./TestPlans/TestPlanReference")
+            ],
+            ["container:firefox-ios-tests/Tests/FloorpNotesSyncG5.xctestplan"],
+        )
+        self.assertIsNone(test_action.find("EnvironmentVariables"))
+        self.assertNotIn("Fennec_Testing", SCHEME.read_text(encoding="utf-8"))
+
+    def test_plan_selects_only_the_protected_g5_preflight(self) -> None:
+        self.assertTrue(TEST_PLAN.is_file(), "the G5 route needs an isolated test plan")
+        if not TEST_PLAN.is_file():
+            return
+        plan = json.loads(TEST_PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(plan["version"], 1)
+        self.assertEqual(len(plan["configurations"]), 1)
+        self.assertRegex(plan["configurations"][0]["id"], r"^[0-9A-F-]{36}$")
+        self.assertEqual(plan["configurations"][0]["name"], "Floorp Notes Sync G5")
+        self.assertEqual(plan["configurations"][0]["options"], {})
+        self.assertEqual(plan["defaultOptions"], {"language": "en-US", "region": "US"})
+        self.assertEqual(len(plan["testTargets"]), 1)
+        target = plan["testTargets"][0]
+        self.assertEqual(
+            target["target"],
+            {
+                "containerPath": "container:Client.xcodeproj",
+                "identifier": XCUITESTS_TARGET_ID,
+                "name": "XCUITests",
+            },
+        )
+        self.assertEqual(target["selectedTests"], [G5_TEST])
+
+    def test_preflight_is_direct_xctest_and_has_no_operational_side_effect(self) -> None:
+        self.assertTrue(TEST_SOURCE.is_file(), "the G5 selector must be an actual XCTest source")
+        if not TEST_SOURCE.is_file():
+            return
+        source = TEST_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("final class FloorpNotesSyncTwoClientMatrixTests: XCTestCase", source)
+        self.assertIn("func testTwoClientProductionMatrix()", source)
+        self.assertIn("FLOORP_NOTES_SYNC_G5_RUN", source)
+        self.assertIn("FLOORP_NOTES_SYNC_PRODUCTION_QA", source)
+        self.assertIn("FIREFOX_USE_STAGE_SERVER", source)
+        for forbidden in (
+            "BaseTestCase",
+            "StageServer",
+            "XCUIApplication",
+            "URLSession",
+            "XCTAttachment",
+            "screenshot()",
+            "debugDescription",
+            "Logger",
+            "NSLog",
+            "print(",
+            "PASSWORD",
+            "TOKEN",
+            "CREDENTIAL",
+            "COORDINATOR",
+        ):
+            self.assertNotIn(forbidden, source)
+
+    def test_source_is_wired_into_the_existing_xcui_target(self) -> None:
+        project = PROJECT.read_text(encoding="utf-8")
+        self.assertIn(
+            f"{G5_BUILD_FILE_ID} /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */",
+            project,
+        )
+        self.assertIn(
+            f"{G5_FILE_REFERENCE_ID} /* FloorpNotesSyncTwoClientMatrixTests.swift */",
+            project,
+        )
+        self.assertEqual(project.count(G5_BUILD_FILE_ID), 2)
+        self.assertEqual(project.count(G5_FILE_REFERENCE_ID), 3)
+
+    def test_ordinary_unbounded_plans_explicitly_skip_the_protected_g5_selector(self) -> None:
+        for plan_path in sorted(TEST_PLAN_DIRECTORY.glob("*.xctestplan")):
+            if plan_path == TEST_PLAN:
+                continue
+            plan = json.loads(plan_path.read_text(encoding="utf-8"))
+            for target in plan["testTargets"]:
+                if target["target"].get("name") != "XCUITests":
+                    continue
+                if "selectedTests" not in target:
+                    self.assertIn(
+                        G5_TEST,
+                        target.get("skippedTests", []),
+                        f"{plan_path.name} could execute the protected G5 XCTest",
+                    )
+
+    def test_existing_production_qa_plan_remains_configuration_only(self) -> None:
+        plan = json.loads(QA_TEST_PLAN.read_text(encoding="utf-8"))
+        self.assertEqual(plan["testTargets"][0]["selectedTests"], [QA_TEST])
+        self.assertNotIn(G5_TEST, plan["testTargets"][0]["selectedTests"])
+
+    def test_primary_ci_compiles_but_cannot_execute_or_publish_the_route(self) -> None:
+        compile_step = self.named_step(
+            self.jobs["build-and-test"],
+            "Compile release-disabled G5 XCTest route",
+        )
+        run = compile_step["run"]
+        for expected in (
+            "xcodebuild build-for-testing -quiet",
+            "-project \"$PROJECT_PATH\"",
+            "-scheme FloorpNotesSyncG5",
+            "-configuration FloorpRelease",
+            "-destination \"$DESTINATION\"",
+            "-testPlan FloorpNotesSyncG5",
+            "-only-testing:XCUITests/FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix",
+            "-derivedDataPath \"$RUNNER_TEMP/G5RouteCompileDerivedData\"",
+            "-clonedSourcePackagesDirPath \"$RUNNER_TEMP/SourcePackages\"",
+            "-disableAutomaticPackageResolution",
+            "-onlyUsePackageVersionsFromResolvedFile",
+            "-skipMacroValidation",
+            "-parallel-testing-enabled NO",
+            "CODE_SIGN_IDENTITY=",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGNING_ALLOWED=NO",
+        ):
+            self.assertIn(expected, run)
+
+        serialized = json.dumps(compile_step, sort_keys=True).lower()
+        for forbidden in (
+            "test-without-building",
+            "floorp_notes_sync_g5_run",
+            "floorp_notes_sync_production_qa",
+            "firefox_use_stage_server",
+            "custom_fxa_server",
+            "secrets.",
+            "environment",
+            "uses",
+            "resultbundlepath",
+            "upload-artifact",
+            "curl ",
+            "gh api",
+        ):
+            self.assertNotIn(forbidden, serialized)
+
+    def test_primary_ci_job_cannot_confuse_compile_output_with_g5_evidence(self) -> None:
+        serialized = json.dumps(self.jobs["build-and-test"], sort_keys=True).lower()
+        self.assertNotIn("floorp-notes-sync-production-qa", serialized)
+        self.assertNotIn(CANONICAL_G5_ARTIFACT, serialized)
+        self.assertNotIn("run_g5_", serialized)
+
+    def test_build_contract_excludes_compile_only_results_from_g5_evidence(self) -> None:
+        source = BUILD_CONTRACT.read_text(encoding="utf-8")
+        self.assertIn("Ordinary PR/main CI compiles", source)
+        self.assertIn("without executing its protected selector", source)
+        self.assertIn("cannot satisfy G5 evidence", source)
+
+    def test_all_actions_in_primary_ci_remain_pinned(self) -> None:
+        serialized = json.dumps(self.jobs["build-and-test"], sort_keys=True)
+        uses = re.findall(r'"uses": "([^"]+)"', serialized)
+        self.assertTrue(uses)
+        self.assertTrue(all(re.search(r"@[0-9a-f]{40}$", item) for item in uses))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a fail-closed, compile-only G5 XCTest test-product route from current main.

- dedicated unsigned FloorpRelease scheme and test plan
- explicit opt-in preflight selector, excluded from unbounded test plans
- ordinary CI builds the route only; it does not execute it, use a protected environment or secrets, upload a G5 artifact, access FxA/Sync, or claim G5
- static contract coverage prevents compile output being used as G5 evidence

Validation:
- 138 related Python contract/admission/preflight tests
- Swift parse and SwiftLint strict/no-cache
- Ruby CI YAML parse and static compile-only boundary audit
- git diff --check

Local Xcode build-for-testing was not assessed because this fresh linked worktree lacks ignored nimbus-fml.sh; PR CI runs bootstrap in a clean checkout. This PR is not actual G5 execution or Todo 20 completion.