### PR TITLE
ci(sync): add protected compile-only preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,24 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      run_floorp_notes_sync_protected_preflight:
+        description: Compile the protected Notes Sync G5 selector without executing it.
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: floorp-ios-ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: >-
+    floorp-ios-ci-${{ github.event_name }}-${{
+    inputs.run_floorp_notes_sync_protected_preflight == true && github.run_id ||
+    github.event.pull_request.number || github.ref }}
+  cancel-in-progress: >-
+    ${{ github.event_name != 'workflow_dispatch' ||
+    inputs.run_floorp_notes_sync_protected_preflight != true }}
 
 env:
   L10N_REVIEW_BASE: e58637e772e4456efcf7dbf3826f172c7da721ba
@@ -27,6 +38,9 @@ env:
 jobs:
   workflow-lint:
     name: Validate workflows
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.run_floorp_notes_sync_protected_preflight != true
     runs-on: ubuntu-24.04
     timeout-minutes: 5
 
@@ -60,6 +74,9 @@ jobs:
 
   build-and-test:
     name: Build and unit test
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.run_floorp_notes_sync_protected_preflight != true
     runs-on: macos-26
     timeout-minutes: 90
 
@@ -251,6 +268,9 @@ jobs:
 
   release-disabled-wrapper:
     name: Release-disabled wrapper build
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      inputs.run_floorp_notes_sync_protected_preflight != true
     runs-on: macos-26
     timeout-minutes: 90
     needs: workflow-lint
@@ -286,3 +306,85 @@ jobs:
             ${{ runner.temp }}/floorp-notes-sync-release-disabled-manifest.json
           if-no-files-found: ignore
           retention-days: 7
+
+  # This Environment-bound job is a manual scheduling preflight only. It
+  # compiles the guard XCTest without executing it and must not be treated as
+  # G5 evidence or execution authorization.
+  notes-sync-protected-preflight:
+    name: Protected Notes Sync compile-only preflight
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.run_floorp_notes_sync_protected_preflight == true
+    environment: floorp-notes-sync-production-qa
+    runs-on: macos-26
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Select Xcode
+        run: |
+          xcode_version="$(<.xcode-version)"
+          sudo xcode-select --switch "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
+          xcodebuild -version
+
+      - name: Bootstrap generated sources
+        run: ./bootstrap.sh firefox
+        env:
+          CI: "true"
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT_PATH" \
+            -scheme FloorpNotesSyncG5 \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
+      - name: Prepare iOS Simulator
+        timeout-minutes: 10
+        run: |
+          runtime="com.apple.CoreSimulator.SimRuntime.iOS-${SIMULATOR_OS//./-}"
+          simulator_id="$(
+            xcrun simctl list devices available --json \
+              | jq -er --arg runtime "$runtime" --arg name "$SIMULATOR_NAME" \
+                '.devices[$runtime] | map(select(.name == $name)) | first | .udid'
+          )"
+          simulator_arch="$(uname -m)"
+
+          xcrun simctl bootstatus "$simulator_id" -b
+          printf 'DESTINATION=platform=iOS Simulator,id=%s,arch=%s\n' \
+            "$simulator_id" "$simulator_arch" >> "$GITHUB_ENV"
+
+      - name: Compile protected G5 XCTest route
+        run: |
+          set -o pipefail
+          xcodebuild build-for-testing -quiet \
+            -project "$PROJECT_PATH" \
+            -scheme FloorpNotesSyncG5 \
+            -configuration FloorpRelease \
+            -destination "$DESTINATION" \
+            -testPlan FloorpNotesSyncG5 \
+            -only-testing:XCUITests/FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix \
+            -derivedDataPath "$RUNNER_TEMP/ProtectedG5PreflightDerivedData" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
+            -disableAutomaticPackageResolution \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -skipMacroValidation \
+            -parallel-testing-enabled NO \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGN_IDENTITY= \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            | tee "$RUNNER_TEMP/protected-g5-preflight-compile.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       run_floorp_notes_sync_protected_preflight:
         description: Compile the protected Notes Sync G5 selector without executing it.
-        required: true
+        required: false
         default: false
         type: boolean
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       github.event_name != 'workflow_dispatch' ||
       inputs.run_floorp_notes_sync_protected_preflight != true
     runs-on: macos-26
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
       - name: Check out source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,21 +317,43 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.run_floorp_notes_sync_protected_preflight == true
     environment: floorp-notes-sync-production-qa
+    # Override the workflow-wide read permission. This job must not receive a
+    # usable GitHub token or invoke a token-defaulting source checkout action.
+    permissions: {}
+    env:
+      GITHUB_TOKEN: ""
+      GH_TOKEN: ""
+      NODE_AUTH_TOKEN: ""
+      NPM_TOKEN: ""
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
+      GIT_TERMINAL_PROMPT: "0"
+      GIT_ASKPASS: /usr/bin/false
     runs-on: macos-26
     timeout-minutes: 90
 
     steps:
-      - name: Check out source
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
+      - name: Check out source anonymously
+        run: |
+          set -euo pipefail
+          git -C "$GITHUB_WORKSPACE" init --quiet
+          git -C "$GITHUB_WORKSPACE" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$GITHUB_WORKSPACE" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            fetch --no-tags --depth=1 origin "$GITHUB_SHA"
+          git -C "$GITHUB_WORKSPACE" checkout --detach --force FETCH_HEAD
+          test "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$GITHUB_SHA"
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version-file: .nvmrc
-          cache: npm
+          token: ""
+          package-manager-cache: false
 
       - name: Select Xcode
         run: |

--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -141,6 +141,13 @@ This compile-only output has no production-QA
 authorization, credentials, artifact upload, or operational evidence and
 cannot satisfy G5 evidence.
 
+The protected manual preflight is a `workflow_dispatch` job restricted to
+`main` and the `floorp-notes-sync-production-qa` Environment. It compiles the
+guard selector with `build-for-testing`; it does not execute the selector,
+does not authorize G5, consumes no credential or endpoint input, and uploads
+no artifact. The Environment is a scheduling boundary, not a G5 approval;
+this preflight cannot satisfy G5 evidence.
+
 The public records are exact metadata-only summaries. Account isolation must
 prove two isolated accounts, post-upload base advancement, cleanup, rollback,
 and local-only fallback against the pinned fixture. Network evidence must prove

--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -144,9 +144,16 @@ cannot satisfy G5 evidence.
 The protected manual preflight is a `workflow_dispatch` job restricted to
 `main` and the `floorp-notes-sync-production-qa` Environment. It compiles the
 guard selector with `build-for-testing`; it does not execute the selector,
-does not authorize G5, consumes no credential or endpoint input, and uploads
-no artifact. The Environment is a scheduling boundary, not a G5 approval;
-this preflight cannot satisfy G5 evidence.
+does not authorize G5, consumes no FxA/Sync credential or endpoint input, and
+uploads no artifact. It uses an anonymous source checkout from the public
+repository, has empty job-level GitHub permissions, explicitly clears GitHub,
+Node, and npm token inputs, and disables the Node package cache. It does not
+pass a GitHub token to checkout, setup, cache, shell, or tool calls. GitHub
+Actions may still provide its platform-managed `github.token` context; this
+job makes no nonissuance claim, does not reference that context, and does not
+forward it to any configured action or command. The Environment is a
+scheduling boundary, not a G5 approval; this preflight cannot satisfy G5
+evidence.
 
 The public records are exact metadata-only summaries. Account isolation must
 prove two isolated accounts, post-upload base advancement, cleanup, rollback,

--- a/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
@@ -213,6 +213,14 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, serialized)
 
+    def test_primary_ci_time_budget_covers_compile_only_route_and_unit_tests(self) -> None:
+        job = self.jobs["build-and-test"]
+        self.assertEqual(job["timeout-minutes"], 120)
+        self.assertEqual(
+            self.named_step(job, "Run unit tests")["timeout-minutes"],
+            30,
+        )
+
     def test_primary_ci_job_cannot_confuse_compile_output_with_g5_evidence(self) -> None:
         serialized = json.dumps(self.jobs["build-and-test"], sort_keys=True).lower()
         self.assertNotIn("floorp-notes-sync-production-qa", serialized)

--- a/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
@@ -1,0 +1,226 @@
+"""TDD contract for the manual, compile-only Notes Sync preflight.
+
+The job is an Environment-bound scheduling preflight only.  It must never
+execute the protected selector, handle credentials, or produce G5 evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW = ROOT / ".github/workflows/ci.yml"
+BUILD_CONTRACT = ROOT / "docs/floorp-notes-sync-build-contract.md"
+RELEASE_CONFIG = ROOT / "firefox-ios/Client/Configuration/FloorpRelease.xcconfig"
+RUBY = "/usr/bin/ruby"
+
+DISPATCH_INPUT = "run_floorp_notes_sync_protected_preflight"
+JOB_ID = "notes-sync-protected-preflight"
+ENVIRONMENT = "floorp-notes-sync-production-qa"
+G5_SELECTOR = "XCUITests/FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix"
+
+
+class FloorpNotesSyncProtectedPreflightContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        result = subprocess.run(
+            [
+                RUBY,
+                "-rjson",
+                "-ryaml",
+                "-e",
+                "print JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true))",
+                str(WORKFLOW),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"failed to parse ci.yml: {result.stderr}")
+        cls.workflow: dict[str, Any] = json.loads(result.stdout)
+        # Ruby's YAML loader follows YAML 1.1 and parses the unquoted GitHub
+        # key `on` as true. JSON object keys are strings, so it becomes
+        # `"true"` in the serialized view used by this contract test.
+        cls.dispatch: dict[str, Any] = cls.workflow["true"]["workflow_dispatch"]
+        cls.jobs: dict[str, Any] = cls.workflow["jobs"]
+
+    @staticmethod
+    def named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+        for step in job["steps"]:
+            if step.get("name") == name:
+                return step
+        raise AssertionError(f"missing step: {name}")
+
+    def test_dispatch_requires_one_explicit_boolean_opt_in(self) -> None:
+        self.assertEqual(set(self.dispatch["inputs"]), {DISPATCH_INPUT})
+        option = self.dispatch["inputs"][DISPATCH_INPUT]
+        self.assertEqual(option["type"], "boolean")
+        self.assertIs(option["required"], True)
+        self.assertIs(option["default"], False)
+
+    def test_job_is_manual_main_only_and_environment_bound(self) -> None:
+        job = self.jobs[JOB_ID]
+        self.assertEqual(job["runs-on"], "macos-26")
+        self.assertEqual(job["timeout-minutes"], 90)
+        self.assertEqual(job["environment"], ENVIRONMENT)
+        self.assertEqual(
+            " ".join(job["if"].split()),
+            "github.event_name == 'workflow_dispatch' && "
+            "github.ref == 'refs/heads/main' && "
+            f"inputs.{DISPATCH_INPUT} == true",
+        )
+        self.assertEqual(self.workflow["permissions"], {"contents": "read"})
+
+    def test_manual_preflight_isolates_the_normal_build_jobs(self) -> None:
+        expected_skip = (
+            "github.event_name != 'workflow_dispatch' || "
+            f"inputs.{DISPATCH_INPUT} != true"
+        )
+        for job_id in (
+            "workflow-lint",
+            "build-and-test",
+            "release-disabled-wrapper",
+        ):
+            self.assertEqual(
+                " ".join(self.jobs[job_id]["if"].split()),
+                expected_skip,
+                f"{job_id} must not run during the protected manual preflight",
+            )
+        self.assertEqual(
+            self.jobs["release-disabled-wrapper"].get("needs"),
+            "workflow-lint",
+            "normal release-disabled CI must retain its existing lint dependency",
+        )
+
+    def test_manual_preflight_has_a_unique_non_cancelling_workflow_slot(self) -> None:
+        concurrency = self.workflow["concurrency"]
+        self.assertIn("github.run_id", concurrency["group"])
+        self.assertIn(DISPATCH_INPUT, concurrency["group"])
+        self.assertEqual(
+            " ".join(concurrency["cancel-in-progress"].split()),
+            "${{ github.event_name != 'workflow_dispatch' || "
+            f"inputs.{DISPATCH_INPUT} != true " + "}}",
+        )
+
+    def test_job_shape_steps_and_xcode_commands_are_allowlisted(self) -> None:
+        job = self.jobs[JOB_ID]
+        self.assertEqual(
+            set(job),
+            {"name", "if", "environment", "runs-on", "timeout-minutes", "steps"},
+        )
+        self.assertNotIn("needs", job)
+        self.assertNotIn("permissions", job)
+        self.assertEqual(
+            [step["name"] for step in job["steps"]],
+            [
+                "Check out source",
+                "Set up Node.js",
+                "Select Xcode",
+                "Bootstrap generated sources",
+                "Resolve Swift packages",
+                "Prepare iOS Simulator",
+                "Compile protected G5 XCTest route",
+            ],
+        )
+
+        runs = "\n".join(
+            step["run"] for step in job["steps"] if "run" in step
+        )
+        self.assertEqual(runs.count("xcodebuild"), 3)
+        for expected in (
+            "xcodebuild -version",
+            "xcodebuild -resolvePackageDependencies",
+            "xcodebuild build-for-testing -quiet",
+        ):
+            self.assertIn(expected, runs)
+        self.assertNotRegex(runs, r"\bxcodebuild\s+test(?:\s|$)")
+
+    def test_job_builds_only_the_unsigned_guard_selector(self) -> None:
+        job = self.jobs[JOB_ID]
+        checkout = self.named_step(job, "Check out source")
+        self.assertFalse(checkout["with"]["persist-credentials"])
+        self.assertRegex(checkout["uses"], r"@[0-9a-f]{40}$")
+
+        setup_node = self.named_step(job, "Set up Node.js")
+        self.assertRegex(setup_node["uses"], r"@[0-9a-f]{40}$")
+        self.assertEqual(
+            self.named_step(job, "Bootstrap generated sources")["env"], {"CI": "true"}
+        )
+
+        compile_step = self.named_step(job, "Compile protected G5 XCTest route")
+        run = compile_step["run"]
+        for expected in (
+            "xcodebuild build-for-testing -quiet",
+            '-project "$PROJECT_PATH"',
+            "-scheme FloorpNotesSyncG5",
+            "-configuration FloorpRelease",
+            '-destination "$DESTINATION"',
+            "-testPlan FloorpNotesSyncG5",
+            f"-only-testing:{G5_SELECTOR}",
+            '-derivedDataPath "$RUNNER_TEMP/ProtectedG5PreflightDerivedData"',
+            '-clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"',
+            "-disableAutomaticPackageResolution",
+            "-onlyUsePackageVersionsFromResolvedFile",
+            "-skipMacroValidation",
+            "-parallel-testing-enabled NO",
+            "CODE_SIGN_IDENTITY=",
+            "CODE_SIGNING_REQUIRED=NO",
+            "CODE_SIGNING_ALLOWED=NO",
+        ):
+            self.assertIn(expected, run)
+
+    def test_job_cannot_execute_or_publish_g5(self) -> None:
+        serialized = json.dumps(self.jobs[JOB_ID], sort_keys=True).lower()
+        for forbidden in (
+            "test-without-building",
+            "floorp_notes_sync_g5_run",
+            "floorp_notes_sync_production_qa",
+            "firefox_use_stage_server",
+            "custom_fxa",
+            "custom_token",
+            "secrets.",
+            "github.token",
+            "upload-artifact",
+            "resultbundlepath",
+            "floorp-notes-sync-two-client-xcresult",
+            "g5_completed",
+            "validation-clock",
+            "validate-floorp-notes-sync-release.py",
+            "assemble-floorp-notes-sync",
+            "build-floorp-notes-sync-ios.sh",
+            "run-floorp-notes-sync-matrix.sh",
+            "-xcconfig",
+            "--allow-signing",
+            "allowprovisioningupdates",
+            "curl ",
+            "gh api",
+            "archive",
+            "exportarchive",
+        ):
+            self.assertNotIn(forbidden, serialized)
+        self.assertIsNone(re.search(r"\bxcodebuild\s+test(?:\s|$)", serialized))
+
+    def test_docs_and_release_defaults_preserve_the_fail_closed_boundary(self) -> None:
+        contract = BUILD_CONTRACT.read_text(encoding="utf-8")
+        for expected in (
+            "protected manual preflight",
+            "does not execute the selector",
+            "does not authorize G5",
+            "cannot satisfy G5 evidence",
+        ):
+            self.assertIn(expected, contract)
+
+        release = RELEASE_CONFIG.read_text(encoding="utf-8")
+        self.assertIn("FLOORP_NOTES_SYNC_REQUESTED = NO", release)
+        self.assertIn("FLOORP_NOTES_SYNC_EFFECTIVE = NO", release)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
@@ -16,6 +16,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = ROOT / ".github/workflows/ci.yml"
+UPSTREAM_SYNC_WORKFLOW = ROOT / ".github/workflows/upstream-sync.yml"
 BUILD_CONTRACT = ROOT / "docs/floorp-notes-sync-build-contract.md"
 RELEASE_CONFIG = ROOT / "firefox-ios/Client/Configuration/FloorpRelease.xcconfig"
 RUBY = "/usr/bin/ruby"
@@ -58,12 +59,17 @@ class FloorpNotesSyncProtectedPreflightContractTests(unittest.TestCase):
                 return step
         raise AssertionError(f"missing step: {name}")
 
-    def test_dispatch_requires_one_explicit_boolean_opt_in(self) -> None:
+    def test_dispatch_adds_an_optional_false_by_default_boolean_opt_in(self) -> None:
         self.assertEqual(set(self.dispatch["inputs"]), {DISPATCH_INPUT})
         option = self.dispatch["inputs"][DISPATCH_INPUT]
         self.assertEqual(option["type"], "boolean")
-        self.assertIs(option["required"], True)
+        self.assertIs(option["required"], False)
         self.assertIs(option["default"], False)
+
+    def test_inputless_upstream_ci_dispatch_remains_compatible(self) -> None:
+        source = UPSTREAM_SYNC_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("actions/workflows/ci.yml/dispatches", source)
+        self.assertIn('--data "{\\"ref\\":\\"${SYNC_BRANCH}\\"}"', source)
 
     def test_job_is_manual_main_only_and_environment_bound(self) -> None:
         job = self.jobs[JOB_ID]

--- a/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_protected_preflight_contract.py
@@ -119,14 +119,22 @@ class FloorpNotesSyncProtectedPreflightContractTests(unittest.TestCase):
         job = self.jobs[JOB_ID]
         self.assertEqual(
             set(job),
-            {"name", "if", "environment", "runs-on", "timeout-minutes", "steps"},
+            {
+                "name",
+                "if",
+                "environment",
+                "permissions",
+                "env",
+                "runs-on",
+                "timeout-minutes",
+                "steps",
+            },
         )
         self.assertNotIn("needs", job)
-        self.assertNotIn("permissions", job)
         self.assertEqual(
             [step["name"] for step in job["steps"]],
             [
-                "Check out source",
+                "Check out source anonymously",
                 "Set up Node.js",
                 "Select Xcode",
                 "Bootstrap generated sources",
@@ -148,12 +156,46 @@ class FloorpNotesSyncProtectedPreflightContractTests(unittest.TestCase):
             self.assertIn(expected, runs)
         self.assertNotRegex(runs, r"\bxcodebuild\s+test(?:\s|$)")
 
+    def test_job_uses_no_github_token_or_authenticated_source_checkout(self) -> None:
+        job = self.jobs[JOB_ID]
+        self.assertEqual(job["permissions"], {})
+        self.assertEqual(
+            job["env"],
+            {
+                "GITHUB_TOKEN": "",
+                "GH_TOKEN": "",
+                "NODE_AUTH_TOKEN": "",
+                "NPM_TOKEN": "",
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_TERMINAL_PROMPT": "0",
+                "GIT_ASKPASS": "/usr/bin/false",
+            },
+        )
+
+        checkout = self.named_step(job, "Check out source anonymously")
+        self.assertNotIn("uses", checkout)
+        self.assertIn("https://github.com/${GITHUB_REPOSITORY}.git", checkout["run"])
+        for expected in (
+            "credential.helper=",
+            "http.https://github.com/.extraheader=",
+            "GITHUB_SHA",
+        ):
+            self.assertIn(expected, checkout["run"])
+
+        setup_node = self.named_step(job, "Set up Node.js")
+        self.assertRegex(setup_node["uses"], r"@[0-9a-f]{40}$")
+        self.assertEqual(
+            setup_node["with"],
+            {
+                "node-version-file": ".nvmrc",
+                "token": "",
+                "package-manager-cache": False,
+            },
+        )
+
     def test_job_builds_only_the_unsigned_guard_selector(self) -> None:
         job = self.jobs[JOB_ID]
-        checkout = self.named_step(job, "Check out source")
-        self.assertFalse(checkout["with"]["persist-credentials"])
-        self.assertRegex(checkout["uses"], r"@[0-9a-f]{40}$")
-
         setup_node = self.named_step(job, "Set up Node.js")
         self.assertRegex(setup_node["uses"], r"@[0-9a-f]{40}$")
         self.assertEqual(
@@ -220,6 +262,10 @@ class FloorpNotesSyncProtectedPreflightContractTests(unittest.TestCase):
             "does not execute the selector",
             "does not authorize G5",
             "cannot satisfy G5 evidence",
+            "anonymous source checkout",
+            "pass a GitHub token to checkout, setup, cache, shell, or tool calls",
+            "makes no nonissuance claim",
+            "does not reference that context",
         ):
             self.assertIn(expected, contract)
 


### PR DESCRIPTION
## Summary

- add an explicit manual/main-only protected compile preflight for the Notes Sync G5 XCTest target;
- isolate an opted-in manual preflight from normal CI jobs and preserve normal CI dependencies otherwise;
- document and contract-test that this is not G5 execution, authorization, or evidence.

## Safety boundary

The job uses unsigned `xcodebuild build-for-testing` only. It has no selector execution, G5-run flags, credentials, secrets, endpoint overrides, artifact/result bundle upload, validation-clock, archive/export/signing, or G5/G6 claim. No workflow was dispatched while preparing this PR.

The current Environment has a main branch policy only; this PR does not treat it as G5 approval. Actual G5 remains externally blocked pending the separately required accounts, protected secret route, cleanup authority, and Desktop runner.

## Validation

- `python3 -m unittest discover -s scripts/ci/tests -p 'test_floorp_notes_sync_protected_preflight_contract.py'` (8 passed)
- `python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py'` (189 passed)
- `python3 -m unittest discover -s scripts/staging/tests -p 'test_floorp_notes_sync_g5_admission.py'` (7 passed)
- actionlint 1.7.12 (official darwin-arm64 digest verified)
- YAML structural dispatch-isolation assertion, SwiftLint, and `git diff --check`

Independent reviews: three final GO verdicts (no P0/P1/P2 findings) after dispatch-isolation and job/step allowlist remediation.
