### PR TITLE
test(sync): add non-live G5 launch policy

### DIFF
--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */; };
 		F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */; };
 		F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */; };
+		F20A20222F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */; };
+		F20A20322F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2818,6 +2820,8 @@
 		F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesLocalV1UITests.swift; sourceTree = "<group>"; };
 		F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncProductionQAConfigurationTests.swift; sourceTree = "<group>"; };
 		F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncTwoClientMatrixTests.swift; sourceTree = "<group>"; };
+		F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncG5LaunchPolicy.swift; sourceTree = "<group>"; };
+		F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncG5LaunchPolicyTests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13568,6 +13572,8 @@
 				F10A002B2F50000100000001 /* FloorpNotesLocalV1UITests.swift */,
 				F20A20032F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift */,
 				F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */,
+				F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */,
+				F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19612,6 +19618,8 @@
 				F10A002A2F50000100000001 /* FloorpNotesLocalV1UITests.swift in Sources */,
 				F20A20022F52000100000001 /* FloorpNotesSyncProductionQAConfigurationTests.swift in Sources */,
 				F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */,
+				F20A20222F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift in Sources */,
+				F20A20322F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncG5LaunchPolicy.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncG5LaunchPolicy.swift
@@ -1,0 +1,41 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+/// A non-live admission check for the protected G5 XCTest selector.
+///
+/// This policy only interprets serialized test-runner environment facts. It
+/// does not launch an app, contact a service, or authorize a production run.
+enum FloorpNotesSyncG5LaunchPolicy {
+    private static let requiredIntentFlags = [
+        "FLOORP_NOTES_SYNC_G5_RUN",
+        "FLOORP_NOTES_SYNC_PRODUCTION_QA",
+    ]
+
+    private static let rejectedEndpointEnvironmentKeys: Set<String> = [
+        "FIREFOX_USE_STAGE_SERVER",
+        "CUSTOM_FXA_SERVER",
+        "CUSTOM_SYNC_TOKEN_SERVER",
+        "FIREFOX_FXA_CHINA_SERVER",
+        "FIREFOX_USE_CHINA_SYNC_SERVICE",
+        "FIREFOX_FXA_CONTENT_SERVER",
+        "FIREFOX_SYNC_TOKEN_SERVER",
+        "FIREFOX_USE_CUSTOM_FXA_CONTENT_SERVER",
+        "FIREFOX_USE_CUSTOM_SYNC_TOKEN_SERVER",
+    ]
+
+    static func allows(environment: [String: String]) -> Bool {
+        guard requiredIntentFlags.allSatisfy({ environment[$0] == "1" }) else {
+            return false
+        }
+
+        let notesSyncEnvironmentKeys = environment.keys.filter {
+            $0.hasPrefix("FLOORP_NOTES_SYNC_")
+        }
+        guard Set(notesSyncEnvironmentKeys) == Set(requiredIntentFlags) else {
+            return false
+        }
+
+        return rejectedEndpointEnvironmentKeys.isDisjoint(with: Set(environment.keys))
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncG5LaunchPolicyTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncG5LaunchPolicyTests.swift
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+final class FloorpNotesSyncG5LaunchPolicyTests: XCTestCase {
+    private let allowedEnvironment = [
+        "FLOORP_NOTES_SYNC_G5_RUN": "1",
+        "FLOORP_NOTES_SYNC_PRODUCTION_QA": "1",
+    ]
+
+    func testAllowsExactlyTheTwoExplicitIntentFlags() {
+        XCTAssertTrue(FloorpNotesSyncG5LaunchPolicy.allows(environment: allowedEnvironment))
+
+        var missingIntent = allowedEnvironment
+        missingIntent.removeValue(forKey: "FLOORP_NOTES_SYNC_G5_RUN")
+        XCTAssertFalse(FloorpNotesSyncG5LaunchPolicy.allows(environment: missingIntent))
+
+        var nonLiteralIntent = allowedEnvironment
+        nonLiteralIntent["FLOORP_NOTES_SYNC_PRODUCTION_QA"] = "true"
+        XCTAssertFalse(FloorpNotesSyncG5LaunchPolicy.allows(environment: nonLiteralIntent))
+
+        var additionalIntent = allowedEnvironment
+        additionalIntent["FLOORP_NOTES_SYNC_ADDITIONAL_INTENT"] = "1"
+        XCTAssertFalse(FloorpNotesSyncG5LaunchPolicy.allows(environment: additionalIntent))
+    }
+
+    func testRejectsEachNonProductionEndpointOverride() {
+        let rejectedOverrides = [
+            "FIREFOX_USE_STAGE_SERVER",
+            "CUSTOM_FXA_SERVER",
+            "CUSTOM_SYNC_TOKEN_SERVER",
+            "FIREFOX_FXA_CHINA_SERVER",
+            "FIREFOX_USE_CHINA_SYNC_SERVICE",
+            "FIREFOX_FXA_CONTENT_SERVER",
+            "FIREFOX_SYNC_TOKEN_SERVER",
+            "FIREFOX_USE_CUSTOM_FXA_CONTENT_SERVER",
+            "FIREFOX_USE_CUSTOM_SYNC_TOKEN_SERVER",
+        ]
+
+        for override in rejectedOverrides {
+            var environment = allowedEnvironment
+            environment[override] = ""
+            XCTAssertFalse(
+                FloorpNotesSyncG5LaunchPolicy.allows(environment: environment),
+                "G5 preflight must reject \\(override) even when its value is empty."
+            )
+        }
+    }
+}

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncTwoClientMatrixTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncTwoClientMatrixTests.swift
@@ -12,17 +12,9 @@ final class FloorpNotesSyncTwoClientMatrixTests: XCTestCase {
     func testTwoClientProductionMatrix() {
         let environment = ProcessInfo.processInfo.environment
 
-        guard environment["FLOORP_NOTES_SYNC_G5_RUN"] == "1" else {
-            XCTFail("G5 preflight was not explicitly authorized.")
-            return
-        }
-        guard environment["FLOORP_NOTES_SYNC_PRODUCTION_QA"] == "1" else {
-            XCTFail("G5 preflight requires the protected production-QA route.")
-            return
-        }
-        guard environment["FIREFOX_USE_STAGE_SERVER"] == nil else {
-            XCTFail("G5 preflight rejects a staging server override.")
-            return
-        }
+        XCTAssertTrue(
+            FloorpNotesSyncG5LaunchPolicy.allows(environment: environment),
+            "G5 preflight requires only its two explicit intent flags and no endpoint override."
+        )
     }
 }

--- a/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
@@ -27,6 +27,16 @@ TEST_SOURCE = (
     / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
     "FloorpNotesSyncTwoClientMatrixTests.swift"
 )
+POLICY_SOURCE = (
+    ROOT
+    / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
+    "FloorpNotesSyncG5LaunchPolicy.swift"
+)
+POLICY_TEST_SOURCE = (
+    ROOT
+    / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
+    "FloorpNotesSyncG5LaunchPolicyTests.swift"
+)
 QA_TEST_PLAN = ROOT / "firefox-ios/firefox-ios-tests/Tests/FloorpNotesSyncQA.xctestplan"
 TEST_PLAN_DIRECTORY = ROOT / "firefox-ios/firefox-ios-tests/Tests"
 RUBY = "/usr/bin/ruby"
@@ -36,6 +46,10 @@ G5_TEST = "FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix()"
 QA_TEST = "FloorpNotesSyncProductionQAConfigurationTests/testReleaseBuildConfigurationIsExplicit()"
 G5_BUILD_FILE_ID = "F20A20122F52000100000001"
 G5_FILE_REFERENCE_ID = "F20A20132F52000100000001"
+G5_POLICY_BUILD_FILE_ID = "F20A20222F52000100000001"
+G5_POLICY_FILE_REFERENCE_ID = "F20A20232F52000100000001"
+G5_POLICY_TEST_BUILD_FILE_ID = "F20A20322F52000100000001"
+G5_POLICY_TEST_FILE_REFERENCE_ID = "F20A20332F52000100000001"
 CANONICAL_G5_ARTIFACT = "floorp-notes-sync-two-client-xcresult"
 
 
@@ -116,9 +130,13 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
         source = TEST_SOURCE.read_text(encoding="utf-8")
         self.assertIn("final class FloorpNotesSyncTwoClientMatrixTests: XCTestCase", source)
         self.assertIn("func testTwoClientProductionMatrix()", source)
-        self.assertIn("FLOORP_NOTES_SYNC_G5_RUN", source)
-        self.assertIn("FLOORP_NOTES_SYNC_PRODUCTION_QA", source)
-        self.assertIn("FIREFOX_USE_STAGE_SERVER", source)
+        self.assertIn(
+            "FloorpNotesSyncG5LaunchPolicy.allows(environment: environment)",
+            source,
+        )
+        self.assertNotIn('environment["FLOORP_NOTES_SYNC_G5_RUN"]', source)
+        self.assertNotIn('environment["FLOORP_NOTES_SYNC_PRODUCTION_QA"]', source)
+        self.assertNotIn('environment["FIREFOX_USE_STAGE_SERVER"]', source)
         for forbidden in (
             "BaseTestCase",
             "StageServer",
@@ -137,18 +155,81 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
         ):
             self.assertNotIn(forbidden, source)
 
+    def test_non_live_launch_policy_is_pure_and_fail_closed(self) -> None:
+        self.assertTrue(POLICY_SOURCE.is_file(), "the G5 selector needs a pure launch policy")
+        if not POLICY_SOURCE.is_file():
+            return
+        source = POLICY_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("enum FloorpNotesSyncG5LaunchPolicy", source)
+        self.assertIn("static func allows(environment: [String: String]) -> Bool", source)
+        for required in (
+            '"FLOORP_NOTES_SYNC_G5_RUN"',
+            '"FLOORP_NOTES_SYNC_PRODUCTION_QA"',
+            '"FIREFOX_USE_STAGE_SERVER"',
+            '"CUSTOM_FXA_SERVER"',
+            '"CUSTOM_SYNC_TOKEN_SERVER"',
+            '"FIREFOX_USE_CHINA_SYNC_SERVICE"',
+            '"FIREFOX_USE_CUSTOM_FXA_CONTENT_SERVER"',
+            '"FIREFOX_USE_CUSTOM_SYNC_TOKEN_SERVER"',
+        ):
+            self.assertIn(required, source)
+        for forbidden in (
+            "ProcessInfo",
+            "XCUIApplication",
+            "BaseTestCase",
+            "URLSession",
+            "XCTAttachment",
+            "screenshot()",
+            "debugDescription",
+            "Logger",
+            "NSLog",
+            "print(",
+            "EMAIL",
+            "PASSWORD",
+            "CREDENTIAL",
+            "SECRET",
+        ):
+            self.assertNotIn(forbidden, source)
+
+    def test_launch_policy_has_direct_xctest_coverage(self) -> None:
+        self.assertTrue(POLICY_TEST_SOURCE.is_file(), "the pure launch policy needs XCTest coverage")
+        if not POLICY_TEST_SOURCE.is_file():
+            return
+        source = POLICY_TEST_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("final class FloorpNotesSyncG5LaunchPolicyTests: XCTestCase", source)
+        self.assertIn("testAllowsExactlyTheTwoExplicitIntentFlags", source)
+        self.assertIn("testRejectsEachNonProductionEndpointOverride", source)
+        for forbidden in (
+            "XCUIApplication",
+            "BaseTestCase",
+            "XCTAttachment",
+            "screenshot()",
+            "Logger",
+            "NSLog",
+            "print(",
+            "EMAIL",
+            "PASSWORD",
+            "CREDENTIAL",
+            "SECRET",
+        ):
+            self.assertNotIn(forbidden, source)
+
     def test_source_is_wired_into_the_existing_xcui_target(self) -> None:
         project = PROJECT.read_text(encoding="utf-8")
-        self.assertIn(
-            f"{G5_BUILD_FILE_ID} /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */",
-            project,
-        )
-        self.assertIn(
-            f"{G5_FILE_REFERENCE_ID} /* FloorpNotesSyncTwoClientMatrixTests.swift */",
-            project,
-        )
-        self.assertEqual(project.count(G5_BUILD_FILE_ID), 2)
-        self.assertEqual(project.count(G5_FILE_REFERENCE_ID), 3)
+        for build_file_id, filename in (
+            (G5_BUILD_FILE_ID, "FloorpNotesSyncTwoClientMatrixTests.swift"),
+            (G5_POLICY_BUILD_FILE_ID, "FloorpNotesSyncG5LaunchPolicy.swift"),
+            (G5_POLICY_TEST_BUILD_FILE_ID, "FloorpNotesSyncG5LaunchPolicyTests.swift"),
+        ):
+            self.assertIn(f"{build_file_id} /* {filename} in Sources */", project)
+            self.assertEqual(project.count(build_file_id), 2)
+        for file_reference_id, filename in (
+            (G5_FILE_REFERENCE_ID, "FloorpNotesSyncTwoClientMatrixTests.swift"),
+            (G5_POLICY_FILE_REFERENCE_ID, "FloorpNotesSyncG5LaunchPolicy.swift"),
+            (G5_POLICY_TEST_FILE_REFERENCE_ID, "FloorpNotesSyncG5LaunchPolicyTests.swift"),
+        ):
+            self.assertIn(f"{file_reference_id} /* {filename} */", project)
+            self.assertEqual(project.count(file_reference_id), 3)
 
     def test_ordinary_unbounded_plans_explicitly_skip_the_protected_g5_selector(self) -> None:
         for plan_path in sorted(TEST_PLAN_DIRECTORY.glob("*.xctestplan")):


### PR DESCRIPTION
Adds a pure XCUITest-target launch policy for the protected G5 selector. It requires exactly the two explicit intent flags and rejects staging, custom FxA/Sync, and China endpoint override variables—even when blank.

This is a non-live admission check only. It does not launch an app, use credentials/accounts, contact FxA/Sync, perform client behavior, create artifacts, or authorize/complete G5 or G6.

Validation: G5 test-product contract 13 passed; protected-preflight 10 passed; production-QA XCTest 5 passed; full scripts/ci/tests 194 passed; SwiftLint 0 violations; git diff check passed. No Xcode, Simulator, UI, account, or workflow dispatch was used locally.