### PR TITLE
test(sync): validate canonical G5 metadata receipts

### DIFF
--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -297,7 +297,7 @@ def parse_and_validate_receipt(payload: str, *, expected_run_binding: Mapping[st
             parse_float=_reject_float,
             parse_int=_parse_safe_int,
         )
-    except (json.JSONDecodeError, TypeError) as error:
+    except (json.JSONDecodeError, TypeError, UnicodeEncodeError) as error:
         raise ReceiptError("receipt payload is not valid JSON") from error
     _require(payload_bytes == _canonical_json_bytes(receipt), "receipt JSON bytes are not canonical")
     return validate_receipt(receipt, expected_run_binding=expected_run_binding)

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -180,6 +180,7 @@ def _canonical_json_bytes(value: Any) -> bytes:
 
 
 def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
+    _require(type(value) is dict, f"{label} must be a plain JSON object")
     binding = _exact_object(
         value,
         frozenset({"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}),
@@ -194,7 +195,7 @@ def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
         f"{label} workflow is not canonical",
     )
     _require(
-        isinstance(binding["head_sha"], str) and _SHA40.fullmatch(binding["head_sha"]) is not None,
+        type(binding["head_sha"]) is str and _SHA40.fullmatch(binding["head_sha"]) is not None,
         f"{label} head SHA is invalid",
     )
     _positive_int(binding["run_id"], f"{label} run ID")
@@ -293,7 +294,7 @@ def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 def parse_and_validate_receipt(payload: str, *, expected_run_binding: Mapping[str, Any]) -> dict[str, object]:
     """Parse strict JSON then apply :func:`validate_receipt`."""
 
-    _require(isinstance(payload, str), "receipt payload must be JSON text")
+    _require(type(payload) is str, "receipt payload must be plain JSON text")
     try:
         payload_bytes = payload.encode("utf-8")
         receipt = json.loads(

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -53,6 +53,7 @@ _DANGEROUS_VALUE = re.compile(
 )
 _SHA40 = re.compile(r"[0-9a-f]{40}\Z")
 _SHA64 = re.compile(r"[0-9a-f]{64}\Z")
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
 _SAFE_POLICY_FIELD_PATHS = frozenset(
     {
         ("retention", "payload_retained"),
@@ -108,8 +109,48 @@ def _exact_object(value: Any, expected: frozenset[str], label: str) -> Mapping[s
 
 
 def _positive_int(value: Any, label: str) -> int:
-    _require(isinstance(value, int) and not isinstance(value, bool) and value > 0, f"{label} must be positive")
+    _require(
+        isinstance(value, int) and not isinstance(value, bool) and 0 < value <= _MAX_SAFE_INTEGER,
+        f"{label} must be a positive safe integer",
+    )
     return value
+
+
+def _reject_float(_: str) -> None:
+    _reject("receipt must not contain floating-point values")
+
+
+def _reject_constant(_: str) -> None:
+    _reject("receipt must not contain non-finite JSON constants")
+
+
+def _require_unicode_scalars(value: Any) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            _require_unicode_scalars(key)
+            _require_unicode_scalars(child)
+    elif isinstance(value, list):
+        for child in value:
+            _require_unicode_scalars(child)
+    elif isinstance(value, str):
+        _require(
+            all(not 0xD800 <= ord(character) <= 0xDFFF for character in value),
+            "receipt contains an unpaired Unicode surrogate",
+        )
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    _require_unicode_scalars(value)
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, UnicodeEncodeError, ValueError) as error:
+        raise ReceiptError("receipt cannot be encoded as canonical UTF-8 JSON") from error
 
 
 def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
@@ -218,7 +259,14 @@ def parse_and_validate_receipt(payload: str, *, expected_run_binding: Mapping[st
 
     _require(isinstance(payload, str), "receipt payload must be JSON text")
     try:
-        receipt = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+        payload_bytes = payload.encode("utf-8")
+        receipt = json.loads(
+            payload,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_constant,
+            parse_float=_reject_float,
+        )
     except (json.JSONDecodeError, TypeError) as error:
         raise ReceiptError("receipt payload is not valid JSON") from error
+    _require(payload_bytes == _canonical_json_bytes(receipt), "receipt JSON bytes are not canonical")
     return validate_receipt(receipt, expected_run_binding=expected_run_binding)

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -112,19 +112,28 @@ def _positive_int(value: Any, label: str) -> int:
     return value
 
 
-def _validate_run_binding(value: Any, expected: Mapping[str, Any]) -> dict[str, object]:
+def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
     binding = _exact_object(
         value,
         frozenset({"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}),
-        "run binding",
+        label,
     )
-    _require(binding["repository"] == EXPECTED_REPOSITORY, "receipt repository is not floorp-ios")
-    _require(binding["workflow_path"] == EXPECTED_WORKFLOW_PATH, "receipt workflow is not canonical")
-    _require(isinstance(binding["head_sha"], str) and _SHA40.fullmatch(binding["head_sha"]) is not None, "receipt head SHA is invalid")
-    _positive_int(binding["run_id"], "receipt run ID")
-    _positive_int(binding["run_attempt"], "receipt run attempt")
-    _require(dict(binding) == dict(expected), "receipt is not bound to the expected workflow run")
+    _require(binding["repository"] == EXPECTED_REPOSITORY, f"{label} repository is not floorp-ios")
+    _require(binding["workflow_path"] == EXPECTED_WORKFLOW_PATH, f"{label} workflow is not canonical")
+    _require(
+        isinstance(binding["head_sha"], str) and _SHA40.fullmatch(binding["head_sha"]) is not None,
+        f"{label} head SHA is invalid",
+    )
+    _positive_int(binding["run_id"], f"{label} run ID")
+    _positive_int(binding["run_attempt"], f"{label} run attempt")
     return dict(binding)
+
+
+def _validate_run_binding(value: Any, expected: Any) -> dict[str, object]:
+    binding = _canonical_run_binding(value, "receipt run binding")
+    expected_binding = _canonical_run_binding(expected, "expected run binding")
+    _require(binding == expected_binding, "receipt is not bound to the expected workflow run")
+    return binding
 
 
 def _validate_matrix(value: Any) -> None:

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -110,7 +110,7 @@ def _exact_object(value: Any, expected: frozenset[str], label: str) -> Mapping[s
 
 def _positive_int(value: Any, label: str) -> int:
     _require(
-        isinstance(value, int) and not isinstance(value, bool) and 0 < value <= _MAX_SAFE_INTEGER,
+        type(value) is int and 0 < value <= _MAX_SAFE_INTEGER,
         f"{label} must be a positive safe integer",
     )
     return value
@@ -124,33 +124,59 @@ def _reject_constant(_: str) -> None:
     _reject("receipt must not contain non-finite JSON constants")
 
 
-def _require_unicode_scalars(value: Any) -> None:
-    if isinstance(value, Mapping):
-        for key, child in value.items():
-            _require_unicode_scalars(key)
-            _require_unicode_scalars(child)
-    elif isinstance(value, list):
-        for child in value:
-            _require_unicode_scalars(child)
-    elif isinstance(value, str):
+def _parse_safe_int(value: str) -> int:
+    parsed = int(value)
+    _require(abs(parsed) <= _MAX_SAFE_INTEGER, "receipt integer exceeds the interoperable safe range")
+    return parsed
+
+
+def _validate_json_domain(value: Any) -> None:
+    if value is None or type(value) is bool:
+        return
+    if type(value) is int:
+        _require(abs(value) <= _MAX_SAFE_INTEGER, "receipt integer exceeds the interoperable safe range")
+        return
+    if type(value) is str:
         _require(
             all(not 0xD800 <= ord(character) <= 0xDFFF for character in value),
             "receipt contains an unpaired Unicode surrogate",
         )
+        return
+    if type(value) is list:
+        for child in value:
+            _validate_json_domain(child)
+        return
+    if type(value) is dict:
+        for key, child in value.items():
+            _require(type(key) is str, "receipt JSON object has a non-string key")
+            _validate_json_domain(key)
+            _validate_json_domain(child)
+        return
+    _reject(f"receipt has unsupported JSON value type {type(value).__name__}")
 
 
 def _canonical_json_bytes(value: Any) -> bytes:
-    _require_unicode_scalars(value)
-    try:
-        return json.dumps(
-            value,
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-            allow_nan=False,
-        ).encode("utf-8")
-    except (TypeError, UnicodeEncodeError, ValueError) as error:
-        raise ReceiptError("receipt cannot be encoded as canonical UTF-8 JSON") from error
+    _validate_json_domain(value)
+    if value is None:
+        return b"null"
+    if value is True:
+        return b"true"
+    if value is False:
+        return b"false"
+    if type(value) is int:
+        return str(value).encode("ascii")
+    if type(value) is str:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if type(value) is list:
+        return b"[" + b",".join(_canonical_json_bytes(child) for child in value) + b"]"
+    if type(value) is dict:
+        ordered_keys = sorted(value, key=lambda key: key.encode("utf-16-be"))
+        members = (
+            _canonical_json_bytes(key) + b":" + _canonical_json_bytes(value[key])
+            for key in ordered_keys
+        )
+        return b"{" + b",".join(members) + b"}"
+    _reject(f"receipt cannot be encoded from {type(value).__name__}")
 
 
 def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
@@ -215,7 +241,7 @@ def _validate_network(value: Any) -> None:
         _require(isinstance(host, str) and host in APPROVED_HOSTS, "network host is not approved")
         _require(host not in seen_hosts, "network hosts must not be duplicated")
         seen_hosts.add(host)
-        _require(event["port"] == 443, "network port must be 443")
+        _require(type(event["port"]) is int and event["port"] == 443, "network port must be 443")
         _require(event["tls_verified"] is True, "network TLS must be verified")
         _require(event["outcome"] == "succeeded", "network outcome is not canonical")
     _require(REQUIRED_SYNC_HOST in seen_hosts, "network evidence lacks required Sync host")
@@ -225,18 +251,22 @@ def validate_receipt(receipt: Any, *, expected_run_binding: Mapping[str, Any]) -
     """Validate a pre-retrieved canonical receipt without authorizing G5."""
 
     _reject_sensitive_values(receipt)
+    _validate_json_domain(receipt)
     root = _exact_object(
         receipt,
         frozenset({"matrix", "network", "outcomes", "retention", "run_binding", "schema_version"}),
         "G5 receipt",
     )
-    _require(root["schema_version"] == 1, "receipt schema is unsupported")
+    _require(type(root["schema_version"]) is int and root["schema_version"] == 1, "receipt schema is unsupported")
     binding = _validate_run_binding(root["run_binding"], expected_run_binding)
     _validate_matrix(root["matrix"])
     _validate_outcomes(root["outcomes"])
     _validate_network(root["network"])
     retention = _exact_object(root["retention"], frozenset({"payload_retained", "secrets_retained"}), "retention")
-    _require(retention == {"payload_retained": False, "secrets_retained": False}, "receipt retains payloads or secrets")
+    _require(
+        retention["payload_retained"] is False and retention["secrets_retained"] is False,
+        "receipt retains payloads or secrets",
+    )
     return {
         "execution_authorization": "not-granted",
         "g5_result": "not-assessed",
@@ -265,6 +295,7 @@ def parse_and_validate_receipt(payload: str, *, expected_run_binding: Mapping[st
             object_pairs_hook=_reject_duplicate_keys,
             parse_constant=_reject_constant,
             parse_float=_reject_float,
+            parse_int=_parse_safe_int,
         )
     except (json.JSONDecodeError, TypeError) as error:
         raise ReceiptError("receipt payload is not valid JSON") from error

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -1,0 +1,215 @@
+"""Fail-closed parser for canonical, metadata-only G5 execution receipts.
+
+This module only validates a receipt supplied by a separately trusted artifact
+retrieval path.  It does not authorize a run, launch clients, read credentials,
+or communicate with FxA or Sync.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping
+
+
+EXPECTED_REPOSITORY = "Floorp-Projects/floorp-ios"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-g5.yml"
+APPROVED_HOSTS = frozenset(
+    {
+        "accounts.firefox.com",
+        "api.accounts.firefox.com",
+        "oauth.accounts.firefox.com",
+        "profile.accounts.firefox.com",
+        "static.accounts.firefox.com",
+        "event-sync.services.mozilla.com",
+        "sync.services.mozilla.com",
+        "token.services.mozilla.com",
+    }
+)
+REQUIRED_SYNC_HOST = "sync.services.mozilla.com"
+_FORBIDDEN_FIELD_PARTS = frozenset(
+    {
+        "account",
+        "authorization",
+        "content",
+        "cookie",
+        "credential",
+        "email",
+        "header",
+        "key",
+        "note",
+        "password",
+        "payload",
+        "query",
+        "secret",
+        "session",
+        "token",
+        "url",
+    }
+)
+_DANGEROUS_VALUE = re.compile(
+    r"(?:[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}|://|[?#]|\b(?:authorization|bearer|oauth|token|cookie|password|credential|secret)\b)",
+    re.IGNORECASE,
+)
+_SHA40 = re.compile(r"[0-9a-f]{40}\Z")
+_SHA64 = re.compile(r"[0-9a-f]{64}\Z")
+_SAFE_POLICY_FIELD_PATHS = frozenset(
+    {
+        ("retention", "payload_retained"),
+        ("retention", "secrets_retained"),
+    }
+)
+
+
+class ReceiptError(ValueError):
+    """The receipt is not canonical, metadata-only, or bound to its run."""
+
+
+def _reject(message: str) -> None:
+    raise ReceiptError(message)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        _reject(message)
+
+
+def _field_parts(name: str) -> tuple[str, ...]:
+    expanded = re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower().replace("-", "_")
+    return tuple(part for part in expanded.split("_") if part)
+
+
+def _reject_sensitive_values(value: Any, label: str = "receipt", path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            _require(isinstance(key, str), f"{label} has a non-string field name")
+            child_path = (*path, key)
+            _require(
+                child_path in _SAFE_POLICY_FIELD_PATHS
+                or not any(part in _FORBIDDEN_FIELD_PARTS for part in _field_parts(key)),
+                f"{label} contains a credential or content-like field",
+            )
+            _reject_sensitive_values(child, label, child_path)
+    elif isinstance(value, list):
+        for child in value:
+            _reject_sensitive_values(child, label, path)
+    elif isinstance(value, str):
+        _require(
+            path == ("network", "observations", "host") and value in APPROVED_HOSTS
+            or not _DANGEROUS_VALUE.search(value),
+            f"{label} contains a dangerous value",
+        )
+
+
+def _exact_object(value: Any, expected: frozenset[str], label: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), f"{label} must be an object")
+    _require(set(value) == expected, f"{label} fields are not exact")
+    return value
+
+
+def _positive_int(value: Any, label: str) -> int:
+    _require(isinstance(value, int) and not isinstance(value, bool) and value > 0, f"{label} must be positive")
+    return value
+
+
+def _validate_run_binding(value: Any, expected: Mapping[str, Any]) -> dict[str, object]:
+    binding = _exact_object(
+        value,
+        frozenset({"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}),
+        "run binding",
+    )
+    _require(binding["repository"] == EXPECTED_REPOSITORY, "receipt repository is not floorp-ios")
+    _require(binding["workflow_path"] == EXPECTED_WORKFLOW_PATH, "receipt workflow is not canonical")
+    _require(isinstance(binding["head_sha"], str) and _SHA40.fullmatch(binding["head_sha"]) is not None, "receipt head SHA is invalid")
+    _positive_int(binding["run_id"], "receipt run ID")
+    _positive_int(binding["run_attempt"], "receipt run attempt")
+    _require(dict(binding) == dict(expected), "receipt is not bound to the expected workflow run")
+    return dict(binding)
+
+
+def _validate_matrix(value: Any) -> None:
+    matrix = _exact_object(value, frozenset({"client_slots", "fixture_digest", "status"}), "matrix")
+    _require(matrix["client_slots"] == ["client-a", "client-b"], "receipt client slots are not the exact opaque pair")
+    _require(isinstance(matrix["fixture_digest"], str) and _SHA64.fullmatch(matrix["fixture_digest"]) is not None, "fixture digest is invalid")
+    _require(matrix["status"] == "passed", "matrix did not pass")
+
+
+def _validate_outcomes(value: Any) -> None:
+    outcomes = _exact_object(
+        value,
+        frozenset(
+            {
+                "base_advanced",
+                "desktop_cleanup_verified",
+                "ios_cleanup_verified",
+                "local_only_fallback_verified",
+                "remote_cleanup_verified",
+                "rollback_verified",
+            }
+        ),
+        "outcomes",
+    )
+    _require(all(item is True for item in outcomes.values()), "receipt lacks a required rollback, fallback, or cleanup outcome")
+
+
+def _validate_network(value: Any) -> None:
+    network = _exact_object(value, frozenset({"metadata_only", "observations", "tls_interception"}), "network")
+    _require(network["metadata_only"] is True, "network evidence is not metadata-only")
+    _require(network["tls_interception"] is False, "TLS interception is forbidden")
+    observations = network["observations"]
+    _require(isinstance(observations, list) and observations, "network observations are required")
+    seen_hosts: set[str] = set()
+    for event in observations:
+        event = _exact_object(event, frozenset({"host", "outcome", "port", "tls_verified"}), "network observation")
+        host = event["host"]
+        _require(isinstance(host, str) and host in APPROVED_HOSTS, "network host is not approved")
+        _require(host not in seen_hosts, "network hosts must not be duplicated")
+        seen_hosts.add(host)
+        _require(event["port"] == 443, "network port must be 443")
+        _require(event["tls_verified"] is True, "network TLS must be verified")
+        _require(event["outcome"] == "succeeded", "network outcome is not canonical")
+    _require(REQUIRED_SYNC_HOST in seen_hosts, "network evidence lacks required Sync host")
+
+
+def validate_receipt(receipt: Any, *, expected_run_binding: Mapping[str, Any]) -> dict[str, object]:
+    """Validate a pre-retrieved canonical receipt without authorizing G5."""
+
+    _reject_sensitive_values(receipt)
+    root = _exact_object(
+        receipt,
+        frozenset({"matrix", "network", "outcomes", "retention", "run_binding", "schema_version"}),
+        "G5 receipt",
+    )
+    _require(root["schema_version"] == 1, "receipt schema is unsupported")
+    binding = _validate_run_binding(root["run_binding"], expected_run_binding)
+    _validate_matrix(root["matrix"])
+    _validate_outcomes(root["outcomes"])
+    _validate_network(root["network"])
+    retention = _exact_object(root["retention"], frozenset({"payload_retained", "secrets_retained"}), "retention")
+    _require(retention == {"payload_retained": False, "secrets_retained": False}, "receipt retains payloads or secrets")
+    return {
+        "execution_authorization": "not-granted",
+        "g5_result": "not-assessed",
+        "run_binding": binding,
+        "status": "receipt-valid",
+    }
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _reject("receipt contains a duplicate JSON field")
+        result[key] = value
+    return result
+
+
+def parse_and_validate_receipt(payload: str, *, expected_run_binding: Mapping[str, Any]) -> dict[str, object]:
+    """Parse strict JSON then apply :func:`validate_receipt`."""
+
+    _require(isinstance(payload, str), "receipt payload must be JSON text")
+    try:
+        receipt = json.loads(payload, object_pairs_hook=_reject_duplicate_keys)
+    except (json.JSONDecodeError, TypeError) as error:
+        raise ReceiptError("receipt payload is not valid JSON") from error
+    return validate_receipt(receipt, expected_run_binding=expected_run_binding)

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -185,8 +185,14 @@ def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
         frozenset({"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}),
         label,
     )
-    _require(binding["repository"] == EXPECTED_REPOSITORY, f"{label} repository is not floorp-ios")
-    _require(binding["workflow_path"] == EXPECTED_WORKFLOW_PATH, f"{label} workflow is not canonical")
+    _require(
+        type(binding["repository"]) is str and binding["repository"] == EXPECTED_REPOSITORY,
+        f"{label} repository is not floorp-ios",
+    )
+    _require(
+        type(binding["workflow_path"]) is str and binding["workflow_path"] == EXPECTED_WORKFLOW_PATH,
+        f"{label} workflow is not canonical",
+    )
     _require(
         isinstance(binding["head_sha"], str) and _SHA40.fullmatch(binding["head_sha"]) is not None,
         f"{label} head SHA is invalid",

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -75,6 +75,15 @@ def valid_receipt() -> dict[str, object]:
     }
 
 
+def canonical_payload(receipt: dict[str, object] | None = None, *, sort_keys: bool = True) -> str:
+    return json.dumps(
+        valid_receipt() if receipt is None else receipt,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=sort_keys,
+    )
+
+
 class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
     def test_accepts_exact_safe_receipt_bound_to_expected_run(self) -> None:
         receipt = valid_receipt()
@@ -88,7 +97,7 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
 
     def test_parses_only_json_without_duplicate_fields(self) -> None:
         parsed = parse_and_validate_receipt(
-            json.dumps(valid_receipt()),
+            canonical_payload(),
             expected_run_binding=expected_run_binding(),
         )
         self.assertEqual(parsed["status"], "receipt-valid")
@@ -110,10 +119,10 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                     )
 
     def test_rejects_nested_duplicate_json_fields(self) -> None:
-        payload = json.dumps(valid_receipt())
+        payload = canonical_payload()
         payload = payload.replace(
-            '"run_id": 123456789,',
-            '"run_id": 123456789, "run_id": 123456789,',
+            '"run_id":123456789,',
+            '"run_id":123456789,"run_id":123456789,',
         )
 
         with self.assertRaises(ReceiptError):
@@ -121,6 +130,44 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                 payload,
                 expected_run_binding=expected_run_binding(),
             )
+
+    def test_rejects_noncanonical_whitespace_and_key_order_bytes(self) -> None:
+        canonical = canonical_payload()
+        original = valid_receipt()
+        reordered_receipt = {"schema_version": original["schema_version"]}
+        reordered_receipt.update(
+            {key: value for key, value in original.items() if key != "schema_version"}
+        )
+        variants = (
+            canonical + "\n",
+            canonical.replace(":", ": ", 1),
+            canonical_payload(reordered_receipt, sort_keys=False),
+        )
+        for payload in variants:
+            with self.subTest(payload=payload[:48]):
+                with self.assertRaises(ReceiptError):
+                    parse_and_validate_receipt(
+                        payload,
+                        expected_run_binding=expected_run_binding(),
+                    )
+
+    def test_rejects_floats_constants_over_safe_integers_and_unpaired_surrogates(self) -> None:
+        canonical = canonical_payload()
+        payloads = (
+            canonical.replace('"run_id":123456789', '"run_id":123456789.0'),
+            canonical.replace('"run_id":123456789', '"run_id":NaN'),
+            canonical.replace('"run_id":123456789', '"run_id":Infinity'),
+            canonical.replace('"run_id":123456789', '"run_id":-Infinity'),
+            canonical.replace('"run_id":123456789', '"run_id":9007199254740992'),
+            canonical.replace('"status":"passed"', '"status":"\\ud800"'),
+        )
+        for payload in payloads:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ReceiptError):
+                    parse_and_validate_receipt(
+                        payload,
+                        expected_run_binding=expected_run_binding(),
+                    )
 
     def test_rejects_unknown_and_credential_or_content_like_fields(self) -> None:
         for path, value in (

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -124,6 +124,15 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                         expected_run_binding=expected_run_binding(),
                     )
 
+    def test_rejects_direct_python_payload_with_unpaired_surrogate(self) -> None:
+        payload = '{"invalid":"' + chr(0xD800) + '"}'
+
+        with self.assertRaises(ReceiptError):
+            parse_and_validate_receipt(
+                payload,
+                expected_run_binding=expected_run_binding(),
+            )
+
     def test_rejects_nested_duplicate_json_fields(self) -> None:
         payload = canonical_payload()
         payload = payload.replace(

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import json
 import unittest
+from collections.abc import Iterator, Mapping
 from unittest.mock import patch
 
 from scripts.staging.floorp_notes_sync_g5_receipt import (
@@ -27,6 +28,30 @@ FIXTURE_DIGEST = "b" * 64
 class AlwaysEqual:
     def __eq__(self, _: object) -> bool:
         return True
+
+
+class AlwaysEqualSha(str):
+    def __eq__(self, _: object) -> bool:
+        return True
+
+
+class CanonicalByteForgingPayload(str):
+    def encode(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
+        return str(self).rstrip("\n").encode(encoding, errors)
+
+
+class ExpectedBindingMapping(Mapping[str, object]):
+    def __init__(self, values: dict[str, object]) -> None:
+        self._values = values
+
+    def __getitem__(self, key: str) -> object:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
 
 
 def expected_run_binding() -> dict[str, object]:
@@ -117,6 +142,15 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
         with self.assertRaises(ReceiptError):
             parse_and_validate_receipt(
                 duplicate_schema,
+                expected_run_binding=expected_run_binding(),
+            )
+
+    def test_rejects_string_subclasses_that_forge_canonical_bytes(self) -> None:
+        forged = CanonicalByteForgingPayload(canonical_payload() + "\n")
+
+        with self.assertRaises(ReceiptError):
+            parse_and_validate_receipt(
+                forged,
                 expected_run_binding=expected_run_binding(),
             )
 
@@ -376,6 +410,18 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                 binding[key] = AlwaysEqual()
                 with self.assertRaises(ReceiptError):
                     validate_receipt(valid_receipt(), expected_run_binding=binding)
+
+    def test_rejects_forged_string_and_mapping_expected_run_bindings(self) -> None:
+        forged_sha = expected_run_binding()
+        forged_sha["head_sha"] = AlwaysEqualSha("c" * 40)
+
+        for binding in (
+            forged_sha,
+            ExpectedBindingMapping(expected_run_binding()),
+        ):
+            with self.subTest(binding_type=type(binding).__name__):
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(valid_receipt(), expected_run_binding=binding)  # type: ignore[arg-type]
 
     def test_rejects_unapproved_or_incomplete_network_observations(self) -> None:
         mutations = (

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -24,6 +24,11 @@ HEAD_SHA = "a" * 40
 FIXTURE_DIGEST = "b" * 64
 
 
+class AlwaysEqual:
+    def __eq__(self, _: object) -> bool:
+        return True
+
+
 def expected_run_binding() -> dict[str, object]:
     return {
         "head_sha": HEAD_SHA,
@@ -363,6 +368,14 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
             with self.subTest(binding=binding):
                 with self.assertRaises(ReceiptError):
                     validate_receipt(valid_receipt(), expected_run_binding=binding)  # type: ignore[arg-type]
+
+    def test_rejects_always_equal_repository_and_workflow_binding_values(self) -> None:
+        for key in ("repository", "workflow_path"):
+            with self.subTest(key=key):
+                binding = expected_run_binding()
+                binding[key] = AlwaysEqual()
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(valid_receipt(), expected_run_binding=binding)
 
     def test_rejects_unapproved_or_incomplete_network_observations(self) -> None:
         mutations = (

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -100,6 +100,28 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                 expected_run_binding=expected_run_binding(),
             )
 
+    def test_rejects_empty_non_json_and_non_object_payloads(self) -> None:
+        for payload in ("", "not-json", "null", "[]", "1", "true"):
+            with self.subTest(payload=payload):
+                with self.assertRaises(ReceiptError):
+                    parse_and_validate_receipt(
+                        payload,
+                        expected_run_binding=expected_run_binding(),
+                    )
+
+    def test_rejects_nested_duplicate_json_fields(self) -> None:
+        payload = json.dumps(valid_receipt())
+        payload = payload.replace(
+            '"run_id": 123456789,',
+            '"run_id": 123456789, "run_id": 123456789,',
+        )
+
+        with self.assertRaises(ReceiptError):
+            parse_and_validate_receipt(
+                payload,
+                expected_run_binding=expected_run_binding(),
+            )
+
     def test_rejects_unknown_and_credential_or_content_like_fields(self) -> None:
         for path, value in (
             (("runner",), "untrusted"),
@@ -148,10 +170,73 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                 with self.assertRaises(ReceiptError):
                     validate_receipt(receipt, expected_run_binding=expected_run_binding())
 
+    def test_rejects_malformed_uppercase_and_wrong_sha_values(self) -> None:
+        mutations = (
+            (("run_binding", "head_sha"), "A" * 40),
+            (("run_binding", "head_sha"), "a" * 39),
+            (("run_binding", "head_sha"), "g" * 40),
+            (("matrix", "fixture_digest"), "B" * 64),
+            (("matrix", "fixture_digest"), "b" * 63),
+            (("matrix", "fixture_digest"), "z" * 64),
+        )
+        for path, value in mutations:
+            with self.subTest(path=path, value=value):
+                receipt = valid_receipt()
+                receipt[path[0]][path[1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_boolean_run_binding_numbers_and_key_variations(self) -> None:
+        for path, value in (
+            (("run_binding", "run_id"), True),
+            (("run_binding", "run_attempt"), False),
+        ):
+            with self.subTest(path=path):
+                receipt = valid_receipt()
+                receipt[path[0]][path[1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+        for key, value in (("unexpected", "value"), ("workflow_path", None)):
+            with self.subTest(key=key):
+                receipt = valid_receipt()
+                if key == "workflow_path":
+                    del receipt["run_binding"][key]  # type: ignore[index]
+                else:
+                    receipt["run_binding"][key] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_invalid_or_noncanonical_expected_run_binding(self) -> None:
+        invalid_bindings = (
+            {},
+            {"head_sha": HEAD_SHA},
+            {**expected_run_binding(), "unexpected": "value"},
+            {**expected_run_binding(), "head_sha": "A" * 40},
+            {**expected_run_binding(), "run_id": True},
+            {**expected_run_binding(), "run_attempt": False},
+        )
+        for binding in invalid_bindings:
+            with self.subTest(binding=binding):
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(valid_receipt(), expected_run_binding=binding)
+
+        for binding in (None, [], 1, True):
+            with self.subTest(binding=binding):
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(valid_receipt(), expected_run_binding=binding)  # type: ignore[arg-type]
+
     def test_rejects_unapproved_or_incomplete_network_observations(self) -> None:
         mutations = (
+            ([],),
             ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 80, "tls_verified": True}],),
             ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 443, "tls_verified": False}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "failed", "port": 443, "tls_verified": True}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "pending", "port": 443, "tls_verified": True}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": True, "tls_verified": True}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": "443", "tls_verified": True}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 443, "tls_verified": 1}],),
+            ([{"host": 1, "outcome": "succeeded", "port": 443, "tls_verified": True}],),
             ([{"host": "unapproved.invalid", "outcome": "succeeded", "port": 443, "tls_verified": True}],),
             ([{"host": "accounts.firefox.com", "outcome": "succeeded", "port": 443, "tls_verified": True}],),
             ([
@@ -192,6 +277,24 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
         receipt["network"]["observations"][0]["url"] = "https://example.invalid"  # type: ignore[index]
         with self.assertRaises(ReceiptError):
             validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_extra_fields_in_each_nested_exact_object(self) -> None:
+        mutations = (
+            (("matrix", "extra"), "value"),
+            (("network", "extra"), "value"),
+            (("outcomes", "extra"), True),
+            (("retention", "extra"), False),
+            (("network", "observations", 0, "extra"), "value"),
+        )
+        for path, value in mutations:
+            with self.subTest(path=path):
+                receipt = valid_receipt()
+                target: object = receipt
+                for key in path[:-1]:
+                    target = target[key]  # type: ignore[index]
+                target[path[-1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
 
 
 if __name__ == "__main__":

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -1,0 +1,198 @@
+"""TDD contract for canonical, metadata-only G5 execution receipts.
+
+These tests cover parsing and validation only.  They neither authorize nor run
+G5, and intentionally contain no account, credential, or Notes data.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import unittest
+
+from scripts.staging.floorp_notes_sync_g5_receipt import (
+    EXPECTED_REPOSITORY,
+    EXPECTED_WORKFLOW_PATH,
+    ReceiptError,
+    parse_and_validate_receipt,
+    validate_receipt,
+)
+
+
+HEAD_SHA = "a" * 40
+FIXTURE_DIGEST = "b" * 64
+
+
+def expected_run_binding() -> dict[str, object]:
+    return {
+        "head_sha": HEAD_SHA,
+        "repository": EXPECTED_REPOSITORY,
+        "run_attempt": 1,
+        "run_id": 123456789,
+        "workflow_path": EXPECTED_WORKFLOW_PATH,
+    }
+
+
+def valid_receipt() -> dict[str, object]:
+    return {
+        "matrix": {
+            "client_slots": ["client-a", "client-b"],
+            "fixture_digest": FIXTURE_DIGEST,
+            "status": "passed",
+        },
+        "network": {
+            "metadata_only": True,
+            "observations": [
+                {
+                    "host": "accounts.firefox.com",
+                    "outcome": "succeeded",
+                    "port": 443,
+                    "tls_verified": True,
+                },
+                {
+                    "host": "sync.services.mozilla.com",
+                    "outcome": "succeeded",
+                    "port": 443,
+                    "tls_verified": True,
+                },
+            ],
+            "tls_interception": False,
+        },
+        "outcomes": {
+            "base_advanced": True,
+            "desktop_cleanup_verified": True,
+            "ios_cleanup_verified": True,
+            "local_only_fallback_verified": True,
+            "remote_cleanup_verified": True,
+            "rollback_verified": True,
+        },
+        "retention": {
+            "payload_retained": False,
+            "secrets_retained": False,
+        },
+        "run_binding": expected_run_binding(),
+        "schema_version": 1,
+    }
+
+
+class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
+    def test_accepts_exact_safe_receipt_bound_to_expected_run(self) -> None:
+        receipt = valid_receipt()
+
+        decision = validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+        self.assertEqual(decision["status"], "receipt-valid")
+        self.assertEqual(decision["execution_authorization"], "not-granted")
+        self.assertEqual(decision["g5_result"], "not-assessed")
+        self.assertEqual(decision["run_binding"], expected_run_binding())
+
+    def test_parses_only_json_without_duplicate_fields(self) -> None:
+        parsed = parse_and_validate_receipt(
+            json.dumps(valid_receipt()),
+            expected_run_binding=expected_run_binding(),
+        )
+        self.assertEqual(parsed["status"], "receipt-valid")
+
+        duplicate_schema = '{"schema_version":1,"schema_version":1}'
+        with self.assertRaises(ReceiptError):
+            parse_and_validate_receipt(
+                duplicate_schema,
+                expected_run_binding=expected_run_binding(),
+            )
+
+    def test_rejects_unknown_and_credential_or_content_like_fields(self) -> None:
+        for path, value in (
+            (("runner",), "untrusted"),
+            (("network", "authorization_header"), "none"),
+            (("matrix", "note_content"), "none"),
+            (("retention", "token_retained"), False),
+        ):
+            with self.subTest(path=path):
+                receipt = valid_receipt()
+                target: dict[str, object] = receipt
+                for key in path[:-1]:
+                    target = target[key]  # type: ignore[assignment]
+                target[path[-1]] = value
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_sensitive_or_location_like_values(self) -> None:
+        mutations = (
+            (("matrix", "status"), "Bearer opaque-value"),
+            (("matrix", "status"), "https://example.invalid"),
+            (("matrix", "status"), "passed?token=opaque"),
+            (("matrix", "status"), "passed#fragment"),
+            (("matrix", "status"), "person@example.invalid"),
+            (("run_binding", "repository"), "Floorp-Projects/floorp-ios OAuth"),
+        )
+        for path, value in mutations:
+            with self.subTest(path=path, value=value):
+                receipt = valid_receipt()
+                receipt[path[0]][path[1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_unbound_run_or_noncanonical_slots_and_outcomes(self) -> None:
+        mutations = (
+            (("run_binding", "head_sha"), "c" * 40),
+            (("run_binding", "run_id"), 0),
+            (("matrix", "client_slots"), ["client-a", "client-c"]),
+            (("matrix", "client_slots"), ["client-b", "client-a"]),
+            (("outcomes", "ios_cleanup_verified"), False),
+            (("outcomes", "remote_cleanup_verified"), False),
+        )
+        for path, value in mutations:
+            with self.subTest(path=path):
+                receipt = valid_receipt()
+                receipt[path[0]][path[1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_rejects_unapproved_or_incomplete_network_observations(self) -> None:
+        mutations = (
+            ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 80, "tls_verified": True}],),
+            ([{"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 443, "tls_verified": False}],),
+            ([{"host": "unapproved.invalid", "outcome": "succeeded", "port": 443, "tls_verified": True}],),
+            ([{"host": "accounts.firefox.com", "outcome": "succeeded", "port": 443, "tls_verified": True}],),
+            ([
+                {"host": "accounts.firefox.com", "outcome": "succeeded", "port": 443, "tls_verified": True},
+                {"host": "accounts.firefox.com", "outcome": "succeeded", "port": 443, "tls_verified": True},
+                {"host": "sync.services.mozilla.com", "outcome": "succeeded", "port": 443, "tls_verified": True},
+            ],),
+        )
+        for (observations,) in mutations:
+            with self.subTest(observations=observations):
+                receipt = valid_receipt()
+                receipt["network"]["observations"] = observations  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+    def test_accepts_approved_oauth_host_as_metadata(self) -> None:
+        receipt = valid_receipt()
+        receipt["network"]["observations"][0]["host"] = "oauth.accounts.firefox.com"  # type: ignore[index]
+
+        decision = validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+        self.assertEqual(decision["status"], "receipt-valid")
+
+    def test_rejects_tls_interception_retention_or_extra_event_fields(self) -> None:
+        for path, value in (
+            (("network", "tls_interception"), True),
+            (("network", "metadata_only"), False),
+            (("retention", "payload_retained"), True),
+            (("retention", "secrets_retained"), True),
+        ):
+            with self.subTest(path=path):
+                receipt = valid_receipt()
+                receipt[path[0]][path[1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+        receipt = copy.deepcopy(valid_receipt())
+        receipt["network"]["observations"][0]["url"] = "https://example.invalid"  # type: ignore[index]
+        with self.assertRaises(ReceiptError):
+            validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import copy
 import json
 import unittest
+from unittest.mock import patch
 
 from scripts.staging.floorp_notes_sync_g5_receipt import (
     EXPECTED_REPOSITORY,
@@ -75,13 +76,18 @@ def valid_receipt() -> dict[str, object]:
     }
 
 
-def canonical_payload(receipt: dict[str, object] | None = None, *, sort_keys: bool = True) -> str:
-    return json.dumps(
-        valid_receipt() if receipt is None else receipt,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=sort_keys,
-    )
+def canonical_payload(receipt: dict[str, object] | None = None) -> str:
+    value = valid_receipt() if receipt is None else receipt
+
+    def encode(item: object) -> str:
+        if isinstance(item, dict):
+            keys = sorted(item, key=lambda key: key.encode("utf-16-be"))
+            return "{" + ",".join(f"{encode(key)}:{encode(item[key])}" for key in keys) + "}"
+        if isinstance(item, list):
+            return "[" + ",".join(encode(child) for child in item) + "]"
+        return json.dumps(item, ensure_ascii=False, separators=(",", ":"), allow_nan=False)
+
+    return encode(value)
 
 
 class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
@@ -141,7 +147,7 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
         variants = (
             canonical + "\n",
             canonical.replace(":", ": ", 1),
-            canonical_payload(reordered_receipt, sort_keys=False),
+            json.dumps(reordered_receipt, ensure_ascii=False, separators=(",", ":")),
         )
         for payload in variants:
             with self.subTest(payload=payload[:48]):
@@ -168,6 +174,82 @@ class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
                         payload,
                         expected_run_binding=expected_run_binding(),
                     )
+
+    def test_rejects_numeric_and_boolean_type_aliases_direct_and_parsed(self) -> None:
+        direct_mutations = (
+            (("schema_version",), True),
+            (("schema_version",), 1.0),
+            (("network", "observations", 0, "port"), 443.0),
+            (("retention", "payload_retained"), 0),
+            (("retention", "payload_retained"), 0.0),
+            (("retention", "secrets_retained"), 0),
+            (("retention", "secrets_retained"), 0.0),
+            (("run_binding", "run_id"), 9_007_199_254_740_992),
+        )
+        for path, value in direct_mutations:
+            with self.subTest(path=path, value=value):
+                receipt = valid_receipt()
+                target: object = receipt
+                for key in path[:-1]:
+                    target = target[key]  # type: ignore[index]
+                target[path[-1]] = value  # type: ignore[index]
+                with self.assertRaises(ReceiptError):
+                    validate_receipt(receipt, expected_run_binding=expected_run_binding())
+
+        canonical = canonical_payload()
+        parsed_mutations = (
+            canonical.replace('"schema_version":1', '"schema_version":true'),
+            canonical.replace('"schema_version":1', '"schema_version":1.0'),
+            canonical.replace('"port":443', '"port":443.0', 1),
+            canonical.replace('"payload_retained":false', '"payload_retained":0'),
+            canonical.replace('"secrets_retained":false', '"secrets_retained":0.0'),
+            canonical.replace('"run_id":123456789', '"run_id":9007199254740992'),
+        )
+        for payload in parsed_mutations:
+            with self.subTest(payload=payload):
+                with self.assertRaises(ReceiptError):
+                    parse_and_validate_receipt(
+                        payload,
+                        expected_run_binding=expected_run_binding(),
+                    )
+
+    def test_uses_utf16be_key_order_for_canonical_receipt_bytes(self) -> None:
+        receipt = valid_receipt()
+        receipt["matrix"] = {
+            "\ue000": receipt["matrix"],
+            "😀": receipt["matrix"],
+            "client_slots": ["client-a", "client-b"],
+            "fixture_digest": FIXTURE_DIGEST,
+            "status": "passed",
+        }
+        # The added keys intentionally make this semantically invalid; canonical
+        # bytes must be checked before schema validation for this ordering proof.
+        utf16_payload = canonical_payload(receipt)
+        code_point_payload = json.dumps(
+            receipt,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        self.assertNotEqual(utf16_payload, code_point_payload)
+
+        with self.assertRaises(ReceiptError) as rejected:
+            parse_and_validate_receipt(
+                code_point_payload,
+                expected_run_binding=expected_run_binding(),
+            )
+        self.assertEqual(str(rejected.exception), "receipt JSON bytes are not canonical")
+
+        with patch(
+            "scripts.staging.floorp_notes_sync_g5_receipt.validate_receipt",
+            return_value={"status": "receipt-valid"},
+        ) as validate:
+            parsed = parse_and_validate_receipt(
+                utf16_payload,
+                expected_run_binding=expected_run_binding(),
+            )
+        self.assertEqual(parsed, {"status": "receipt-valid"})
+        validate.assert_called_once()
 
     def test_rejects_unknown_and_credential_or_content_like_fields(self) -> None:
         for path, value in (


### PR DESCRIPTION
## Summary

- add a strict, canonical, metadata-only G5 receipt validator
- bind accepted metadata to the expected repository, workflow, run, attempt, and head SHA
- reject duplicate fields, noncanonical JSON, type aliases, mutable mappings, string subclasses, sensitive fields, and unsafe network metadata

## Safety boundary

This is an unconnected parser foundation only. It does not authorize or execute G5, launch clients, retrieve artifacts, access credentials, or contact FxA or Sync. Successful validation explicitly returns execution_authorization: not-granted and g5_result: not-assessed.

## Validation

- TDD red captured for forged canonical-byte string subclasses and custom or mutable expected-run bindings.
- receipt unit suite: 22 passed.
- staging test suite: 102 passed.
- Python compile and diff check: passed.