### PR TITLE
test(sync): bind canonical receipt bytes to G5 artifacts

### DIFF
--- a/scripts/staging/floorp_notes_sync_g5_artifact_binding.py
+++ b/scripts/staging/floorp_notes_sync_g5_artifact_binding.py
@@ -7,12 +7,15 @@ network, browser, Xcode, FxA, or Sync operation.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from typing import Any, Mapping
 
 from scripts.staging.floorp_notes_sync_g5_receipt import (
     EXPECTED_REPOSITORY,
     EXPECTED_WORKFLOW_PATH,
+    ReceiptError,
+    parse_and_validate_receipt,
 )
 
 
@@ -22,9 +25,6 @@ _MAX_SAFE_INTEGER = 9_007_199_254_740_991
 _ARTIFACT_NAME = "floorp-notes-sync-two-client-xcresult"
 _RUN_BINDING_FIELDS = frozenset(
     {"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}
-)
-_RECEIPT_METADATA_FIELDS = frozenset(
-    {"execution_authorization", "g5_result", "run_binding", "status"}
 )
 _SNAPSHOT_FIELDS = frozenset(
     {
@@ -109,25 +109,15 @@ def _require_same_run(left: dict[str, object], right: dict[str, object], label: 
         _require(left[field] == right[field], f"{label} {field} does not match")
 
 
-def _validate_receipt_metadata(value: Any, expected_run_binding: Any) -> dict[str, object]:
-    metadata = _exact_plain_object(value, _RECEIPT_METADATA_FIELDS, "receipt metadata")
-    _require(
-        type(metadata["status"]) is str and metadata["status"] == "receipt-valid",
-        "receipt metadata status is not receipt-valid",
-    )
-    _require(
-        type(metadata["execution_authorization"]) is str
-        and metadata["execution_authorization"] == "not-granted",
-        "receipt metadata authorizes execution",
-    )
-    _require(
-        type(metadata["g5_result"]) is str and metadata["g5_result"] == "not-assessed",
-        "receipt metadata claims a G5 result",
-    )
-    receipt_binding = _canonical_run_binding(metadata["run_binding"], "receipt run binding")
-    expected_binding = _canonical_run_binding(expected_run_binding, "expected run binding")
-    _require_same_run(receipt_binding, expected_binding, "receipt run binding")
-    return receipt_binding
+def _validate_canonical_receipt(payload: Any, expected_run_binding: dict[str, object]) -> tuple[dict[str, object], str]:
+    _require(type(payload) is str, "receipt payload must be canonical JSON text")
+    try:
+        metadata = parse_and_validate_receipt(payload, expected_run_binding=expected_run_binding)
+    except ReceiptError as error:
+        raise ArtifactBindingError(str(error)) from error
+    binding = _canonical_run_binding(metadata["run_binding"], "receipt run binding")
+    _require_same_run(binding, expected_run_binding, "receipt run binding")
+    return binding, hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _validate_snapshot(value: Any, run_binding: dict[str, object]) -> dict[str, object]:
@@ -165,7 +155,7 @@ def _require_same_artifact(
 
 
 def validate_artifact_provenance_binding(
-    receipt_metadata: Any,
+    canonical_receipt_payload: Any,
     artifact_provenance_snapshot: Any,
     *,
     expected_artifact_binding: Mapping[str, Any],
@@ -183,9 +173,15 @@ def validate_artifact_provenance_binding(
     expected_binding = _run_binding_from_snapshot(
         _exact_plain_object(expected_artifact_binding, _SNAPSHOT_FIELDS, "expected artifact binding")
     )
-    receipt_binding = _validate_receipt_metadata(receipt_metadata, expected_binding)
+    receipt_binding, receipt_sha256 = _validate_canonical_receipt(
+        canonical_receipt_payload, expected_binding
+    )
     artifact = _validate_snapshot(artifact_provenance_snapshot, receipt_binding)
     _require_same_artifact(artifact, expected_snapshot)
+    _require(
+        artifact["receipt_member_sha256"] == receipt_sha256,
+        "artifact receipt member SHA-256 does not match canonical receipt bytes",
+    )
     return {
         "artifact_provenance": "binding-valid",
         "artifact": artifact,

--- a/scripts/staging/floorp_notes_sync_g5_artifact_binding.py
+++ b/scripts/staging/floorp_notes_sync_g5_artifact_binding.py
@@ -1,0 +1,196 @@
+"""Fail-closed, offline binding of G5 receipt metadata to artifact metadata.
+
+This module intentionally accepts only caller-supplied JSON-domain objects.  It
+does not retrieve artifacts, access credentials, authorize G5, or perform any
+network, browser, Xcode, FxA, or Sync operation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from scripts.staging.floorp_notes_sync_g5_receipt import (
+    EXPECTED_REPOSITORY,
+    EXPECTED_WORKFLOW_PATH,
+)
+
+
+_SHA40 = re.compile(r"[0-9a-f]{40}\Z")
+_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+_ARTIFACT_NAME = "floorp-notes-sync-two-client-xcresult"
+_RUN_BINDING_FIELDS = frozenset(
+    {"head_sha", "repository", "run_attempt", "run_id", "workflow_path"}
+)
+_RECEIPT_METADATA_FIELDS = frozenset(
+    {"execution_authorization", "g5_result", "run_binding", "status"}
+)
+_SNAPSHOT_FIELDS = frozenset(
+    {
+        "artifact_id",
+        "artifact_name",
+        "artifact_run_id",
+        "artifact_zip_sha256",
+        "head_sha",
+        "receipt_member_sha256",
+        "repository",
+        "run_attempt",
+        "run_id",
+        "workflow_path",
+    }
+)
+
+
+class ArtifactBindingError(ValueError):
+    """Receipt metadata or artifact snapshot is not exactly bound."""
+
+
+def _reject(message: str) -> None:
+    raise ArtifactBindingError(message)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        _reject(message)
+
+
+def _exact_plain_object(value: Any, fields: frozenset[str], label: str) -> dict[str, Any]:
+    _require(type(value) is dict, f"{label} must be a plain JSON object")
+    _require(all(type(key) is str for key in value), f"{label} has a non-string field")
+    _require(set(value) == fields, f"{label} fields are not exact")
+    return value
+
+
+def _positive_safe_int(value: Any, label: str) -> int:
+    _require(
+        type(value) is int and 0 < value <= _MAX_SAFE_INTEGER,
+        f"{label} must be a positive safe integer",
+    )
+    return value
+
+
+def _plain_sha(value: Any, length: int, label: str) -> str:
+    pattern = _SHA40 if length == 40 else _SHA256
+    _require(type(value) is str and pattern.fullmatch(value) is not None, f"{label} is invalid")
+    return value
+
+
+def _canonical_run_binding(value: Any, label: str) -> dict[str, object]:
+    binding = _exact_plain_object(value, _RUN_BINDING_FIELDS, label)
+    repository = binding["repository"]
+    workflow_path = binding["workflow_path"]
+    _require(
+        type(repository) is str and repository == EXPECTED_REPOSITORY,
+        f"{label} repository is not floorp-ios",
+    )
+    _require(
+        type(workflow_path) is str and workflow_path == EXPECTED_WORKFLOW_PATH,
+        f"{label} workflow is not canonical",
+    )
+    return {
+        "head_sha": _plain_sha(binding["head_sha"], 40, f"{label} head SHA"),
+        "repository": repository,
+        "run_attempt": _positive_safe_int(binding["run_attempt"], f"{label} run attempt"),
+        "run_id": _positive_safe_int(binding["run_id"], f"{label} run ID"),
+        "workflow_path": workflow_path,
+    }
+
+
+def _run_binding_from_snapshot(snapshot: dict[str, Any]) -> dict[str, object]:
+    return _canonical_run_binding(
+        {field: snapshot[field] for field in _RUN_BINDING_FIELDS},
+        "artifact provenance run binding",
+    )
+
+
+def _require_same_run(left: dict[str, object], right: dict[str, object], label: str) -> None:
+    for field in _RUN_BINDING_FIELDS:
+        _require(left[field] == right[field], f"{label} {field} does not match")
+
+
+def _validate_receipt_metadata(value: Any, expected_run_binding: Any) -> dict[str, object]:
+    metadata = _exact_plain_object(value, _RECEIPT_METADATA_FIELDS, "receipt metadata")
+    _require(
+        type(metadata["status"]) is str and metadata["status"] == "receipt-valid",
+        "receipt metadata status is not receipt-valid",
+    )
+    _require(
+        type(metadata["execution_authorization"]) is str
+        and metadata["execution_authorization"] == "not-granted",
+        "receipt metadata authorizes execution",
+    )
+    _require(
+        type(metadata["g5_result"]) is str and metadata["g5_result"] == "not-assessed",
+        "receipt metadata claims a G5 result",
+    )
+    receipt_binding = _canonical_run_binding(metadata["run_binding"], "receipt run binding")
+    expected_binding = _canonical_run_binding(expected_run_binding, "expected run binding")
+    _require_same_run(receipt_binding, expected_binding, "receipt run binding")
+    return receipt_binding
+
+
+def _validate_snapshot(value: Any, run_binding: dict[str, object]) -> dict[str, object]:
+    snapshot = _exact_plain_object(value, _SNAPSHOT_FIELDS, "artifact provenance snapshot")
+    _require(
+        type(snapshot["artifact_name"]) is str and snapshot["artifact_name"] == _ARTIFACT_NAME,
+        "artifact name is not canonical",
+    )
+    _positive_safe_int(snapshot["artifact_id"], "artifact ID")
+    _positive_safe_int(snapshot["artifact_run_id"], "artifact run ID")
+    snapshot_binding = _run_binding_from_snapshot(snapshot)
+    _require_same_run(snapshot_binding, run_binding, "artifact provenance snapshot")
+    _require(
+        snapshot["artifact_run_id"] == snapshot_binding["run_id"],
+        "artifact run ID does not match its run binding",
+    )
+    return {
+        "artifact_id": _positive_safe_int(snapshot["artifact_id"], "artifact ID"),
+        "artifact_name": snapshot["artifact_name"],
+        "artifact_run_id": snapshot["artifact_run_id"],
+        "artifact_zip_sha256": _plain_sha(
+            snapshot["artifact_zip_sha256"], 64, "artifact ZIP SHA-256"
+        ),
+        "receipt_member_sha256": _plain_sha(
+            snapshot["receipt_member_sha256"], 64, "receipt member SHA-256"
+        ),
+    }
+
+
+def _require_same_artifact(
+    snapshot: dict[str, object], expected_snapshot: dict[str, object]
+) -> None:
+    for field in snapshot:
+        _require(snapshot[field] == expected_snapshot[field], f"artifact provenance {field} does not match")
+
+
+def validate_artifact_provenance_binding(
+    receipt_metadata: Any,
+    artifact_provenance_snapshot: Any,
+    *,
+    expected_artifact_binding: Mapping[str, Any],
+) -> dict[str, object]:
+    """Validate metadata-only artifact binding without authorizing or running G5."""
+
+    expected_snapshot = _validate_snapshot(
+        expected_artifact_binding,
+        _run_binding_from_snapshot(
+            _exact_plain_object(
+                expected_artifact_binding, _SNAPSHOT_FIELDS, "expected artifact binding"
+            )
+        ),
+    )
+    expected_binding = _run_binding_from_snapshot(
+        _exact_plain_object(expected_artifact_binding, _SNAPSHOT_FIELDS, "expected artifact binding")
+    )
+    receipt_binding = _validate_receipt_metadata(receipt_metadata, expected_binding)
+    artifact = _validate_snapshot(artifact_provenance_snapshot, receipt_binding)
+    _require_same_artifact(artifact, expected_snapshot)
+    return {
+        "artifact_provenance": "binding-valid",
+        "artifact": artifact,
+        "execution_authorization": "not-granted",
+        "g5_result": "not-assessed",
+        "run_binding": receipt_binding,
+        "status": "artifact-binding-valid",
+    }

--- a/scripts/staging/floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/floorp_notes_sync_g5_receipt.py
@@ -13,7 +13,7 @@ from typing import Any, Mapping
 
 
 EXPECTED_REPOSITORY = "Floorp-Projects/floorp-ios"
-EXPECTED_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-g5.yml"
+EXPECTED_WORKFLOW_PATH = ".github/workflows/ci.yml"
 APPROVED_HOSTS = frozenset(
     {
         "accounts.firefox.com",

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_artifact_binding.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_artifact_binding.py
@@ -1,0 +1,224 @@
+"""TDD contract for offline G5 artifact-provenance binding.
+
+These tests validate caller-supplied metadata only.  They do not retrieve an
+artifact, authorize G5, or access any account, credential, browser, or device.
+"""
+
+from __future__ import annotations
+
+import copy
+import unittest
+from collections.abc import Iterator, Mapping
+
+from scripts.staging.floorp_notes_sync_g5_artifact_binding import (
+    ArtifactBindingError,
+    validate_artifact_provenance_binding,
+)
+from scripts.staging.floorp_notes_sync_g5_receipt import (
+    EXPECTED_REPOSITORY,
+    EXPECTED_WORKFLOW_PATH,
+)
+
+
+HEAD_SHA = "a" * 40
+ZIP_SHA256 = "b" * 64
+RECEIPT_MEMBER_SHA256 = "c" * 64
+ARTIFACT_NAME = "floorp-notes-sync-two-client-xcresult"
+
+
+class AlwaysEqual:
+    def __eq__(self, _: object) -> bool:
+        return True
+
+
+class ForgedString(str):
+    def __eq__(self, _: object) -> bool:
+        return True
+
+
+class MappingProxy(Mapping[str, object]):
+    def __init__(self, values: dict[str, object]) -> None:
+        self._values = values
+
+    def __getitem__(self, key: str) -> object:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+
+def expected_run_binding() -> dict[str, object]:
+    return {
+        "head_sha": HEAD_SHA,
+        "repository": EXPECTED_REPOSITORY,
+        "run_attempt": 1,
+        "run_id": 123456789,
+        "workflow_path": EXPECTED_WORKFLOW_PATH,
+    }
+
+
+def receipt_metadata() -> dict[str, object]:
+    return {
+        "execution_authorization": "not-granted",
+        "g5_result": "not-assessed",
+        "run_binding": expected_run_binding(),
+        "status": "receipt-valid",
+    }
+
+
+def provenance_snapshot() -> dict[str, object]:
+    return {
+        "artifact_id": 987654321,
+        "artifact_name": ARTIFACT_NAME,
+        "artifact_run_id": 123456789,
+        "artifact_zip_sha256": ZIP_SHA256,
+        "head_sha": HEAD_SHA,
+        "receipt_member_sha256": RECEIPT_MEMBER_SHA256,
+        "repository": EXPECTED_REPOSITORY,
+        "run_attempt": 1,
+        "run_id": 123456789,
+        "workflow_path": EXPECTED_WORKFLOW_PATH,
+    }
+
+
+def expected_artifact_binding() -> dict[str, object]:
+    return provenance_snapshot()
+
+
+class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
+    def test_accepts_exact_receipt_metadata_and_bound_snapshot(self) -> None:
+        decision = validate_artifact_provenance_binding(
+            receipt_metadata(),
+            provenance_snapshot(),
+            expected_artifact_binding=expected_artifact_binding(),
+        )
+
+        self.assertEqual(decision["status"], "artifact-binding-valid")
+        self.assertEqual(decision["artifact_provenance"], "binding-valid")
+        self.assertEqual(decision["execution_authorization"], "not-granted")
+        self.assertEqual(decision["g5_result"], "not-assessed")
+        self.assertEqual(decision["run_binding"], expected_run_binding())
+
+    def test_rejects_non_receipt_valid_metadata_and_extra_fields(self) -> None:
+        mutations = (
+            ("status", "g5-passed"),
+            ("execution_authorization", "granted"),
+            ("g5_result", "passed"),
+        )
+        for key, value in mutations:
+            with self.subTest(key=key):
+                metadata = receipt_metadata()
+                metadata[key] = value
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
+                    )
+
+        metadata = receipt_metadata()
+        metadata["extra"] = "value"
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
+            )
+
+    def test_rejects_wrong_artifact_identity_or_digest(self) -> None:
+        for key, value in (
+            ("artifact_name", "wrong-artifact"),
+            ("artifact_zip_sha256", "B" * 64),
+            ("artifact_zip_sha256", "b" * 63),
+            ("receipt_member_sha256", "c" * 63),
+            ("receipt_member_sha256", "d" * 64),
+            ("artifact_id", 0),
+            ("artifact_id", True),
+            ("artifact_id", 1.0),
+        ):
+            with self.subTest(key=key, value=value):
+                snapshot = provenance_snapshot()
+                snapshot[key] = value
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                    )
+
+    def test_rejects_every_run_binding_mismatch(self) -> None:
+        for key, value in (
+            ("repository", "Floorp-Projects/other"),
+            ("workflow_path", ".github/workflows/other.yml"),
+            ("run_id", 123456790),
+            ("run_attempt", 2),
+            ("head_sha", "d" * 40),
+            ("artifact_run_id", 123456790),
+        ):
+            with self.subTest(key=key):
+                snapshot = provenance_snapshot()
+                snapshot[key] = value
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                    )
+
+    def test_rejects_non_builtin_objects_and_equality_forgery(self) -> None:
+        for metadata, snapshot, expected in (
+            (MappingProxy(receipt_metadata()), provenance_snapshot(), expected_artifact_binding()),
+            (receipt_metadata(), MappingProxy(provenance_snapshot()), expected_artifact_binding()),
+            (receipt_metadata(), provenance_snapshot(), MappingProxy(expected_artifact_binding())),
+        ):
+            with self.subTest(value_type=type(metadata).__name__):
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        metadata, snapshot, expected_artifact_binding=expected  # type: ignore[arg-type]
+                    )
+
+        for container, key in (
+            ("metadata", "status"),
+            ("snapshot", "artifact_name"),
+            ("expected", "repository"),
+        ):
+            with self.subTest(container=container):
+                metadata = receipt_metadata()
+                snapshot = provenance_snapshot()
+                expected = expected_artifact_binding()
+                target = {"metadata": metadata, "snapshot": snapshot, "expected": expected}[container]
+                target[key] = ForgedString(str(target[key]))
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        metadata, snapshot, expected_artifact_binding=expected
+                    )
+
+        metadata = receipt_metadata()
+        metadata["status"] = AlwaysEqual()
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
+            )
+
+    def test_rejects_bool_int_aliases_unsafe_hashes_and_extra_snapshot_keys(self) -> None:
+        for key, value in (
+            ("run_id", True),
+            ("run_attempt", False),
+            ("artifact_run_id", True),
+            ("run_id", 9_007_199_254_740_992),
+            ("head_sha", "A" * 40),
+            ("head_sha", "x" * 40),
+        ):
+            with self.subTest(key=key, value=value):
+                snapshot = provenance_snapshot()
+                snapshot[key] = value
+                with self.assertRaises(ArtifactBindingError):
+                    validate_artifact_provenance_binding(
+                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                    )
+
+        snapshot = copy.deepcopy(provenance_snapshot())
+        snapshot["unexpected"] = "value"
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_artifact_binding.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_artifact_binding.py
@@ -7,6 +7,8 @@ artifact, authorize G5, or access any account, credential, browser, or device.
 from __future__ import annotations
 
 import copy
+import hashlib
+import json
 import unittest
 from collections.abc import Iterator, Mapping
 
@@ -18,12 +20,14 @@ from scripts.staging.floorp_notes_sync_g5_receipt import (
     EXPECTED_REPOSITORY,
     EXPECTED_WORKFLOW_PATH,
 )
+from scripts.staging.floorp_notes_sync_g5_admission import CI_WORKFLOW_PATH
 
 
 HEAD_SHA = "a" * 40
 ZIP_SHA256 = "b" * 64
-RECEIPT_MEMBER_SHA256 = "c" * 64
 ARTIFACT_NAME = "floorp-notes-sync-two-client-xcresult"
+LEGACY_G5_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-g5.yml"
+FIXTURE_DIGEST = "d" * 64
 
 
 class AlwaysEqual:
@@ -60,6 +64,44 @@ def expected_run_binding() -> dict[str, object]:
     }
 
 
+def canonical_receipt_payload(*, fixture_digest: str = FIXTURE_DIGEST) -> str:
+    receipt = {
+        "matrix": {
+            "client_slots": ["client-a", "client-b"],
+            "fixture_digest": fixture_digest,
+            "status": "passed",
+        },
+        "network": {
+            "metadata_only": True,
+            "observations": [
+                {
+                    "host": "sync.services.mozilla.com",
+                    "outcome": "succeeded",
+                    "port": 443,
+                    "tls_verified": True,
+                }
+            ],
+            "tls_interception": False,
+        },
+        "outcomes": {
+            "base_advanced": True,
+            "desktop_cleanup_verified": True,
+            "ios_cleanup_verified": True,
+            "local_only_fallback_verified": True,
+            "remote_cleanup_verified": True,
+            "rollback_verified": True,
+        },
+        "retention": {"payload_retained": False, "secrets_retained": False},
+        "run_binding": expected_run_binding(),
+        "schema_version": 1,
+    }
+    return json.dumps(receipt, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def receipt_member_sha256(*, fixture_digest: str = FIXTURE_DIGEST) -> str:
+    return hashlib.sha256(canonical_receipt_payload(fixture_digest=fixture_digest).encode("utf-8")).hexdigest()
+
+
 def receipt_metadata() -> dict[str, object]:
     return {
         "execution_authorization": "not-granted",
@@ -76,7 +118,7 @@ def provenance_snapshot() -> dict[str, object]:
         "artifact_run_id": 123456789,
         "artifact_zip_sha256": ZIP_SHA256,
         "head_sha": HEAD_SHA,
-        "receipt_member_sha256": RECEIPT_MEMBER_SHA256,
+        "receipt_member_sha256": receipt_member_sha256(),
         "repository": EXPECTED_REPOSITORY,
         "run_attempt": 1,
         "run_id": 123456789,
@@ -91,7 +133,7 @@ def expected_artifact_binding() -> dict[str, object]:
 class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
     def test_accepts_exact_receipt_metadata_and_bound_snapshot(self) -> None:
         decision = validate_artifact_provenance_binding(
-            receipt_metadata(),
+            canonical_receipt_payload(),
             provenance_snapshot(),
             expected_artifact_binding=expected_artifact_binding(),
         )
@@ -102,26 +144,19 @@ class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
         self.assertEqual(decision["g5_result"], "not-assessed")
         self.assertEqual(decision["run_binding"], expected_run_binding())
 
-    def test_rejects_non_receipt_valid_metadata_and_extra_fields(self) -> None:
-        mutations = (
-            ("status", "g5-passed"),
-            ("execution_authorization", "granted"),
-            ("g5_result", "passed"),
-        )
-        for key, value in mutations:
-            with self.subTest(key=key):
-                metadata = receipt_metadata()
-                metadata[key] = value
-                with self.assertRaises(ArtifactBindingError):
-                    validate_artifact_provenance_binding(
-                        metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
-                    )
-
-        metadata = receipt_metadata()
-        metadata["extra"] = "value"
+    def test_rejects_metadata_and_noncanonical_receipt_substitutes(self) -> None:
         with self.assertRaises(ArtifactBindingError):
             validate_artifact_provenance_binding(
-                metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
+                receipt_metadata(),
+                provenance_snapshot(),
+                expected_artifact_binding=expected_artifact_binding(),
+            )
+
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                canonical_receipt_payload() + "\n",
+                provenance_snapshot(),
+                expected_artifact_binding=expected_artifact_binding(),
             )
 
     def test_rejects_wrong_artifact_identity_or_digest(self) -> None:
@@ -140,7 +175,7 @@ class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
                 snapshot[key] = value
                 with self.assertRaises(ArtifactBindingError):
                     validate_artifact_provenance_binding(
-                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                        canonical_receipt_payload(), snapshot, expected_artifact_binding=expected_artifact_binding()
                     )
 
     def test_rejects_every_run_binding_mismatch(self) -> None:
@@ -157,14 +192,14 @@ class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
                 snapshot[key] = value
                 with self.assertRaises(ArtifactBindingError):
                     validate_artifact_provenance_binding(
-                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                        canonical_receipt_payload(), snapshot, expected_artifact_binding=expected_artifact_binding()
                     )
 
     def test_rejects_non_builtin_objects_and_equality_forgery(self) -> None:
         for metadata, snapshot, expected in (
             (MappingProxy(receipt_metadata()), provenance_snapshot(), expected_artifact_binding()),
-            (receipt_metadata(), MappingProxy(provenance_snapshot()), expected_artifact_binding()),
-            (receipt_metadata(), provenance_snapshot(), MappingProxy(expected_artifact_binding())),
+            (canonical_receipt_payload(), MappingProxy(provenance_snapshot()), expected_artifact_binding()),
+            (canonical_receipt_payload(), provenance_snapshot(), MappingProxy(expected_artifact_binding())),
         ):
             with self.subTest(value_type=type(metadata).__name__):
                 with self.assertRaises(ArtifactBindingError):
@@ -178,18 +213,20 @@ class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
             ("expected", "repository"),
         ):
             with self.subTest(container=container):
-                metadata = receipt_metadata()
+                metadata: object = canonical_receipt_payload()
                 snapshot = provenance_snapshot()
                 expected = expected_artifact_binding()
-                target = {"metadata": metadata, "snapshot": snapshot, "expected": expected}[container]
-                target[key] = ForgedString(str(target[key]))
+                if container == "metadata":
+                    metadata = ForgedString(str(metadata))
+                else:
+                    target = {"snapshot": snapshot, "expected": expected}[container]
+                    target[key] = ForgedString(str(target[key]))
                 with self.assertRaises(ArtifactBindingError):
                     validate_artifact_provenance_binding(
                         metadata, snapshot, expected_artifact_binding=expected
                     )
 
-        metadata = receipt_metadata()
-        metadata["status"] = AlwaysEqual()
+        metadata = AlwaysEqual()
         with self.assertRaises(ArtifactBindingError):
             validate_artifact_provenance_binding(
                 metadata, provenance_snapshot(), expected_artifact_binding=expected_artifact_binding()
@@ -209,14 +246,45 @@ class FloorpNotesSyncG5ArtifactBindingTests(unittest.TestCase):
                 snapshot[key] = value
                 with self.assertRaises(ArtifactBindingError):
                     validate_artifact_provenance_binding(
-                        receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                        canonical_receipt_payload(), snapshot, expected_artifact_binding=expected_artifact_binding()
                     )
 
         snapshot = copy.deepcopy(provenance_snapshot())
         snapshot["unexpected"] = "value"
         with self.assertRaises(ArtifactBindingError):
             validate_artifact_provenance_binding(
-                receipt_metadata(), snapshot, expected_artifact_binding=expected_artifact_binding()
+                canonical_receipt_payload(), snapshot, expected_artifact_binding=expected_artifact_binding()
+            )
+
+    def test_binds_receipt_digest_to_canonical_payload_and_rejects_legacy_workflow(self) -> None:
+        self.assertEqual(EXPECTED_WORKFLOW_PATH, CI_WORKFLOW_PATH)
+        self.assertEqual(CI_WORKFLOW_PATH, ".github/workflows/ci.yml")
+
+        altered_payload = canonical_receipt_payload(fixture_digest="e" * 64)
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                altered_payload,
+                provenance_snapshot(),
+                expected_artifact_binding=expected_artifact_binding(),
+            )
+
+        snapshot = provenance_snapshot()
+        expected = expected_artifact_binding()
+        snapshot["receipt_member_sha256"] = "f" * 64
+        expected["receipt_member_sha256"] = "f" * 64
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                canonical_receipt_payload(), snapshot, expected_artifact_binding=expected
+            )
+
+        legacy_payload = canonical_receipt_payload().replace(
+            CI_WORKFLOW_PATH, LEGACY_G5_WORKFLOW_PATH
+        )
+        with self.assertRaises(ArtifactBindingError):
+            validate_artifact_provenance_binding(
+                legacy_payload,
+                provenance_snapshot(),
+                expected_artifact_binding=expected_artifact_binding(),
             )
 
 

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_receipt.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
+import sys
 import unittest
 from collections.abc import Iterator, Mapping
+from pathlib import Path
 from unittest.mock import patch
 
 from scripts.staging.floorp_notes_sync_g5_receipt import (
@@ -19,10 +22,12 @@ from scripts.staging.floorp_notes_sync_g5_receipt import (
     parse_and_validate_receipt,
     validate_receipt,
 )
+from scripts.staging.floorp_notes_sync_g5_admission import CI_WORKFLOW_PATH
 
 
 HEAD_SHA = "a" * 40
 FIXTURE_DIGEST = "b" * 64
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
 class AlwaysEqual:
@@ -121,6 +126,40 @@ def canonical_payload(receipt: dict[str, object] | None = None) -> str:
 
 
 class FloorpNotesSyncG5ReceiptTests(unittest.TestCase):
+    def test_receipt_import_does_not_initialize_the_admission_loader(self) -> None:
+        source = "\n".join(
+            (
+                "import sys",
+                f"sys.path.insert(0, {str(REPOSITORY_ROOT)!r})",
+                "import scripts.staging.floorp_notes_sync_g5_receipt",
+                "assert 'scripts.staging.floorp_notes_sync_g5_admission' not in sys.modules",
+            )
+        )
+        result = subprocess.run(
+            [sys.executable, "-B", "-c", source],
+            capture_output=True,
+            env={"PATH": "/usr/bin:/bin", "PYTHONDONTWRITEBYTECODE": "1"},
+            stdin=subprocess.DEVNULL,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_binds_g5_receipts_to_the_release_validator_workflow(self) -> None:
+        self.assertEqual(EXPECTED_WORKFLOW_PATH, CI_WORKFLOW_PATH)
+        self.assertEqual(CI_WORKFLOW_PATH, ".github/workflows/ci.yml")
+
+        legacy = expected_run_binding()
+        legacy["workflow_path"] = ".github/workflows/floorp-notes-sync-g5.yml"
+        with self.assertRaises(ReceiptError):
+            validate_receipt(valid_receipt(), expected_run_binding=legacy)
+
+        legacy_receipt = valid_receipt()
+        legacy_receipt["run_binding"]["workflow_path"] = (
+            ".github/workflows/floorp-notes-sync-g5.yml"
+        )
+        with self.assertRaises(ReceiptError):
+            validate_receipt(legacy_receipt, expected_run_binding=expected_run_binding())
+
     def test_accepts_exact_safe_receipt_bound_to_expected_run(self) -> None:
         receipt = valid_receipt()
 


### PR DESCRIPTION
## What changed

- Corrected the G5 receipt workflow binding to the actual release workflow, `.github/workflows/ci.yml`.
- Kept receipt runtime imports pure; tests alone compare the local literal with the admission/release-validator constant and prove the admission loader is not initialized.
- Made artifact provenance validation parse canonical receipt bytes and bind `receipt_member_sha256` to the SHA-256 of those exact bytes.

## Why

Independent review found that the prior workflow path was stale and that a snapshot digest was only syntactically checked rather than cryptographically tied to the receipt payload.

## Safety boundary

This is offline validation code only. It does not access credentials, accounts, FxA, Sync, browser, Xcode, network, artifacts, or authorize/run G5.

## Validation

- receipt and artifact-binding tests: 31 passing
- full staging suite: 111 passing
- CI scripts suite: 202 passing
- G5 admission and two-client preflight suite: 14 passing
- final security diff scan: 0 findings
