### PR TITLE
test(sync): add fail-closed actual G5 selector

### DIFF
--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -146,6 +146,13 @@ without executing its protected selector. This compile-only output has no
 production-QA authorization, credentials, artifact upload, or operational evidence and
 cannot satisfy G5 evidence.
 
+`FloorpNotesSyncActualG5TwoClientTests` is compiled into `XCUITests` so the
+future evidence selector has a stable product identity. Until the external
+driver, disposable protected runner, cleanup receipt, metadata-only network
+record, and fresh G1-G4 inputs are admitted together, that selector is
+unconditionally skipped with `UPSTREAM_ARTIFACT_MISSING`. It does not inspect
+environment values, launch an app, contact a service, or access credentials.
+
 The protected manual preflight is a `workflow_dispatch` job restricted to
 `main` and the `floorp-notes-sync-production-qa` Environment. It compiles the
 guard selector with `build-for-testing`; it does not execute the selector,

--- a/firefox-ios/Client.xcodeproj/project.pbxproj
+++ b/firefox-ios/Client.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */; };
 		F20A20222F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */; };
 		F20A20322F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */; };
+		F20A20422F52000100000001 /* FloorpNotesSyncActualG5TwoClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20A20432F52000100000001 /* FloorpNotesSyncActualG5TwoClientTests.swift */; };
 		032CE5F62EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032CE5F52EBA0C04007CCC0D /* ToUExperiencePointsCalculatorTests.swift */; };
 		033A5FCC2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A5FCB2E5F001200A84E8A /* TermsOfUseTelemetryTests.swift */; };
 		033A62002E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A61FF2E77FE9900A84E8A /* ResetTermsOfServiceAcceptancePage.swift */; };
@@ -2822,6 +2823,7 @@
 		F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncTwoClientMatrixTests.swift; sourceTree = "<group>"; };
 		F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncG5LaunchPolicy.swift; sourceTree = "<group>"; };
 		F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncG5LaunchPolicyTests.swift; sourceTree = "<group>"; };
+		F20A20432F52000100000001 /* FloorpNotesSyncActualG5TwoClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloorpNotesSyncActualG5TwoClientTests.swift; sourceTree = "<group>"; };
 		001348F79CA80B94DCD3E535 /* km */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = km; path = km.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		00218A431FC749D7BC8EC05D /* homepageStoryCategoriesOn.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = homepageStoryCategoriesOn.json; sourceTree = "<group>"; };
 		003141C6B19507C79B6C399C /* ga */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ga; path = ga.lproj/Menu.strings; sourceTree = "<group>"; };
@@ -13574,6 +13576,7 @@
 				F20A20132F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift */,
 				F20A20232F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift */,
 				F20A20332F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift */,
+				F20A20432F52000100000001 /* FloorpNotesSyncActualG5TwoClientTests.swift */,
 				5FEB88322D6F5E4A00ECE6B1 /* A11yHomePageTests.swift */,
 				5F7C8A032D09A62A00C9F89D /* A11yOnboardingTests.swift */,
 				5FACA10F2D099DCD00B289BC /* A11ySearchTest.swift */,
@@ -19620,6 +19623,7 @@
 				F20A20122F52000100000001 /* FloorpNotesSyncTwoClientMatrixTests.swift in Sources */,
 				F20A20222F52000100000001 /* FloorpNotesSyncG5LaunchPolicy.swift in Sources */,
 				F20A20322F52000100000001 /* FloorpNotesSyncG5LaunchPolicyTests.swift in Sources */,
+				F20A20422F52000100000001 /* FloorpNotesSyncActualG5TwoClientTests.swift in Sources */,
 				2CA16FDE1E5F089100332277 /* SearchTest.swift in Sources */,
 				8A9F0B5827C59E1800FE09AE /* ImageIdentifiers.swift in Sources */,
 				EDDC4F732F68697E00E0B8FA /* ModernKitOnboardingTests.swift in Sources */,

--- a/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/AccessibilityTestPlan.xctestplan
@@ -504,7 +504,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/ExperimentIntegrationTests.xctestplan
@@ -232,7 +232,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FullFunctionalTestPlan.xctestplan
@@ -358,7 +358,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/PerformanceTestPlan.xctestplan
@@ -174,7 +174,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/Smoketest.xctestplan
@@ -664,7 +664,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/SyncIntegrationTestPlan.xctestplan
@@ -195,7 +195,8 @@
         "ZoomingTestsTAE\/testZoomingActions()",
         "ZoomingTestsTAE\/testZoomingActionsLandscape_tabTrayExperimentOff()",
         "FloorpNotesSyncProductionQAConfigurationTests\/testReleaseBuildConfigurationIsExplicit()",
-        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()"
+        "FloorpNotesSyncTwoClientMatrixTests\/testTwoClientProductionMatrix()",
+        "FloorpNotesSyncActualG5TwoClientTests\/testActualG5TwoClientProductionMatrix()"
       ],
       "target" : {
         "containerPath" : "container:Client.xcodeproj",

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncActualG5TwoClientTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/FloorpNotesSyncActualG5TwoClientTests.swift
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+@MainActor
+final class FloorpNotesSyncActualG5TwoClientTests: XCTestCase {
+    func testActualG5TwoClientProductionMatrix() throws {
+        throw XCTSkip(
+            "UPSTREAM_ARTIFACT_MISSING: actual G5 requires an admitted external driver."
+        )
+    }
+}

--- a/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_g5_test_product_contract.py
@@ -27,6 +27,11 @@ TEST_SOURCE = (
     / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
     "FloorpNotesSyncTwoClientMatrixTests.swift"
 )
+ACTUAL_TEST_SOURCE = (
+    ROOT
+    / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
+    "FloorpNotesSyncActualG5TwoClientTests.swift"
+)
 POLICY_SOURCE = (
     ROOT
     / "firefox-ios/firefox-ios-tests/Tests/XCUITests/"
@@ -56,6 +61,8 @@ G5_POLICY_BUILD_FILE_ID = "F20A20222F52000100000001"
 G5_POLICY_FILE_REFERENCE_ID = "F20A20232F52000100000001"
 G5_POLICY_TEST_BUILD_FILE_ID = "F20A20322F52000100000001"
 G5_POLICY_TEST_FILE_REFERENCE_ID = "F20A20332F52000100000001"
+ACTUAL_G5_BUILD_FILE_ID = "F20A20422F52000100000001"
+ACTUAL_G5_FILE_REFERENCE_ID = "F20A20432F52000100000001"
 CANONICAL_G5_ARTIFACT = "floorp-notes-sync-two-client-xcresult"
 
 
@@ -229,6 +236,7 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
             (G5_BUILD_FILE_ID, "FloorpNotesSyncTwoClientMatrixTests.swift"),
             (G5_POLICY_BUILD_FILE_ID, "FloorpNotesSyncG5LaunchPolicy.swift"),
             (G5_POLICY_TEST_BUILD_FILE_ID, "FloorpNotesSyncG5LaunchPolicyTests.swift"),
+            (ACTUAL_G5_BUILD_FILE_ID, "FloorpNotesSyncActualG5TwoClientTests.swift"),
         ):
             self.assertIn(f"{build_file_id} /* {filename} in Sources */", project)
             self.assertEqual(project.count(build_file_id), 2)
@@ -236,29 +244,59 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
             (G5_FILE_REFERENCE_ID, "FloorpNotesSyncTwoClientMatrixTests.swift"),
             (G5_POLICY_FILE_REFERENCE_ID, "FloorpNotesSyncG5LaunchPolicy.swift"),
             (G5_POLICY_TEST_FILE_REFERENCE_ID, "FloorpNotesSyncG5LaunchPolicyTests.swift"),
+            (ACTUAL_G5_FILE_REFERENCE_ID, "FloorpNotesSyncActualG5TwoClientTests.swift"),
         ):
             self.assertIn(f"{file_reference_id} /* {filename} */", project)
             self.assertEqual(project.count(file_reference_id), 3)
+
+    def test_actual_selector_is_compiled_but_fails_closed_before_runner_admission(self) -> None:
+        self.assertTrue(ACTUAL_TEST_SOURCE.is_file(), "the actual G5 selector must exist in XCUITests")
+        if not ACTUAL_TEST_SOURCE.is_file():
+            return
+        source = ACTUAL_TEST_SOURCE.read_text(encoding="utf-8")
+        self.assertIn("final class FloorpNotesSyncActualG5TwoClientTests: XCTestCase", source)
+        self.assertIn("func testActualG5TwoClientProductionMatrix()", source)
+        self.assertIn("throw XCTSkip(", source)
+        self.assertIn("UPSTREAM_ARTIFACT_MISSING", source)
+        for forbidden in (
+            "ProcessInfo",
+            "XCUIApplication",
+            "BaseTestCase",
+            "URLSession",
+            "XCTAttachment",
+            "screenshot()",
+            "debugDescription",
+            "Logger",
+            "NSLog",
+            "print(",
+            "EMAIL",
+            "PASSWORD",
+            "TOKEN",
+            "CREDENTIAL",
+            "SECRET",
+        ):
+            self.assertNotIn(forbidden, source)
 
     def test_ordinary_unbounded_plans_explicitly_skip_the_protected_g5_selector(self) -> None:
         for plan_path in sorted(TEST_PLAN_DIRECTORY.glob("*.xctestplan")):
             if plan_path == TEST_PLAN:
                 continue
             plan = json.loads(plan_path.read_text(encoding="utf-8"))
-            self.assertNotIn(
-                ACTUAL_G5_TEST,
-                json.dumps(plan, sort_keys=True),
-                f"{plan_path.name} must not reserve the future actual G5 test",
-            )
             for target in plan["testTargets"]:
                 if target["target"].get("name") != "XCUITests":
                     continue
+                self.assertNotIn(
+                    ACTUAL_G5_TEST,
+                    target.get("selectedTests", []),
+                    f"{plan_path.name} must not select the future actual G5 test",
+                )
                 if "selectedTests" not in target:
-                    self.assertIn(
-                        STATIC_G5_TEST,
-                        target.get("skippedTests", []),
-                        f"{plan_path.name} could execute the protected G5 XCTest",
-                    )
+                    for protected_test in (STATIC_G5_TEST, ACTUAL_G5_TEST):
+                        self.assertIn(
+                            protected_test,
+                            target.get("skippedTests", []),
+                            f"{plan_path.name} could execute a protected G5 XCTest",
+                        )
 
     def test_existing_production_qa_plan_remains_configuration_only(self) -> None:
         plan = json.loads(QA_TEST_PLAN.read_text(encoding="utf-8"))
@@ -331,6 +369,7 @@ class FloorpNotesSyncG5TestProductContractTests(unittest.TestCase):
         self.assertIn("without executing its protected selector", source)
         self.assertIn("cannot satisfy G5 evidence", source)
         self.assertIn(ACTUAL_G5_TEST, source)
+        self.assertIn("unconditionally skipped", source)
         self.assertIn("static preflight selector", source)
         self.assertRegex(source, r"external driver is\s+the coordinator")
         self.assertIn("metadata-only participant", source)


### PR DESCRIPTION
## Summary

- compile a reserved actual-G5 two-client XCTest that unconditionally skips until an external driver and protected runner are admitted
- exclude both protected G5 selectors from ordinary unbounded XCUITest plans
- enforce the boundary through contract tests and document the non-operational state

## Validation

- `python3 -m unittest scripts.ci.tests.test_floorp_notes_sync_g5_test_product_contract`
- `python3 -m unittest discover -s scripts/ci/tests -p "test_*.py"`
- `python3 -m unittest discover -s scripts/staging/tests -p "test_*.py"`
- strict SwiftLint for the added XCTest
- unsigned `xcodebuild build-for-testing` for the release G5 route

No actual G5 execution, FxA credential access, Sync operation, app launch, or simulator test run was performed.