### PR TITLE
test(sync): bridge owner-pinned G5 admission boundary

### DIFF
--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -245,6 +245,25 @@ manifest's `previous_manifest_sha256` against the currently accepted external
 record before replacing either artifact. This static loader does not install a
 trust bundle or establish a broker, runner, lease, cleanup, or G5 result.
 
+`scripts/staging/floorp_notes_sync_g5_broker_admission.py` is the next,
+metadata-only connection between those two static controls. Its sole public
+entry point accepts one canonical signed admission envelope plus expected
+run/release bindings and a broker-provided trusted clock. It reloads the fixed
+owner-pinned trust source on every call, then immediately passes that freshly
+loaded bundle to the existing driver-admission verifier. It accepts no caller
+supplied trust bundle, prior loader result, path, signature verifier, SSH
+executable, execution callback, or force/override flag. Even after both
+checks succeed, it returns exactly `execution_authorization: not-granted` and
+`g5_result: not-assessed`; it deliberately discards the validation metadata so
+this library cannot become an execution capability or a G5 receipt.
+
+The bridge is not the future root-owned broker. An eventual Operations-owned
+broker must install and invoke its reviewed code from a root-controlled
+location, supply a separately trusted clock, atomically manage the external
+high-water record, provide the isolated runner lease and credential boundary,
+and retain independently verified cleanup evidence. Repository code and a
+workflow checkout never substitute for those controls.
+
 The eventual runner must be an ephemeral runner in a dedicated restricted
 runner group, under a dedicated OS account and an expiring lease. It must be
 destroyed after the operation, with an independent watchdog responsible for

--- a/scripts/staging/floorp_notes_sync_g5_broker_admission.py
+++ b/scripts/staging/floorp_notes_sync_g5_broker_admission.py
@@ -1,0 +1,134 @@
+"""Fail-closed bridge from fixed owner trust to driver-admission verification.
+
+This is a metadata-only library boundary for a future root-owned broker.  It
+always reloads the fixed owner-pinned trust source, verifies one canonical
+driver-admission envelope against that source, and returns no execution
+capability.  It never starts a runner or client, accesses credentials, or
+contacts any service.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from scripts.staging.floorp_notes_sync_g5_driver_admission import (
+    DriverAdmissionError as _DriverAdmissionError,
+    validate_driver_admission as _validate_driver_admission,
+)
+from scripts.staging.floorp_notes_sync_g5_owner_trust import (
+    OwnerTrustError as _OwnerTrustError,
+    load_owner_pinned_driver_trust as _load_owner_pinned_driver_trust,
+)
+
+
+PINNED_SSH_KEYGEN = Path("/usr/bin/ssh-keygen")
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_OWNER_TRUST_KEYS = frozenset(
+    {
+        "driver_key_fingerprint",
+        "driver_login",
+        "execution_authorization",
+        "g5_result",
+        "status",
+        "trust_bundle",
+        "trust_manifest_sha256",
+        "trust_version",
+    }
+)
+_DRIVER_DECISION_KEYS = frozenset(
+    {
+        "admission_digest_sha256",
+        "driver_binary_sha256",
+        "execution_authorization",
+        "g5_result",
+        "release_binding",
+        "run_binding",
+        "status",
+    }
+)
+_TRUST_BUNDLE_KEYS = frozenset({"allowed_signers", "driver_registry", "revocations"})
+
+
+class BrokerAdmissionError(ValueError):
+    """Owner-pinned broker admission is unavailable, invalid, or noncanonical."""
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise BrokerAdmissionError(message)
+
+
+def _load_fixed_owner_trust(*, trusted_now: datetime) -> Mapping[str, object]:
+    try:
+        loaded = _load_owner_pinned_driver_trust(trusted_now=trusted_now)
+    except _OwnerTrustError as error:
+        raise BrokerAdmissionError("owner-pinned driver trust was rejected") from error
+    _require(type(loaded) is dict, "owner-pinned driver trust result is malformed")
+    _require(set(loaded) == _OWNER_TRUST_KEYS, "owner-pinned driver trust result has unexpected fields")
+    _require(
+        loaded["status"] == "owner-pinned-driver-trust-valid",
+        "owner-pinned driver trust result is not valid",
+    )
+    _require(
+        loaded["execution_authorization"] == "not-granted",
+        "owner-pinned driver trust must not grant execution",
+    )
+    _require(loaded["g5_result"] == "not-assessed", "owner-pinned driver trust must not claim G5")
+    _require(type(loaded["driver_login"]) is str and bool(loaded["driver_login"]), "driver login is invalid")
+    _require(
+        type(loaded["driver_key_fingerprint"]) is str and bool(loaded["driver_key_fingerprint"]),
+        "driver key fingerprint is invalid",
+    )
+    _require(
+        type(loaded["trust_manifest_sha256"]) is str
+        and SHA256.fullmatch(loaded["trust_manifest_sha256"]) is not None,
+        "owner-pinned trust manifest digest is invalid",
+    )
+    _require(
+        type(loaded["trust_version"]) is int and loaded["trust_version"] > 0,
+        "owner-pinned trust version is invalid",
+    )
+    bundle = loaded["trust_bundle"]
+    _require(type(bundle) is dict and set(bundle) == _TRUST_BUNDLE_KEYS, "owner-pinned trust bundle is malformed")
+    _require(all(type(value) is bytes and bool(value) for value in bundle.values()), "owner-pinned trust bytes are invalid")
+    return loaded
+
+
+def verify_broker_admission(
+    raw_admission: bytes,
+    *,
+    expected_run_binding: Mapping[str, Any],
+    expected_release_binding: Mapping[str, Any],
+    trusted_now: datetime,
+) -> dict[str, str]:
+    """Verify a canonical admission against freshly loaded fixed owner trust.
+
+    No caller may provide a trust bundle, path, signature verifier, or callback.
+    A valid metadata check still leaves execution and G5 assessment unavailable.
+    """
+
+    owner_trust = _load_fixed_owner_trust(trusted_now=trusted_now)
+    bundle = owner_trust["trust_bundle"]
+    assert type(bundle) is dict
+    try:
+        decision = _validate_driver_admission(
+            raw_admission,
+            trust_bundle=bundle,
+            expected_run_binding=expected_run_binding,
+            expected_release_binding=expected_release_binding,
+            trusted_now=trusted_now,
+            ssh_keygen=PINNED_SSH_KEYGEN,
+        )
+    except _DriverAdmissionError as error:
+        raise BrokerAdmissionError("driver admission was rejected") from error
+    _require(type(decision) is dict and set(decision) == _DRIVER_DECISION_KEYS, "driver admission result is malformed")
+    _require(decision["status"] == "driver-admission-valid", "driver admission result is not valid")
+    _require(decision["execution_authorization"] == "not-granted", "driver admission must not grant execution")
+    _require(decision["g5_result"] == "not-assessed", "driver admission must not claim G5")
+    return {
+        "execution_authorization": "not-granted",
+        "g5_result": "not-assessed",
+    }

--- a/scripts/staging/tests/test_floorp_notes_sync_g5_broker_admission.py
+++ b/scripts/staging/tests/test_floorp_notes_sync_g5_broker_admission.py
@@ -1,0 +1,358 @@
+"""TDD contract for the non-executing owner-pinned G5 broker admission bridge.
+
+All keys and trust files below are generated in private temporary directories.
+The suite never accesses accounts or credentials, launches a runner/client, or
+authorizes G5.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import inspect
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+from scripts.staging import floorp_notes_sync_g5_driver_admission as driver_admission
+from scripts.staging import floorp_notes_sync_g5_owner_trust as owner_trust
+
+
+ROOT = Path(__file__).resolve().parents[3]
+BROKER_MODULE_PATH = ROOT / "scripts/staging/floorp_notes_sync_g5_broker_admission.py"
+SSH_KEYGEN = Path("/usr/bin/ssh-keygen")
+TRUSTED_NOW = datetime(2026, 8, 15, 12, 0, 0, tzinfo=timezone.utc)
+EXPIRY = datetime(2026, 8, 15, 12, 30, 0, tzinfo=timezone.utc)
+HEAD_SHA = "a" * 40
+G1_G4_DIGEST = "b" * 64
+RELEASE_INPUTS_DIGEST = "c" * 64
+DRIVER_BINARY_DIGEST = "d" * 64
+
+
+class FloorpNotesSyncG5BrokerAdmissionTests(unittest.TestCase):
+    def load_broker_module(self) -> Any | None:
+        self.assertTrue(BROKER_MODULE_PATH.is_file(), "owner-pinned broker admission bridge is missing")
+        if not BROKER_MODULE_PATH.is_file():
+            return None
+        specification = importlib.util.spec_from_file_location(
+            "floorp_notes_sync_g5_broker_admission_test", BROKER_MODULE_PATH
+        )
+        self.assertIsNotNone(specification)
+        assert specification is not None
+        self.assertIsNotNone(specification.loader)
+        assert specification.loader is not None
+        module = importlib.util.module_from_spec(specification)
+        specification.loader.exec_module(module)
+        return module
+
+    @staticmethod
+    def run_command(command: list[str]) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(command, capture_output=True, check=False)
+
+    def create_test_signer(self, directory: Path, name: str) -> tuple[Path, str, str, str]:
+        self.assertTrue(SSH_KEYGEN.is_file(), "the pinned ssh-keygen executable is unavailable")
+        private_key = directory / name
+        generated = self.run_command(
+            [str(SSH_KEYGEN), "-q", "-t", "ed25519", "-N", "", "-f", str(private_key)]
+        )
+        self.assertEqual(generated.returncode, 0, generated.stderr.decode("utf-8", "replace"))
+        fields = private_key.with_suffix(".pub").read_text(encoding="utf-8").split()
+        self.assertGreaterEqual(len(fields), 2)
+        fingerprint = self.run_command([str(SSH_KEYGEN), "-lf", str(private_key.with_suffix(".pub"))])
+        self.assertEqual(fingerprint.returncode, 0, fingerprint.stderr.decode("utf-8", "replace"))
+        parsed = fingerprint.stdout.decode("utf-8", "replace").split()
+        self.assertGreaterEqual(len(parsed), 2)
+        return private_key, fields[0], fields[1], parsed[1]
+
+    @staticmethod
+    def sha256(value: bytes) -> str:
+        return hashlib.sha256(value).hexdigest()
+
+    @staticmethod
+    def expected_run_binding() -> dict[str, object]:
+        return {
+            "head_sha": HEAD_SHA,
+            "repository": "Floorp-Projects/floorp-ios",
+            "run_attempt": 1,
+            "run_id": 123456789,
+            "workflow_path": ".github/workflows/ci.yml",
+        }
+
+    @staticmethod
+    def expected_release_binding() -> dict[str, object]:
+        return {
+            "g1_g4_digest_sha256": G1_G4_DIGEST,
+            "release_inputs_sha256": RELEASE_INPUTS_DIGEST,
+        }
+
+    def install_owner_bundle(self, root: Path, high_water_path: Path) -> dict[str, object]:
+        root.mkdir(mode=0o700)
+        owner_key, owner_type, owner_value, owner_fingerprint = self.create_test_signer(root, "owner")
+        driver_key, driver_type, driver_value, driver_fingerprint = self.create_test_signer(root, "driver")
+        owner_allowed_signers = f"owner-login {owner_type} {owner_value}\n".encode("ascii")
+        driver_allowed_signers = f"driver-login {driver_type} {driver_value}\n".encode("ascii")
+        driver_registry = owner_trust.canonical_bytes(
+            {
+                "driver_registry": [
+                    {
+                        "authority": "ephemeral-test-authority",
+                        "key_fingerprint": driver_fingerprint,
+                        "login": "driver-login",
+                        "role": "driver-admission",
+                    }
+                ],
+                "schema_version": 1,
+            }
+        )
+        revocations = b'{"revocations":[],"schema_version":1}'
+        (root / "owner-allowed-signers").write_bytes(owner_allowed_signers)
+        (root / "allowed-signers").write_bytes(driver_allowed_signers)
+        (root / "driver-registry.json").write_bytes(driver_registry)
+        (root / "revocations.json").write_bytes(revocations)
+        manifest: dict[str, object] = {
+            "authority_domain": owner_trust.AUTHORITY_DOMAIN,
+            "driver_signer": {
+                "key_fingerprint": driver_fingerprint,
+                "login": "driver-login",
+            },
+            "expires_at": "2026-08-15T12:30:00Z",
+            "files": {
+                "allowed_signers_sha256": self.sha256(driver_allowed_signers),
+                "driver_registry_sha256": self.sha256(driver_registry),
+                "revocations_sha256": self.sha256(revocations),
+            },
+            "issued_at": "2026-08-15T12:00:00Z",
+            "owner": {
+                "key_fingerprint": owner_fingerprint,
+                "login": "owner-login",
+                "role": owner_trust.OWNER_ROLE,
+            },
+            "previous_manifest_sha256": None,
+            "schema_version": 1,
+            "version": 1,
+        }
+        manifest_path = root / "manifest.json"
+        manifest_path.write_bytes(owner_trust.canonical_bytes(manifest))
+        signed = self.run_command(
+            [
+                str(SSH_KEYGEN),
+                "-Y",
+                "sign",
+                "-f",
+                str(owner_key),
+                "-n",
+                owner_trust.OWNER_NAMESPACE,
+                str(manifest_path),
+            ]
+        )
+        self.assertEqual(signed.returncode, 0, signed.stderr.decode("utf-8", "replace"))
+        signature_path = manifest_path.with_suffix(".json.sig")
+        self.assertTrue(signature_path.is_file(), "owner trust signature was not produced")
+        (root / "manifest.sig").write_bytes(signature_path.read_bytes())
+        high_water_path.parent.mkdir(mode=0o700)
+        high_water_path.write_bytes(
+            owner_trust.canonical_bytes(
+                {
+                    "manifest_sha256": self.sha256(manifest_path.read_bytes()),
+                    "schema_version": 1,
+                    "version": 1,
+                }
+            )
+        )
+        return {
+            "driver_fingerprint": driver_fingerprint,
+            "driver_key": driver_key,
+        }
+
+    def make_signed_admission(self, directory: Path, driver_key: Path, driver_fingerprint: str) -> bytes:
+        payload: dict[str, object] = {
+            "driver": {
+                "binary_sha256": DRIVER_BINARY_DIGEST,
+                "interface": driver_admission.EXPECTED_DRIVER_INTERFACE,
+            },
+            "lease": {
+                "ephemeral": True,
+                "expires_at": "2026-08-15T12:30:00Z",
+                "id": "g5-driver-lease-0123456789abcdef",
+                "issued_at": "2026-08-15T12:00:00Z",
+                "watchdog_cleanup_required": True,
+            },
+            "release": self.expected_release_binding(),
+            "run_binding": self.expected_run_binding(),
+            "schema_version": 1,
+            "signer": {
+                "github_login": "driver-login",
+                "key_fingerprint": driver_fingerprint,
+                "role": driver_admission.DRIVER_ROLE,
+            },
+        }
+        payload_path = directory / "driver-admission.json"
+        payload_path.write_bytes(driver_admission.canonical_bytes(payload))
+        signed = self.run_command(
+            [
+                str(SSH_KEYGEN),
+                "-Y",
+                "sign",
+                "-f",
+                str(driver_key),
+                "-n",
+                driver_admission.NAMESPACE,
+                str(payload_path),
+            ]
+        )
+        self.assertEqual(signed.returncode, 0, signed.stderr.decode("utf-8", "replace"))
+        envelope = {
+            "payload": payload,
+            "signature": payload_path.with_suffix(".json.sig").read_text(encoding="ascii"),
+        }
+        return driver_admission.canonical_bytes(envelope)
+
+    @staticmethod
+    def root_loader(root: Path, high_water_path: Path) -> Any:
+        def load(*, trusted_now: datetime) -> dict[str, object]:
+            return owner_trust._load_owner_pinned_driver_trust_from_root(
+                root,
+                high_water_path=high_water_path,
+                trusted_now=trusted_now,
+                ssh_keygen=SSH_KEYGEN,
+                required_owner_uid=os.geteuid(),
+            )
+
+        return load
+
+    def test_bridge_reloads_fixed_owner_trust_and_returns_exact_non_grant(self) -> None:
+        broker = self.load_broker_module()
+        if broker is None:
+            return
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            root = directory / "driver-trust"
+            high_water_path = directory / "state" / "driver-trust-high-water.json"
+            installed = self.install_owner_bundle(root, high_water_path)
+            raw = self.make_signed_admission(directory, installed["driver_key"], installed["driver_fingerprint"])
+            loader = self.root_loader(root, high_water_path)
+            with mock.patch.object(broker, "_load_owner_pinned_driver_trust", side_effect=loader) as patched:
+                decision = broker.verify_broker_admission(
+                    raw,
+                    expected_run_binding=self.expected_run_binding(),
+                    expected_release_binding=self.expected_release_binding(),
+                    trusted_now=TRUSTED_NOW,
+                )
+        self.assertEqual(
+            decision,
+            {
+                "execution_authorization": "not-granted",
+                "g5_result": "not-assessed",
+            },
+        )
+        patched.assert_called_once_with(trusted_now=TRUSTED_NOW)
+
+    def test_bridge_reloads_trust_on_each_call_and_rejects_expiry(self) -> None:
+        broker = self.load_broker_module()
+        if broker is None:
+            return
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            root = directory / "driver-trust"
+            high_water_path = directory / "state" / "driver-trust-high-water.json"
+            installed = self.install_owner_bundle(root, high_water_path)
+            raw = self.make_signed_admission(directory, installed["driver_key"], installed["driver_fingerprint"])
+            loader = self.root_loader(root, high_water_path)
+            with mock.patch.object(broker, "_load_owner_pinned_driver_trust", side_effect=loader) as patched:
+                broker.verify_broker_admission(
+                    raw,
+                    expected_run_binding=self.expected_run_binding(),
+                    expected_release_binding=self.expected_release_binding(),
+                    trusted_now=TRUSTED_NOW,
+                )
+                with self.assertRaises(broker.BrokerAdmissionError):
+                    broker.verify_broker_admission(
+                        raw,
+                        expected_run_binding=self.expected_run_binding(),
+                        expected_release_binding=self.expected_release_binding(),
+                        trusted_now=EXPIRY,
+                    )
+        self.assertEqual(patched.call_count, 2)
+        self.assertEqual(patched.call_args_list[1].kwargs, {"trusted_now": EXPIRY})
+
+    def test_bridge_rejects_wrong_bindings_noncanonical_input_and_invalid_loader_result(self) -> None:
+        broker = self.load_broker_module()
+        if broker is None:
+            return
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            root = directory / "driver-trust"
+            high_water_path = directory / "state" / "driver-trust-high-water.json"
+            installed = self.install_owner_bundle(root, high_water_path)
+            raw = self.make_signed_admission(directory, installed["driver_key"], installed["driver_fingerprint"])
+            loader = self.root_loader(root, high_water_path)
+            bad_run = self.expected_run_binding()
+            bad_run["head_sha"] = "e" * 40
+            bad_release = self.expected_release_binding()
+            bad_release["g1_g4_digest_sha256"] = "f" * 64
+            with mock.patch.object(broker, "_load_owner_pinned_driver_trust", side_effect=loader):
+                for candidate, run, release in (
+                    (raw + b" ", self.expected_run_binding(), self.expected_release_binding()),
+                    (raw, bad_run, self.expected_release_binding()),
+                    (raw, self.expected_run_binding(), bad_release),
+                ):
+                    with self.subTest(candidate=candidate[:16]):
+                        with self.assertRaises(broker.BrokerAdmissionError):
+                            broker.verify_broker_admission(
+                                candidate,
+                                expected_run_binding=run,
+                                expected_release_binding=release,
+                                trusted_now=TRUSTED_NOW,
+                            )
+
+            def invalid_loader(*, trusted_now: datetime) -> dict[str, object]:
+                result = loader(trusted_now=trusted_now)
+                invalid = copy.deepcopy(result)
+                invalid["execution_authorization"] = "granted"
+                return invalid
+
+            with mock.patch.object(broker, "_load_owner_pinned_driver_trust", side_effect=invalid_loader):
+                with self.assertRaises(broker.BrokerAdmissionError):
+                    broker.verify_broker_admission(
+                        raw,
+                        expected_run_binding=self.expected_run_binding(),
+                        expected_release_binding=self.expected_release_binding(),
+                        trusted_now=TRUSTED_NOW,
+                    )
+
+    def test_public_api_has_no_caller_supplied_trust_or_execution_capability(self) -> None:
+        broker = self.load_broker_module()
+        if broker is None:
+            return
+        parameters = set(inspect.signature(broker.verify_broker_admission).parameters)
+        self.assertEqual(
+            parameters,
+            {"raw_admission", "expected_run_binding", "expected_release_binding", "trusted_now"},
+        )
+        self.assertFalse(hasattr(broker, "load_owner_pinned_driver_trust"))
+        self.assertFalse(hasattr(broker, "validate_driver_admission"))
+        source = BROKER_MODULE_PATH.read_text(encoding="utf-8")
+        for forbidden in (
+            "importlib",
+            "subprocess",
+            "xcodebuild",
+            "simctl",
+            "socket",
+            "urllib",
+            "requests",
+            "os.system",
+        ):
+            self.assertNotIn(forbidden, source)
+        self.assertIn("_load_owner_pinned_driver_trust", source)
+        self.assertIn("_validate_driver_admission", source)
+        self.assertNotIn("def main", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds a metadata-only bridge that reloads fixed owner-pinned driver trust for every admission verification
- keeps owner-loader and driver-verifier imports private, pins the verifier executable path, and returns only non-authorizing/non-G5 fields
- adds temporary-key contract tests and documents why this is not the future root-owned broker

## Safety scope

This PR performs no actual G5 operation and adds no FxA login, credential, runner, client, network, or process-execution path. It cannot satisfy the Todo 20 production gate.

## Validation

- focused broker-admission tests: 4 passed
- staging suite after the final API-surface correction: 130 passed
- CI contract suite after the final API-surface correction: 212 passed
- final Codex Security diff scan: complete, 0 findings
- independent API-boundary review: APPROVE

## Remaining blocker

Actual G5 remains blocked on the separately owned root broker/trust bundle, isolated runner, and fresh G1-G5/G6 evidence.