### PR TITLE
fix(sync): single shallow fetch and main-tree audit commit binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -951,9 +951,10 @@ jobs:
           base_oid="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["base"]["sha"])' "$root/pr.json")"
           head_oid="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["head"]["sha"])' "$root/pr.json")"
           merged_oid="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["merge_commit_sha"])' "$root/pr.json")"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin "$base_oid" "$head_oid"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT"
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
+          # A single shallow fetch keeps the boundary file consistent; the
+          # immutable commits are compared against the exact head/merged trees.
+          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin \
+            "$base_oid" "$head_oid" "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT" "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT^{commit}"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_MERGE_AUDIT_COMMIT^{commit}"
           printf "%s\n" "$FLOORP_TODO20_OWNER_REVIEW_JSON" > "$root/owner-review.json"

--- a/scripts/ci/capture-floorp-notes-sync-review-receipt.py
+++ b/scripts/ci/capture-floorp-notes-sync-review-receipt.py
@@ -939,7 +939,7 @@ def main(arguments: list[str] | None = None) -> int:
         )
         verify_immutable_merge_audit_commit(
             args.repository_root, args.merge_audit_commit, merge_raw,
-            args.merged_oid,
+            os.environ["GITHUB_SHA"],
         )
         if merge["schema_version"] == 2:
             validate_github_audit_log(audit, audit_raw, merge, pr, args.merged_oid)


### PR DESCRIPTION
Follow-up to PR #109: combine the four immutable-ref shallow fetches into one command (shallow-file race) and bind the immutable merge-audit commit tree comparison to the current checkout tree instead of the historical PR merge commit.