### PR TITLE
fix(sync): fetch merged OID for squash-child verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
           # A single shallow fetch keeps the boundary file consistent; the
           # immutable commits are compared against the exact head/merged trees.
           git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin \
-            "$base_oid" "$head_oid" "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT" "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
+            "$base_oid" "$head_oid" "$merged_oid" "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT" "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT^{commit}"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_MERGE_AUDIT_COMMIT^{commit}"
           printf "%s\n" "$FLOORP_TODO20_OWNER_REVIEW_JSON" > "$root/owner-review.json"


### PR DESCRIPTION
The owner-waived enablement run failed at the review-receipt capture: verify_merged_parent needs the merged OID object (c8e370192e), which the runner never fetched. Add it to the single shallow fetch.