### PR TITLE
fix(sync): fetch depth 2 so the merged OID parent is visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,7 +953,7 @@ jobs:
           merged_oid="$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["merge_commit_sha"])' "$root/pr.json")"
           # A single shallow fetch keeps the boundary file consistent; the
           # immutable commits are compared against the exact head/merged trees.
-          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=1 origin \
+          git -C "$GITHUB_WORKSPACE" fetch --no-tags --depth=2 origin \
             "$base_oid" "$head_oid" "$merged_oid" "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT" "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT^{commit}"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_MERGE_AUDIT_COMMIT^{commit}"


### PR DESCRIPTION
The owner-waived enablement run failed the squash-child verification: a depth=1 shallow fetch of the merged OID hides its parent. Use depth=2 in the single fetch.