### PR TITLE
fix(ci): authenticate protected ruleset reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,6 +931,7 @@ jobs:
           curl --fail --silent --show-error --location --retry 3 \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/rulesets/20229460" \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $FLOORP_TODO20_GH_AUDIT_TOKEN" \
             -o "$root/ruleset.json"
           /opt/homebrew/bin/gh api --paginate --slurp \
             "orgs/Floorp-Projects/audit-log?phrase=repo%3AFloorp-Projects%2Ffloorp-ios&per_page=100" \
@@ -1161,6 +1162,7 @@ jobs:
           curl --fail --silent --show-error --location --retry 3 \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/rulesets/20229460" \
             -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $FLOORP_TODO20_GH_AUDIT_TOKEN" \
             -o "$qa_root/ruleset.json"
           /opt/homebrew/bin/gh api --paginate --slurp \
             "orgs/Floorp-Projects/audit-log?phrase=repo%3AFloorp-Projects%2Ffloorp-ios&per_page=100" \

--- a/scripts/ci/tests/test_floorp_notes_sync_t20_rescope_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_t20_rescope_contract.py
@@ -163,6 +163,23 @@ class FloorpNotesSyncT20RescopeContractTests(unittest.TestCase):
         self.assertNotIn("testflight", enablement_text)
         self.assertNotIn("root-owned-broker", serialized)
 
+    def test_source_bound_receipts_authenticate_protected_ruleset_reads(self) -> None:
+        for job_id, step_name in (
+            (
+                "notes-sync-production-enablement-waived",
+                "Capture source-bound review evidence and create waived enablement record",
+            ),
+            ("notes-sync-production-qa", "Capture source-bound Todo 20 review receipt"),
+        ):
+            job = self.jobs[job_id]
+            step = next(item for item in job["steps"] if item.get("name") == step_name)
+            run = step["run"]
+            self.assertIn(
+                '-H "Authorization: Bearer $FLOORP_TODO20_GH_AUDIT_TOKEN"',
+                run,
+                f"{job_id} must authenticate its protected ruleset read",
+            )
+
     def test_workflow_keeps_normal_ci_and_public_release_disabled(self) -> None:
         serialized = json.dumps(self.workflow, sort_keys=True).lower()
         self.assertNotIn("app store", serialized)


### PR DESCRIPTION
Todo 20 follow-up fix for the owner-waived production Sync enablement gate.

The protected ruleset endpoint is not public; the two source-bound receipt capture steps now send the existing protected Environment audit token as a Bearer header. The checked-in contract test prevents regression.

No ruleset policy, merge path, Sync implementation, credentials, test accounts, or release behavior is changed. Live desktop/mobile QA remains owner-approved and not performed; no no-data-loss or real-Sync reliability claim is made.