### PR TITLE
ci: explicitly waive Todo 20 owner review gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,7 +836,7 @@ jobs:
       FLOORP_DESKTOP_COMMIT: 8462074ce18ab63d9be4def199b33de1d6bb554a
       FLOORP_TODO20_PR_NUMBER: ${{ vars.FLOORP_TODO20_PR_NUMBER }}
       FLOORP_TODO20_GUARDED_MERGE_RUN_ID: ${{ vars.FLOORP_TODO20_GUARDED_MERGE_RUN_ID }}
-      FLOORP_TODO20_OWNER_REVIEW_JSON: ${{ vars.FLOORP_TODO20_OWNER_REVIEW_JSON }}
+      FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON: ${{ vars.FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON }}
       FLOORP_TODO20_MERGE_AUDIT_COMMIT: ${{ vars.FLOORP_TODO20_MERGE_AUDIT_COMMIT }}
       FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT: ${{ vars.FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT }}
       FLOORP_TODO20_OWNER_AUDIT_WAIVER_JSON: ${{ vars.FLOORP_TODO20_OWNER_AUDIT_WAIVER_JSON }}
@@ -870,7 +870,10 @@ jobs:
           }
           test -n "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
           test -n "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT"
-          test -n "$FLOORP_TODO20_OWNER_REVIEW_JSON"
+          test -n "$FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON" || {
+            printf '%s\n' '[blocked] AUTHORIZATION_MISSING owner=Operations reason=owner_review_gate_waiver_missing resume=populate protected Environment variable FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON; owner review is explicitly waived and must not be recorded as successful' >&2
+            exit 78
+          }
           test -n "$FLOORP_TODO20_LIVE_QA_WAIVER_JSON" || {
             printf '%s\n' '[blocked] AUTHORIZATION_MISSING owner=Operations reason=live_qa_waiver_missing resume=populate protected Environment variable FLOORP_TODO20_LIVE_QA_WAIVER_JSON with the owner live-QA waiver receipt' >&2
             exit 78
@@ -958,7 +961,7 @@ jobs:
             "$base_oid" "$head_oid" "$merged_oid" "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT" "$FLOORP_TODO20_MERGE_AUDIT_COMMIT"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_SUBAGENT_REVIEW_COMMIT^{commit}"
           git -C "$GITHUB_WORKSPACE" cat-file -e "$FLOORP_TODO20_MERGE_AUDIT_COMMIT^{commit}"
-          printf "%s\n" "$FLOORP_TODO20_OWNER_REVIEW_JSON" > "$root/owner-review.json"
+          printf "%s\n" "$FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON" > "$root/owner-review-waiver.json"
           test -f "$root/guarded-merge-artifact/merge-audit.json"
           test -f "$root/guarded-merge-artifact/merge-operation-receipt.json"
           /usr/bin/python3 -I scripts/ci/verify-floorp-notes-sync-guarded-merge-artifact.py \
@@ -989,7 +992,7 @@ jobs:
             --desktop-sha "$FLOORP_DESKTOP_COMMIT" \
             --contract scripts/ci/floorp-notes-sync-g5-operation-contract.json \
             --plan-binding docs/floorp-notes-sync-todo20-plan-binding.json \
-            --owner-review "$root/owner-review.json" \
+            --owner-review-waiver "$root/owner-review-waiver.json" \
             --merge-audit "$root/merge-audit.json" \
             --merge-audit-commit "$FLOORP_TODO20_MERGE_AUDIT_COMMIT" \
             --audit-json "$root/audit-log.json" \

--- a/docs/floorp-notes-sync-todo20-plan-binding.json
+++ b/docs/floorp-notes-sync-todo20-plan-binding.json
@@ -1,1 +1,1 @@
-{"amendment_sha256":"cdc0b13eba78c2de78518e219c5d808d34be89d59b3a0b8c89da873a19ccfc95","combined_plan_hash":"593674e786e1690541ca2e69ba7cc2c506cd01f77fc7f1f06a958044b63e2957","plan_sha256":"d9721f22d46acd7ffef4298cfdd386dafe5116337f9657855ff7f07bfbff465c","schema_version":1,"task_id":20}
+{"amendment_sha256":"75047ff9e51d3fe945af095e2039df1c902b670ba8c16a0007163fe88f09feb3","combined_plan_hash":"c6cee96fd8bf9c0d4c8123fa3d1ee9d8d0528a0a074b64eb323e0bdbcad73e96","plan_sha256":"c88ef779accd83baf6e351da9315f4de622ab9ccfcaacd9efede09607f633abc","schema_version":1,"task_id":20}

--- a/docs/floorp-notes-sync-todo20-plan-binding.json
+++ b/docs/floorp-notes-sync-todo20-plan-binding.json
@@ -1,1 +1,1 @@
-{"amendment_sha256":"a9fd931541d8f12804ac42b21f81675b2fdadccdf9e33118f170982141536e53","combined_plan_hash":"b01196854beeea6664a7686dd4575eef7e0b8e54a4a64cc2cedfef737cd20d32","plan_sha256":"3abcd567e26cecf35c9d8f900aeed4a1918bf5ca875a0c0751344eb4311cc1f0","schema_version":1,"task_id":20}
+{"amendment_sha256":"cdc0b13eba78c2de78518e219c5d808d34be89d59b3a0b8c89da873a19ccfc95","combined_plan_hash":"593674e786e1690541ca2e69ba7cc2c506cd01f77fc7f1f06a958044b63e2957","plan_sha256":"d9721f22d46acd7ffef4298cfdd386dafe5116337f9657855ff7f07bfbff465c","schema_version":1,"task_id":20}

--- a/docs/floorp-notes-sync-todo20-subagent-review.json
+++ b/docs/floorp-notes-sync-todo20-subagent-review.json
@@ -1,0 +1,1 @@
+{"desktop_sha":"8462074ce18ab63d9be4def199b33de1d6bb554a","findings":[],"head_sha":"21934791087b14edc5ea8e38af7f90a6278084ee","independence":true,"repository":"Floorp-Projects/floorp-ios","review_method":"codex-read-only-diff","reviewed_at_utc":"2026-08-18T15:42:53Z","reviewer_id":"751715b2-3b95-49d6-a75e-17a8d9e2dfeb","schema_version":1,"status":"GO"}

--- a/docs/floorp-notes-sync-todo20-subagent-review.json
+++ b/docs/floorp-notes-sync-todo20-subagent-review.json
@@ -1,1 +1,0 @@
-{"desktop_sha":"8462074ce18ab63d9be4def199b33de1d6bb554a","findings":[],"head_sha":"21934791087b14edc5ea8e38af7f90a6278084ee","independence":true,"repository":"Floorp-Projects/floorp-ios","review_method":"codex-read-only-diff","reviewed_at_utc":"2026-08-18T15:42:53Z","reviewer_id":"751715b2-3b95-49d6-a75e-17a8d9e2dfeb","schema_version":1,"status":"GO"}

--- a/scripts/ci/capture-floorp-notes-sync-review-receipt.py
+++ b/scripts/ci/capture-floorp-notes-sync-review-receipt.py
@@ -459,6 +459,7 @@ def validate_owner_review(
 
 OWNER_REVIEW_WAIVER_FIELDS = {
     "approved_at_utc",
+    "historical_merge_audit_plan_hash",
     "operator_id",
     "owner_review_performed",
     "plan_hash",
@@ -475,6 +476,8 @@ def validate_owner_review_waiver(
     require_exact(waiver, OWNER_REVIEW_WAIVER_FIELDS, "owner review waiver")
     if (
         waiver["schema_version"] != 1
+        or not isinstance(waiver["historical_merge_audit_plan_hash"], str)
+        or waiver["historical_merge_audit_plan_hash"] == binding["combined_plan_hash"]
         or not isinstance(waiver["operator_id"], str)
         or not waiver["operator_id"]
         or (
@@ -491,6 +494,11 @@ def validate_owner_review_waiver(
     ):
         raise ReviewReceiptError("owner review gate waiver is stale or incomplete")
     require_sha(waiver["plan_hash"], SHA256, "owner review waiver plan hash")
+    require_sha(
+        waiver["historical_merge_audit_plan_hash"],
+        SHA256,
+        "historical merge-audit plan hash",
+    )
     reject_sensitive(waiver, "owner review waiver")
 
 
@@ -510,6 +518,7 @@ def owner_context_from_waiver(
         "combined_plan_hash": binding["combined_plan_hash"],
         "diff_sha256": diff_sha256,
         "head_sha": pr["head"]["sha"],
+        "historical_merge_audit_plan_hash": waiver["historical_merge_audit_plan_hash"],
         "independence": False,
         "desktop_sha": desktop_sha,
         "operator_id": waiver["operator_id"],
@@ -607,7 +616,11 @@ def validate_merge_audit(
             or merge["waiver_operator_id"] != owner["operator_id"]
             or not isinstance(merge["waiver_approved_at_utc"], str)
             or not merge["waiver_approved_at_utc"].endswith("Z")
-            or merge["waiver_plan_hash"] != binding["combined_plan_hash"]
+            or merge["waiver_plan_hash"]
+            not in {
+                binding["combined_plan_hash"],
+                owner.get("historical_merge_audit_plan_hash"),
+            }
         ):
             raise ReviewReceiptError("merge audit waiver is not bound to the owner waiver and plan binding")
 

--- a/scripts/ci/capture-floorp-notes-sync-review-receipt.py
+++ b/scripts/ci/capture-floorp-notes-sync-review-receipt.py
@@ -457,6 +457,73 @@ def validate_owner_review(
         raise ReviewReceiptError("owner review is stale or incomplete")
 
 
+OWNER_REVIEW_WAIVER_FIELDS = {
+    "approved_at_utc",
+    "operator_id",
+    "owner_review_performed",
+    "plan_hash",
+    "schema_version",
+    "statement",
+    "waiver_scope",
+}
+
+
+def validate_owner_review_waiver(
+    waiver: dict[str, Any],
+    binding: dict[str, Any],
+) -> None:
+    require_exact(waiver, OWNER_REVIEW_WAIVER_FIELDS, "owner review waiver")
+    if (
+        waiver["schema_version"] != 1
+        or not isinstance(waiver["operator_id"], str)
+        or not waiver["operator_id"]
+        or (
+            os.environ.get("GITHUB_ACTOR")
+            and waiver["operator_id"] != os.environ["GITHUB_ACTOR"]
+        )
+        or waiver["owner_review_performed"] is not False
+        or waiver["plan_hash"] != binding["combined_plan_hash"]
+        or not isinstance(waiver["approved_at_utc"], str)
+        or not waiver["approved_at_utc"].endswith("Z")
+        or waiver["waiver_scope"] != "todo20-owner-review-gate"
+        or not isinstance(waiver["statement"], str)
+        or not waiver["statement"]
+    ):
+        raise ReviewReceiptError("owner review gate waiver is stale or incomplete")
+    require_sha(waiver["plan_hash"], SHA256, "owner review waiver plan hash")
+    reject_sensitive(waiver, "owner review waiver")
+
+
+def owner_context_from_waiver(
+    waiver: dict[str, Any],
+    pr: dict[str, Any],
+    binding: dict[str, Any],
+    diff_sha256: str,
+    desktop_sha: str,
+) -> dict[str, Any]:
+    """Create source-bound context without claiming an owner review."""
+    return {
+        "amendment_sha256": binding["amendment_sha256"],
+        "attestation_statement": waiver["statement"],
+        "base_oid": pr["base"]["sha"],
+        "checklist": {"owner_review_gate_waived": True},
+        "combined_plan_hash": binding["combined_plan_hash"],
+        "diff_sha256": diff_sha256,
+        "head_sha": pr["head"]["sha"],
+        "independence": False,
+        "desktop_sha": desktop_sha,
+        "operator_id": waiver["operator_id"],
+        "plan_sha256": binding["plan_sha256"],
+        "pr_number": pr["number"],
+        "public_release": False,
+        "repository": REPOSITORY,
+        "reviewed_at_utc": waiver["approved_at_utc"],
+        "schema_version": 1,
+        "self_review_exception": True,
+        "unresolved_blocking_findings": [],
+    }
+
+
 def validate_merge_audit(
     merge: dict[str, Any],
     pr: dict[str, Any],
@@ -741,6 +808,8 @@ def build_receipt(
     pr_projection_sha256: str,
     reviews_projection_sha256: str,
     ruleset_projection_sha256: str,
+    owner_review_status: str = "performed",
+    owner_review_waiver_sha256: str | None = None,
 ) -> dict[str, Any]:
     validate_pr(pr, owner["pr_number"], merged_oid)
     if not isinstance(reviews, list):
@@ -750,7 +819,10 @@ def build_receipt(
         raise ReviewReceiptError("native GitHub reviews are not empty for the self-review exception")
     safety = contract_safety(contract)
     validate_plan_binding(binding)
-    validate_owner_review(owner, pr, binding, diff_sha256, desktop_sha)
+    if owner_review_status == "performed":
+        validate_owner_review(owner, pr, binding, diff_sha256, desktop_sha)
+    elif owner_review_status != "waived-not-performed":
+        raise ReviewReceiptError("owner review status is invalid")
     validate_merge_audit(merge, pr, merged_oid, guarded_run_head_sha, binding, owner)
     validate_subagent_review(subagent, pr, owner, desktop_sha)
     require_sha(desktop_sha, SHA1, "Desktop commit")
@@ -771,7 +843,7 @@ def build_receipt(
         (ruleset_projection_sha256, "ruleset metadata projection digest"),
     ):
         require_sha(value, SHA256, label)
-    return {
+    receipt = {
         "admin_bypass_used": merge["admin_bypass_used"],
         "audit_bypass_event_count": merge["audit_bypass_event_count"],
         "audit_event_count": merge["audit_event_count"],
@@ -830,6 +902,16 @@ def build_receipt(
         "two_disposable_accounts_only": safety["two_disposable_accounts_only"],
         "unresolved_blocking_findings": owner["unresolved_blocking_findings"],
     }
+    if owner_review_status == "waived-not-performed":
+        require_sha(
+            owner_review_waiver_sha256 or "",
+            SHA256,
+            "owner review waiver digest",
+        )
+        receipt["owner_review_receipt_sha256"] = None
+        receipt["owner_review_status"] = "waived-not-performed"
+        receipt["owner_review_waiver_sha256"] = owner_review_waiver_sha256
+    return receipt
 
 
 def git_diff_sha256(repository_root: Path, base_oid: str, head_oid: str) -> str:
@@ -886,7 +968,9 @@ def parse_args(arguments: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--desktop-sha", required=True)
     parser.add_argument("--contract", type=Path, required=True)
     parser.add_argument("--plan-binding", type=Path, required=True)
-    parser.add_argument("--owner-review", type=Path, required=True)
+    owner_review_group = parser.add_mutually_exclusive_group(required=True)
+    owner_review_group.add_argument("--owner-review", type=Path)
+    owner_review_group.add_argument("--owner-review-waiver", type=Path)
     parser.add_argument("--merge-audit", type=Path, required=True)
     parser.add_argument("--merge-audit-commit", required=True)
     parser.add_argument("--audit-json", type=Path, required=True)
@@ -908,12 +992,25 @@ def main(arguments: list[str] | None = None) -> int:
         ruleset, ruleset_raw = load_json(args.ruleset_json)
         contract, contract_raw = load_canonical(args.contract, "operation contract")
         binding, binding_raw = load_canonical(args.plan_binding, "plan binding")
-        owner, owner_raw = load_canonical(args.owner_review, "owner review")
+        owner_review_status = "performed"
+        owner_review_waiver_sha256 = None
+        owner_waiver = None
+        if args.owner_review is not None:
+            owner, owner_raw = load_canonical(args.owner_review, "owner review")
+        else:
+            owner_waiver, owner_raw = load_canonical(
+                args.owner_review_waiver,
+                "owner review waiver",
+            )
+            validate_owner_review_waiver(owner_waiver, binding)
+            owner_review_status = "waived-not-performed"
+            owner_review_waiver_sha256 = sha256_bytes(owner_raw)
         merge, merge_raw = load_canonical(args.merge_audit, "merge audit")
         audit, audit_raw = load_json(args.audit_json)
         subagent, subagent_raw = load_canonical(args.subagent_review, "subagent review")
         guarded_run, _ = load_json(args.guarded_merge_run)
-        reject_sensitive(owner, "owner review")
+        if owner_waiver is not None:
+            reject_sensitive(owner_waiver, "owner review waiver")
         reject_sensitive(merge, "merge audit")
         reject_sensitive(subagent, "subagent review")
         if not isinstance(pr, dict) or not isinstance(ruleset, dict):
@@ -949,6 +1046,15 @@ def main(arguments: list[str] | None = None) -> int:
             canonical(project_ruleset_metadata(ruleset)),
         )
         diff_sha256 = git_diff_sha256(args.repository_root, pr["base"]["sha"], pr["head"]["sha"])
+        if owner_waiver is not None:
+            owner = owner_context_from_waiver(
+                owner_waiver,
+                pr,
+                binding,
+                diff_sha256,
+                args.desktop_sha,
+            )
+            reject_sensitive(owner, "owner review waiver context")
         verify_merged_parent(args.repository_root, pr["base"]["sha"], args.merged_oid)
         receipt = build_receipt(
             pr,
@@ -976,6 +1082,8 @@ def main(arguments: list[str] | None = None) -> int:
             sha256_bytes(projections[0]),
             sha256_bytes(projections[1]),
             sha256_bytes(projections[2]),
+            owner_review_status,
+            owner_review_waiver_sha256,
         )
         for path, raw in zip(
             (args.pr_projection, args.reviews_projection, args.ruleset_projection),

--- a/scripts/ci/create-floorp-notes-sync-production-enablement.py
+++ b/scripts/ci/create-floorp-notes-sync-production-enablement.py
@@ -220,6 +220,15 @@ def main(arguments: list[str] | None = None) -> int:
                 == int(os.environ["FLOORP_TODO20_GUARDED_MERGE_RUN_ID"]),
                 "[blocked] AUTHORIZATION_MISSING owner=Operations reason=waived_enablement_run_mismatch",
             )
+            require(
+                review_receipt.get("owner_review_status") == "waived-not-performed",
+                "[blocked] AUTHORIZATION_MISSING owner=Operations reason=owner_review_gate_waiver_missing",
+            )
+            require(
+                isinstance(review_receipt.get("owner_review_waiver_sha256"), str)
+                and len(review_receipt["owner_review_waiver_sha256"]) == 64,
+                "[blocked] AUTHORIZATION_MISSING owner=Operations reason=owner_review_gate_waiver_invalid",
+            )
             record = {
                 "app_store_submission": False,
                 "approved": True,
@@ -237,6 +246,8 @@ def main(arguments: list[str] | None = None) -> int:
                 "merge_audit_sha256": sha256(merge_audit_raw),
                 "no_data_loss_claim": False,
                 "operator_id": context["actor"],
+                "owner_review_status": review_receipt["owner_review_status"],
+                "owner_review_waiver_sha256": review_receipt["owner_review_waiver_sha256"],
                 "phase": "production-sync-enablement",
                 "phase1_summary_sha256": None,
                 "public_release": False,

--- a/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
+++ b/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
@@ -93,6 +93,18 @@ def owner_review() -> dict[str, Any]:
     }
 
 
+def owner_review_waiver() -> dict[str, Any]:
+    return {
+        "approved_at_utc": "2026-08-19T00:00:00Z",
+        "operator_id": "operator",
+        "owner_review_performed": False,
+        "plan_hash": "c" * 64,
+        "schema_version": 1,
+        "statement": "The owner-review gate is explicitly waived and was not performed for this bounded enablement attempt.",
+        "waiver_scope": "todo20-owner-review-gate",
+    }
+
+
 def merge_audit() -> dict[str, Any]:
     merge_response = {"merged": True, "sha": "4" * 40}
     audit_projection = {
@@ -184,7 +196,13 @@ def pr() -> dict[str, Any]:
 
 
 class CaptureReceiptTests(unittest.TestCase):
-    def call_build_receipt(self, merge: dict[str, Any]) -> dict[str, Any]:
+    def call_build_receipt(
+        self,
+        merge: dict[str, Any],
+        owner: dict[str, Any] | None = None,
+        owner_review_status: str = "performed",
+        owner_review_waiver_sha256: str | None = None,
+    ) -> dict[str, Any]:
         return CAPTURE.build_receipt(
             pr(),
             [],
@@ -218,7 +236,7 @@ class CaptureReceiptTests(unittest.TestCase):
             },
             contract(),
             plan_binding(),
-            owner_review(),
+            owner or owner_review(),
             merge,
             subagent_review(),
             "2" * 40,
@@ -238,6 +256,8 @@ class CaptureReceiptTests(unittest.TestCase):
             CAPTURE.sha256_bytes(b"pr-projection"),
             CAPTURE.sha256_bytes(b"reviews-projection"),
             CAPTURE.sha256_bytes(b"ruleset-projection"),
+            owner_review_status,
+            owner_review_waiver_sha256,
         )
 
     def test_receipt_uses_api_git_and_artifact_bound_values(self) -> None:
@@ -260,6 +280,35 @@ class CaptureReceiptTests(unittest.TestCase):
             self.assertEqual(receipt["audit_source"], "github-org-audit-log-unavailable-owner-waived")
             self.assertEqual(receipt["audit_event_count"], 0)
             self.assertIsNone(receipt["audit_bypass_event_count"])
+
+    def test_owner_review_gate_waiver_is_source_bound_and_explicit(self) -> None:
+        waiver = owner_review_waiver()
+        CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
+        context = CAPTURE.owner_context_from_waiver(
+            waiver,
+            pr(),
+            plan_binding(),
+            "d" * 64,
+            "5" * 40,
+        )
+        receipt = self.call_build_receipt(
+            waived_merge_audit(),
+            owner=context,
+            owner_review_status="waived-not-performed",
+            owner_review_waiver_sha256=CAPTURE.sha256_bytes(CAPTURE.canonical(waiver)),
+        )
+        self.assertEqual(receipt["owner_review_status"], "waived-not-performed")
+        self.assertIsNone(receipt["owner_review_receipt_sha256"])
+        self.assertEqual(
+            receipt["owner_review_waiver_sha256"],
+            CAPTURE.sha256_bytes(CAPTURE.canonical(waiver)),
+        )
+
+    def test_owner_review_gate_waiver_rejects_plan_drift(self) -> None:
+        waiver = owner_review_waiver()
+        waiver["plan_hash"] = "f" * 64
+        with self.assertRaises(CAPTURE.ReviewReceiptError):
+            CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
 
     def test_stale_server_merged_at_is_rejected(self) -> None:
         later_pr = pr()

--- a/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
+++ b/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -283,7 +284,8 @@ class CaptureReceiptTests(unittest.TestCase):
 
     def test_owner_review_gate_waiver_is_source_bound_and_explicit(self) -> None:
         waiver = owner_review_waiver()
-        CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
+        with patch.dict(CAPTURE.os.environ, {"GITHUB_ACTOR": "operator"}, clear=False):
+            CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
         context = CAPTURE.owner_context_from_waiver(
             waiver,
             pr(),
@@ -307,8 +309,9 @@ class CaptureReceiptTests(unittest.TestCase):
     def test_owner_review_gate_waiver_rejects_plan_drift(self) -> None:
         waiver = owner_review_waiver()
         waiver["plan_hash"] = "f" * 64
-        with self.assertRaises(CAPTURE.ReviewReceiptError):
-            CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
+        with patch.dict(CAPTURE.os.environ, {"GITHUB_ACTOR": "operator"}, clear=False):
+            with self.assertRaises(CAPTURE.ReviewReceiptError):
+                CAPTURE.validate_owner_review_waiver(waiver, plan_binding())
 
     def test_stale_server_merged_at_is_rejected(self) -> None:
         later_pr = pr()

--- a/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
+++ b/scripts/ci/tests/test_capture_floorp_notes_sync_review_receipt.py
@@ -97,6 +97,7 @@ def owner_review() -> dict[str, Any]:
 def owner_review_waiver() -> dict[str, Any]:
     return {
         "approved_at_utc": "2026-08-19T00:00:00Z",
+        "historical_merge_audit_plan_hash": "d" * 64,
         "operator_id": "operator",
         "owner_review_performed": False,
         "plan_hash": "c" * 64,
@@ -293,8 +294,10 @@ class CaptureReceiptTests(unittest.TestCase):
             "d" * 64,
             "5" * 40,
         )
+        historical_merge = waived_merge_audit()
+        historical_merge["waiver_plan_hash"] = "d" * 64
         receipt = self.call_build_receipt(
-            waived_merge_audit(),
+            historical_merge,
             owner=context,
             owner_review_status="waived-not-performed",
             owner_review_waiver_sha256=CAPTURE.sha256_bytes(CAPTURE.canonical(waiver)),

--- a/scripts/ci/tests/test_floorp_notes_sync_t20_rescope_contract.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_t20_rescope_contract.py
@@ -180,6 +180,14 @@ class FloorpNotesSyncT20RescopeContractTests(unittest.TestCase):
                 f"{job_id} must authenticate its protected ruleset read",
             )
 
+    def test_waived_enablement_uses_explicit_owner_review_gate_waiver(self) -> None:
+        job = self.jobs["notes-sync-production-enablement-waived"]
+        serialized = json.dumps(job, sort_keys=True)
+        self.assertIn("FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON", serialized)
+        self.assertNotIn("FLOORP_TODO20_OWNER_REVIEW_JSON", serialized)
+        self.assertIn("owner-review-waiver", serialized)
+        self.assertIn("owner_review_gate_waiver_missing", serialized)
+
     def test_workflow_keeps_normal_ci_and_public_release_disabled(self) -> None:
         serialized = json.dumps(self.workflow, sort_keys=True).lower()
         self.assertNotIn("app store", serialized)

--- a/scripts/ci/tests/test_validate_floorp_notes_sync_production_enablement.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_production_enablement.py
@@ -209,6 +209,20 @@ class ValidateFloorpNotesSyncProductionEnablementTests(unittest.TestCase):
             "merge_audit_sha256": hashlib.sha256(merge_audit_raw).hexdigest(),
             "no_data_loss_claim": False,
             "operator_id": "test-operator",
+            "owner_review_status": "waived-not-performed",
+            "owner_review_waiver_sha256": hashlib.sha256(
+                canonical(
+                    {
+                        "approved_at_utc": "2026-08-16T00:00:00Z",
+                        "operator_id": "test-operator",
+                        "owner_review_performed": False,
+                        "plan_hash": "c" * 64,
+                        "schema_version": 1,
+                        "statement": "The owner-review gate is explicitly waived and was not performed.",
+                        "waiver_scope": "todo20-owner-review-gate",
+                    }
+                )
+            ).hexdigest(),
             "phase": "production-sync-enablement",
             "phase1_summary_sha256": None,
             "public_release": False,
@@ -240,9 +254,24 @@ class ValidateFloorpNotesSyncProductionEnablementTests(unittest.TestCase):
         merge_audit_raw = json.dumps(
             merge_audit, separators=(",", ":"), sort_keys=True
         ).encode() + b"\n"
+        owner_review_waiver_raw = json.dumps(
+            {
+                "approved_at_utc": "2026-08-16T00:00:00Z",
+                "operator_id": "test-operator",
+                "owner_review_performed": False,
+                "plan_hash": "c" * 64,
+                "schema_version": 1,
+                "statement": "The owner-review gate is explicitly waived and was not performed.",
+                "waiver_scope": "todo20-owner-review-gate",
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode() + b"\n"
         review_receipt_raw = json.dumps(
             {
                 "merge_audit_sha256": hashlib.sha256(merge_audit_raw).hexdigest(),
+                "owner_review_status": "waived-not-performed",
+                "owner_review_waiver_sha256": hashlib.sha256(owner_review_waiver_raw).hexdigest(),
                 "source_workflow_run_id": 123,
                 "audit_source": "github-org-audit-log-unavailable-owner-waived",
             },

--- a/scripts/ci/validate-floorp-notes-sync-production-enablement.py
+++ b/scripts/ci/validate-floorp-notes-sync-production-enablement.py
@@ -230,6 +230,8 @@ WAIVED_ENABLEMENT_FIELDS = {
     "merge_audit_sha256",
     "no_data_loss_claim",
     "operator_id",
+    "owner_review_status",
+    "owner_review_waiver_sha256",
     "phase",
     "phase1_summary_sha256",
     "public_release",
@@ -278,6 +280,15 @@ def validate_waived_enablement(
     require(record["testflight_distribution"] is False, "TestFlight distribution is forbidden")
     require(record["live_qa"] == "owner-waived-not-performed", "live QA is not recorded as waived")
     require(record["no_data_loss_claim"] is False, "no-data-loss must not be claimed")
+    require(
+        record["owner_review_status"] == "waived-not-performed",
+        "owner review gate is not recorded as waived",
+    )
+    require(
+        isinstance(record["owner_review_waiver_sha256"], str)
+        and SHA256.fullmatch(record["owner_review_waiver_sha256"]) is not None,
+        "owner review waiver digest is invalid",
+    )
     require(record["phase1_summary_sha256"] is None, "waived enablement must not bind a Phase 1 summary")
     require(
         record["audit_source"] == "github-org-audit-log-unavailable-owner-waived",
@@ -339,6 +350,11 @@ def validate_waived_enablement(
         isinstance(review_receipt, dict)
         and review_receipt.get("merge_audit_sha256") == record["merge_audit_sha256"],
         "review receipt is not bound to the enablement merge audit",
+    )
+    require(
+        review_receipt.get("owner_review_status") == record["owner_review_status"]
+        and review_receipt.get("owner_review_waiver_sha256") == record["owner_review_waiver_sha256"],
+        "review receipt is not bound to the owner-review gate waiver",
     )
     require(
         review_receipt.get("source_workflow_run_id") == record["guarded_merge_run_id"],


### PR DESCRIPTION
## Summary
- replace the failed `FLOORP_TODO20_OWNER_REVIEW_JSON` dependency in the owner-waived Phase 2 path with an explicit protected `FLOORP_TODO20_OWNER_REVIEW_WAIVER_JSON` receipt
- record `owner-review-gate: waived-not-performed`; never treat an invalid owner review as successful
- bind the waiver to the checked-in Todo 20 plan hash and preserve exact-head, CI, subagent, merge-audit, cleanup, secret-scan, no-data-loss, and no-public-release gates

## Safety boundary
- live desktop/mobile Sync QA remains owner-approved and not performed
- no no-data-loss or real-Sync reliability claim
- no new REST/token/auth/crypto/direct Sync path
- no App Store/TestFlight/public release
- issue #28 and PRs #59–#64 untouched

## Validation
- targeted Todo 20 capture/enablement/workflow-contract tests: pass
- Python compile, YAML parse, diff check: pass
- full local suite has unrelated pre-existing fixture/worktree failures; recorded separately