### PR TITLE
fix(ci): preserve source branch during Todo 20 audit recovery

### DIFF
--- a/scripts/ci/execute-floorp-notes-sync-merge-recovery.py
+++ b/scripts/ci/execute-floorp-notes-sync-merge-recovery.py
@@ -37,7 +37,7 @@ GH = "/opt/homebrew/bin/gh"
 SHA1 = re.compile(r"[0-9a-f]{40}\Z")
 SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 EXPECTED_BASE_REF = "main"
-EXPECTED_HEAD_REF = "agent/floorp-plan-t20-live-executor"
+EXPECTED_EXECUTOR_HEAD_REF = "agent/floorp-plan-t20-live-executor"
 EXPECTED_WORKFLOW_PATH = ".github/workflows/ci.yml"
 EXPECTED_SOURCE_JOB = "Todo 20 protected OID-guarded merge and audit receipt"
 EXPECTED_SOURCE_STEP = "Execute repository-owned OID-guarded merge"
@@ -142,7 +142,8 @@ def validate_admission(
         or admission["repository"] != REPOSITORY
         or admission["pr_number"] != pr_number
         or admission["base_ref_name"] != EXPECTED_BASE_REF
-        or admission["head_ref_name"] != EXPECTED_HEAD_REF
+        or not isinstance(admission["head_ref_name"], str)
+        or not admission["head_ref_name"]
         or admission["head_sha"] != expected_head_sha
         or admission["admin_bypass_used"] is not False
         or admission["native_github_approval"] is not False
@@ -156,7 +157,13 @@ def validate_admission(
         raise MergeRecoveryError("merge admission receipt is not an exact-head terminal GO")
 
 
-def verify_merged_pr(pr: dict[str, Any], pr_number: int, expected_head_sha: str, expected_merged_oid: str) -> str:
+def verify_merged_pr(
+    pr: dict[str, Any],
+    pr_number: int,
+    expected_head_sha: str,
+    expected_merged_oid: str,
+    expected_source_head_ref: str,
+) -> str:
     base = pr.get("base") if isinstance(pr.get("base"), dict) else {}
     head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
     base_oid = require_sha(base.get("sha"), "merged PR base OID")
@@ -166,7 +173,7 @@ def verify_merged_pr(pr: dict[str, Any], pr_number: int, expected_head_sha: str,
         or pr.get("merged") is not True
         or merged_oid != expected_merged_oid
         or base.get("ref") != EXPECTED_BASE_REF
-        or head.get("ref") != EXPECTED_HEAD_REF
+        or head.get("ref") != expected_source_head_ref
         or head.get("sha") != expected_head_sha
         or not isinstance(pr.get("merged_at"), str)
         or not pr["merged_at"]
@@ -180,7 +187,7 @@ def verify_source_run(run: dict[str, Any], source_run_id: int, expected_head_sha
         run.get("id") != source_run_id
         or run.get("path") != EXPECTED_WORKFLOW_PATH
         or run.get("event") != "workflow_dispatch"
-        or run.get("head_branch") != EXPECTED_HEAD_REF
+        or run.get("head_branch") != EXPECTED_EXECUTOR_HEAD_REF
         or run.get("head_sha") != expected_head_sha
     ):
         raise MergeRecoveryError("original guarded-merge run provenance is not exact")
@@ -260,7 +267,11 @@ def main(arguments: list[str] | None = None) -> int:
             "merged PR response",
         )
         base_oid = verify_merged_pr(
-            merged_pr, args.pr_number, expected_head_sha, expected_merged_oid,
+            merged_pr,
+            args.pr_number,
+            expected_head_sha,
+            expected_merged_oid,
+            admission["head_ref_name"],
         )
         source_run = load_object(
             run_gh(["api", f"repos/{REPOSITORY}/actions/runs/{args.source_run_id}"]),

--- a/scripts/ci/tests/test_execute_floorp_notes_sync_merge_recovery.py
+++ b/scripts/ci/tests/test_execute_floorp_notes_sync_merge_recovery.py
@@ -38,7 +38,7 @@ class MergeRecoveryTests(unittest.TestCase):
             "checks_count": 4,
             "checks_sha256": "a" * 64,
             "head_sha": "2" * 40,
-            "head_ref_name": "agent/floorp-plan-t20-live-executor",
+            "head_ref_name": "agent/floorp-t20-enable-runtime-compat",
             "native_github_approval": False,
             "operator_id": "operator",
             "owner_review_sha256": "b" * 64,
@@ -56,7 +56,7 @@ class MergeRecoveryTests(unittest.TestCase):
     def merged_pr() -> dict[str, object]:
         return {
             "base": {"ref": "main", "sha": "1" * 40},
-            "head": {"ref": "agent/floorp-plan-t20-live-executor", "sha": "2" * 40},
+            "head": {"ref": "agent/floorp-t20-enable-runtime-compat", "sha": "2" * 40},
             "merge_commit_sha": "4" * 40,
             "merged": True,
             "merged_at": "2026-08-15T01:00:00Z",

--- a/scripts/ci/tests/test_verify_floorp_notes_sync_guarded_merge_artifact.py
+++ b/scripts/ci/tests/test_verify_floorp_notes_sync_guarded_merge_artifact.py
@@ -36,7 +36,7 @@ class GuardedMergeArtifactTests(unittest.TestCase):
             "checks_count": 4,
             "checks_sha256": "a" * 64,
             "head_sha": "2" * 40,
-            "head_ref_name": "agent/floorp-plan-t20-live-executor",
+            "head_ref_name": "agent/floorp-t20-enable-runtime-compat",
             "native_github_approval": False,
             "operator_id": "operator",
             "owner_review_sha256": "b" * 64,

--- a/scripts/ci/tests/test_verify_floorp_notes_sync_merge_admission.py
+++ b/scripts/ci/tests/test_verify_floorp_notes_sync_merge_admission.py
@@ -298,11 +298,27 @@ class MergeAdmissionTests(unittest.TestCase):
             workflow_runs = json.loads(workflow_runs_path.read_text(encoding="utf-8"))
             for workflow_run in workflow_runs["workflow_runs"]:
                 workflow_run["pull_requests"] = []
-                workflow_run["head_branch"] = ADMISSION.RECOVERY_HEAD_BRANCH
             workflow_runs_path.write_text(json.dumps(workflow_runs) + "\n", encoding="utf-8")
             self.assertNotEqual(ADMISSION.main(self.args(values)), 0)
             recovery_args = self.args(values) + ["--recovery"]
             self.assertEqual(ADMISSION.main(recovery_args), 0)
+            value = json.loads(Path(values["output"]).read_text(encoding="utf-8"))
+            self.assertEqual(value["head_ref_name"], "agent/floorp-t20-enable-runtime-compat")
+
+    def test_recovery_mode_rejects_missing_workflow_source_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            head, commit = self.build_repo(root)
+            values = self.write_inputs(root, head, commit)
+            check_runs = json.loads(Path(values["check_runs"]).read_text(encoding="utf-8"))
+            for check_run in check_runs["check_runs"]:
+                check_run["pull_requests"] = []
+            Path(values["check_runs"]).write_text(json.dumps(check_runs) + "\n", encoding="utf-8")
+            workflow_runs = json.loads(Path(values["workflow_runs"]).read_text(encoding="utf-8"))
+            workflow_runs["workflow_runs"][0]["pull_requests"] = []
+            workflow_runs["workflow_runs"][0]["head_branch"] = ""
+            Path(values["workflow_runs"]).write_text(json.dumps(workflow_runs) + "\n", encoding="utf-8")
+            self.assertNotEqual(ADMISSION.main(self.args(values) + ["--recovery"]), 0)
 
     def test_pending_ci_is_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/ci/verify-floorp-notes-sync-guarded-merge-artifact.py
+++ b/scripts/ci/verify-floorp-notes-sync-guarded-merge-artifact.py
@@ -23,7 +23,7 @@ MERGE_RESPONSE_SOURCE = "github-api-put-merge-executor"
 WORKFLOW_SOURCE = "protected-guarded-merge-workflow"
 WORKFLOW_PATH = ".github/workflows/ci.yml"
 BASE_BRANCH = "main"
-HEAD_BRANCH = "agent/floorp-plan-t20-live-executor"
+EXECUTOR_HEAD_BRANCH = "agent/floorp-plan-t20-live-executor"
 SHA1 = re.compile(r"[0-9a-f]{40}\Z")
 SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 
@@ -96,7 +96,7 @@ def validate_run_metadata(
         or metadata["artifact_name"] != f"floorp-notes-sync-guarded-merge-{expected_run_id}"
         or metadata["workflow_path"] != WORKFLOW_PATH
         or metadata["event"] != "workflow_dispatch"
-        or metadata["head_branch"] != HEAD_BRANCH
+        or metadata["head_branch"] != EXECUTOR_HEAD_BRANCH
         or metadata["status"] != "completed"
         or metadata["conclusion"] != "success"
     ):
@@ -107,7 +107,7 @@ def validate_run_metadata(
         run.get("id") != expected_run_id
         or run.get("path") != WORKFLOW_PATH
         or run.get("event") != "workflow_dispatch"
-        or run.get("head_branch") != HEAD_BRANCH
+        or run.get("head_branch") != EXECUTOR_HEAD_BRANCH
         or run.get("head_sha") != metadata["head_sha"]
         or run.get("status") != "completed"
         or run.get("conclusion") != "success"
@@ -218,7 +218,8 @@ def validate(
         or not isinstance(admission["pr_number"], int)
         or admission["pr_number"] <= 0
         or admission["base_ref_name"] != BASE_BRANCH
-        or admission["head_ref_name"] != HEAD_BRANCH
+        or not isinstance(admission["head_ref_name"], str)
+        or not admission["head_ref_name"]
         or admission["head_sha"] != expected_head_sha
         or admission["admin_bypass_used"] is not False
         or admission["native_github_approval"] is not False

--- a/scripts/ci/verify-floorp-notes-sync-merge-admission.py
+++ b/scripts/ci/verify-floorp-notes-sync-merge-admission.py
@@ -27,13 +27,13 @@ SHA1 = re.compile(r"[0-9a-f]{40}\Z")
 SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 AGENT_ID = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z")
 RUN_JOB_LINK = re.compile(r"/actions/runs/(?P<run_id>[0-9]+)/job/(?P<job_id>[0-9]+)(?:$|[?#])")
-# The protected merge executor is dispatched from this branch, but the
+# The protected merge executor is dispatched from its own branch, but the
 # reviewed PR checks may legitimately run on a different source branch.  In
 # normal mode the source branch is derived from the exact PR association below
 # and then required to agree across every check and workflow run.  Recovery
-# mode retains the executor branch because it intentionally runs after the PR
-# association has been cleared by a merge.
-RECOVERY_HEAD_BRANCH = "agent/floorp-plan-t20-live-executor"
+# mode derives the same source branch from the exact-head workflow-run
+# metadata because GitHub clears the PR associations after a merge.  The
+# recovery executor branch is never substituted for the reviewed source.
 EXPECTED_BASE_BRANCH = "main"
 EXPECTED_WORKFLOW_PATHS = {
     "Floorp iOS CI": ".github/workflows/ci.yml",
@@ -343,7 +343,6 @@ def validate_checks(
             or workflow_run.get("conclusion") != "success"
         ):
             raise MergeAdmissionError(f"GitHub workflow provenance is not exact: {name}")
-        workflow_head_ref = RECOVERY_HEAD_BRANCH
         if not recovery:
             workflow_head_ref = require_pull_request(
                 workflow_run.get("pull_requests"),
@@ -354,10 +353,14 @@ def validate_checks(
             )
             if check_head_ref != workflow_head_ref:
                 raise MergeAdmissionError(f"GitHub source branch binding differs: {name}")
-            if source_head_ref is None:
-                source_head_ref = check_head_ref
-            elif source_head_ref != check_head_ref:
-                raise MergeAdmissionError(f"GitHub source branch is inconsistent: {name}")
+        else:
+            workflow_head_ref = workflow_run.get("head_branch")
+            if not isinstance(workflow_head_ref, str) or not workflow_head_ref:
+                raise MergeAdmissionError(f"GitHub workflow source branch is missing: {name}")
+        if source_head_ref is None:
+            source_head_ref = workflow_head_ref
+        elif source_head_ref != workflow_head_ref:
+            raise MergeAdmissionError(f"GitHub source branch is inconsistent: {name}")
         if workflow_run.get("head_branch") != workflow_head_ref:
             raise MergeAdmissionError(f"GitHub workflow head branch is not PR-bound: {name}")
         state = str(check.get("state", "")).upper()
@@ -374,6 +377,8 @@ def validate_checks(
         raise MergeAdmissionError("required terminal CI checks are missing")
     if not referenced_workflow_run_ids:
         raise MergeAdmissionError("GitHub workflow provenance is empty")
+    if source_head_ref is None:
+        raise MergeAdmissionError("GitHub source branch provenance is empty")
     return len(checks), source_head_ref
 
 
@@ -453,7 +458,7 @@ def main(arguments: list[str] | None = None) -> int:
             # bundle, not only the gh-pr-checks projection.
             "checks_sha256": sha256(checks_raw + check_runs_raw + workflow_runs_raw),
             "head_sha": args.expected_head_sha,
-            "head_ref_name": source_head_ref or RECOVERY_HEAD_BRANCH,
+            "head_ref_name": source_head_ref,
             "native_github_approval": False,
             "operator_id": owner["operator_id"],
             "owner_review_sha256": sha256(owner_raw),


### PR DESCRIPTION
## Summary\n\n- keep the original PR source branch in exact-head admission during post-merge recovery\n- keep the recovery executor branch bound to the original guarded run\n- allow the artifact verifier to distinguish executor-run branch from reviewed source branch\n- add fail-closed regression coverage\n\nThis is a metadata and verification fix only. It performs no merge, no Sync QA, no production enablement, and no release.