### PR TITLE
feat: isolate public beta Sync release path

### DIFF
--- a/.github/workflows/floorp-notes-sync-public-beta-qa.yml
+++ b/.github/workflows/floorp-notes-sync-public-beta-qa.yml
@@ -201,6 +201,49 @@ jobs:
           set -euo pipefail
           /usr/bin/python3 -I scripts/ci/scan-floorp-notes-sync-process-argv.py
 
+      - name: Scan public-beta QA material for secrets
+        if: always()
+        env:
+          FLOORP_NOTES_SYNC_ACCOUNT_A_EMAIL: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_A_EMAIL }}
+          FLOORP_NOTES_SYNC_ACCOUNT_A_PASSWORD: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_A_PASSWORD }}
+          FLOORP_NOTES_SYNC_ACCOUNT_B_EMAIL: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_B_EMAIL }}
+          FLOORP_NOTES_SYNC_ACCOUNT_B_PASSWORD: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_B_PASSWORD }}
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 - "$RUNNER_TEMP/floorp-notes-sync-public-beta-qa" <<'PY'
+          import os
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+          secret_names = (
+              "FLOORP_NOTES_SYNC_ACCOUNT_A_EMAIL",
+              "FLOORP_NOTES_SYNC_ACCOUNT_A_PASSWORD",
+              "FLOORP_NOTES_SYNC_ACCOUNT_B_EMAIL",
+              "FLOORP_NOTES_SYNC_ACCOUNT_B_PASSWORD",
+          )
+          secrets = tuple(os.environ[name].encode("utf-8") for name in secret_names)
+          if any(not value for value in secrets):
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=public_beta_secret_scan_scope_missing resume=populate all four protected Sync account secrets")
+          markers = (
+              "password=", "password:", "access_token=", "refresh_token=", "sync_key=",
+              "authorization: bearer ", "bearer ", "cookie=", "credential=",
+              "begin private key", "oauth_token=", "note_content:", "note_title:",
+              "request_body:", "response_body:",
+          )
+          if root.exists():
+              for path in root.rglob("*"):
+                  if not path.is_file() or path.is_symlink():
+                      continue
+                  raw = path.read_bytes()
+                  if any(secret and secret in raw for secret in secrets):
+                      raise SystemExit(f"[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason=secret_value_detected_in_{path.name} resume=remove the secret from public-beta QA material")
+                  text = raw.decode("utf-8", errors="ignore").lower()
+                  if any(marker in text for marker in markers):
+                      raise SystemExit(f"[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason=secret_marker_detected_in_{path.name} resume=remove the secret marker from public-beta QA material")
+          print('{"status":"public-beta-secret-scan-passed"}')
+          PY
+
       - name: Clean up test accounts and client state
         if: always()
         run: |

--- a/.github/workflows/floorp-notes-sync-public-beta-qa.yml
+++ b/.github/workflows/floorp-notes-sync-public-beta-qa.yml
@@ -1,0 +1,246 @@
+name: Floorp Notes Sync Public Beta QA
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_floorp_notes_sync_public_beta_qa:
+        description: Run the protected two-account production Sync QA used by the public-beta candidate.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: floorp-notes-sync-public-beta-qa-${{ github.run_id || github.ref }}
+  cancel-in-progress: false
+
+env:
+  PROJECT_PATH: firefox-ios/Client.xcodeproj
+  SIMULATOR_NAME: iPhone 17
+  SIMULATOR_OS: "26.2"
+
+jobs:
+  notes-sync-public-beta-qa:
+    name: Protected public-beta two-client Sync QA
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.run_floorp_notes_sync_public_beta_qa == true
+    environment: floorp-notes-sync-production-qa
+    permissions:
+      actions: read
+    runs-on: macos-26
+    timeout-minutes: 180
+    env:
+      GITHUB_TOKEN: ""
+      GH_TOKEN: ""
+      NODE_AUTH_TOKEN: ""
+      NPM_TOKEN: ""
+      GIT_CONFIG_GLOBAL: /dev/null
+      GIT_CONFIG_NOSYSTEM: "1"
+      GIT_TERMINAL_PROMPT: "0"
+      GIT_ASKPASS: /usr/bin/false
+      FLOORP_DESKTOP_COMMIT: 8462074ce18ab63d9be4def199b33de1d6bb554a
+
+    steps:
+      - name: Check out source anonymously
+        run: |
+          set -euo pipefail
+          git -C "$GITHUB_WORKSPACE" init --quiet
+          git -C "$GITHUB_WORKSPACE" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$GITHUB_WORKSPACE" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            fetch --no-tags --depth=1 origin "$GITHUB_SHA"
+          git -C "$GITHUB_WORKSPACE" checkout --detach --force FETCH_HEAD
+          test "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$GITHUB_SHA"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          token: ""
+          package-manager-cache: false
+
+      - name: Validate protected Sync operation contract
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 -I scripts/ci/validate-floorp-notes-sync-g5-operation-contract.py \
+            --contract scripts/ci/floorp-notes-sync-g5-operation-contract.json
+
+      - name: Check out reviewed Desktop source anonymously
+        run: |
+          set -euo pipefail
+          desktop_root="$RUNNER_TEMP/floorp-desktop"
+          git init --quiet "$desktop_root"
+          git -C "$desktop_root" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            remote add origin https://github.com/Floorp-Projects/Floorp.git
+          git -C "$desktop_root" \
+            -c credential.helper= \
+            -c http.https://github.com/.extraheader= \
+            fetch --no-tags --depth=1 origin "$FLOORP_DESKTOP_COMMIT"
+          git -C "$desktop_root" checkout --detach --force FETCH_HEAD
+          test "$(git -C "$desktop_root" rev-parse HEAD)" = "$FLOORP_DESKTOP_COMMIT"
+          printf 'FLOORP_NOTES_SYNC_DESKTOP_ROOT=%s\n' "$desktop_root" >> "$GITHUB_ENV"
+
+      - name: Create public-beta QA capability
+        run: |
+          set -euo pipefail
+          qa_root="$RUNNER_TEMP/floorp-notes-sync-public-beta-qa"
+          install -d -m 700 "$qa_root"
+          capability="$qa_root/production-qa-capability.json"
+          xcconfig="$qa_root/production-qa.xcconfig"
+          /usr/bin/python3 -I scripts/ci/create-floorp-notes-sync-production-qa-capability.py \
+            --contract scripts/ci/floorp-notes-sync-g5-operation-contract.json \
+            --endpoint-policy docs/floorp-release-endpoints.json \
+            --desktop-sha "$FLOORP_DESKTOP_COMMIT" \
+            --ios-build-number 4 \
+            --output "$capability"
+          /usr/bin/python3 -I scripts/ci/validate-floorp-notes-sync-production-qa-capability.py \
+            --capability "$capability" \
+            --source-sha "$GITHUB_SHA" \
+            --desktop-sha "$FLOORP_DESKTOP_COMMIT" \
+            --contract scripts/ci/floorp-notes-sync-g5-operation-contract.json \
+            --endpoint-policy docs/floorp-release-endpoints.json
+          /usr/bin/python3 -I scripts/ci/prepare-floorp-notes-sync-production-qa-build.py \
+            --capability "$capability" \
+            --source-sha "$GITHUB_SHA" \
+            --desktop-sha "$FLOORP_DESKTOP_COMMIT" \
+            --contract scripts/ci/floorp-notes-sync-g5-operation-contract.json \
+            --endpoint-policy docs/floorp-release-endpoints.json \
+            --output "$xcconfig"
+          {
+            printf 'FLOORP_NOTES_SYNC_QA_ROOT=%s\n' "$qa_root"
+            printf 'FLOORP_NOTES_SYNC_QA_CAPABILITY=%s\n' "$capability"
+            printf 'FLOORP_NOTES_SYNC_QA_XCCONFIG=%s\n' "$xcconfig"
+          } >> "$GITHUB_ENV"
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          xcode_version="$(<.xcode-version)"
+          sudo xcode-select --switch "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
+          xcodebuild -version
+
+      - name: Bootstrap generated sources
+        run: ./bootstrap.sh firefox
+        env:
+          CI: "true"
+
+      - name: Resolve Swift packages
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT_PATH" \
+            -scheme FloorpNotesSyncG5 \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
+      - name: Prepare dedicated QA Simulator
+        run: |
+          set -euo pipefail
+          runtime="com.apple.CoreSimulator.SimRuntime.iOS-${SIMULATOR_OS//./-}"
+          simulator_id="$(
+            xcrun simctl list devices available --json \
+              | jq -er --arg runtime "$runtime" --arg name "$SIMULATOR_NAME" \
+                '.devices[$runtime] | map(select(.name == $name)) | first | .udid'
+          )"
+          simulator_arch="$(uname -m)"
+          xcrun simctl boot "$simulator_id" 2>/dev/null || true
+          xcrun simctl bootstatus "$simulator_id" -b
+          printf 'FLOORP_NOTES_SYNC_QA_SIMULATOR_UDID=%s\n' "$simulator_id" >> "$GITHUB_ENV"
+          printf 'FLOORP_NOTES_SYNC_QA_DESTINATION=platform=iOS Simulator,id=%s,arch=%s\n' \
+            "$simulator_id" "$simulator_arch" >> "$GITHUB_ENV"
+
+      - name: Run protected two-client integrity QA
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 -I scripts/ci/run-floorp-notes-sync-production-qa.py \
+            --summary "$FLOORP_NOTES_SYNC_QA_ROOT/qa-summary.json" \
+            --cleanup-receipt "$FLOORP_NOTES_SYNC_QA_ROOT/cleanup-receipt.json" \
+            --desktop-log "$FLOORP_NOTES_SYNC_QA_ROOT/desktop.log" \
+            --xcodebuild-log "$FLOORP_NOTES_SYNC_QA_ROOT/xcodebuild.log" \
+            --client-state "$FLOORP_NOTES_SYNC_QA_ROOT/client-state" \
+            --desktop-root "$FLOORP_NOTES_SYNC_DESKTOP_ROOT" \
+            --desktop-sha "$FLOORP_DESKTOP_COMMIT" \
+            --simulator-udid "$FLOORP_NOTES_SYNC_QA_SIMULATOR_UDID" \
+            --coordination-root "/tmp/floorp-notes-sync-public-beta-qa-$GITHUB_RUN_ID" \
+            --ios-project "$GITHUB_WORKSPACE/$PROJECT_PATH" \
+            --destination "$FLOORP_NOTES_SYNC_QA_DESTINATION" \
+            --derived-data "$FLOORP_NOTES_SYNC_QA_ROOT/DerivedData" \
+            --source-packages "$RUNNER_TEMP/SourcePackages" \
+            --xcconfig "$FLOORP_NOTES_SYNC_QA_XCCONFIG" \
+            --result-bundle "$FLOORP_NOTES_SYNC_QA_ROOT/floorp-notes-sync-two-client.xcresult"
+        env:
+          FLOORP_NOTES_SYNC_ACCOUNT_A_EMAIL: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_A_EMAIL }}
+          FLOORP_NOTES_SYNC_ACCOUNT_A_PASSWORD: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_A_PASSWORD }}
+          FLOORP_NOTES_SYNC_ACCOUNT_B_EMAIL: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_B_EMAIL }}
+          FLOORP_NOTES_SYNC_ACCOUNT_B_PASSWORD: ${{ secrets.FLOORP_NOTES_SYNC_ACCOUNT_B_PASSWORD }}
+
+      - name: Validate live production-QA summary and cleanup receipt
+        if: success()
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 -I scripts/ci/validate-floorp-notes-sync-production-qa.py \
+            --summary "$FLOORP_NOTES_SYNC_QA_ROOT/qa-summary.json" \
+            --xcresult "$FLOORP_NOTES_SYNC_QA_ROOT/floorp-notes-sync-two-client.xcresult"
+          /usr/bin/python3 -I scripts/ci/validate-floorp-notes-sync-production-qa-cleanup.py \
+            --summary "$FLOORP_NOTES_SYNC_QA_ROOT/qa-summary.json" \
+            --receipt "$FLOORP_NOTES_SYNC_QA_ROOT/cleanup-receipt.json"
+
+      - name: Scan QA process arguments for secret exposure
+        if: always()
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 -I scripts/ci/scan-floorp-notes-sync-process-argv.py
+
+      - name: Clean up test accounts and client state
+        if: always()
+        run: |
+          set -euo pipefail
+          qa_root="${FLOORP_NOTES_SYNC_QA_ROOT:-$RUNNER_TEMP/floorp-notes-sync-public-beta-qa}"
+          if [ -d "$qa_root/client-state" ]; then
+            /usr/bin/python3 -I scripts/ci/cleanup-floorp-notes-sync-production-qa.py \
+              --work-root "$qa_root/client-state"
+          fi
+
+      - name: Clean up Simulator Keychain and local cache
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -n "${FLOORP_NOTES_SYNC_QA_SIMULATOR_UDID:-}" ]; then
+            xcrun simctl shutdown "$FLOORP_NOTES_SYNC_QA_SIMULATOR_UDID" || true
+            xcrun simctl erase "$FLOORP_NOTES_SYNC_QA_SIMULATOR_UDID"
+          fi
+
+      - name: Upload public-beta QA evidence
+        if: success()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: floorp-notes-sync-public-beta-qa-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/qa-summary.json
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/cleanup-receipt.json
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/production-qa-capability.json
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/production-qa.xcconfig
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/floorp-notes-sync-two-client.xcresult
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/xcodebuild.log
+            ${{ runner.temp }}/floorp-notes-sync-public-beta-qa/desktop.log
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove runner-local public-beta QA material
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -d "$RUNNER_TEMP/floorp-notes-sync-public-beta-qa" ]; then
+            /usr/bin/python3 -I scripts/ci/cleanup-floorp-notes-sync-production-qa.py \
+              --work-root "$RUNNER_TEMP/floorp-notes-sync-public-beta-qa"
+          fi

--- a/.github/workflows/floorp-public-beta-release.yml
+++ b/.github/workflows/floorp-public-beta-release.yml
@@ -1,0 +1,551 @@
+name: Floorp Public Beta Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      qa_run_id:
+        description: Successful Floorp Notes Sync public-beta QA workflow run ID.
+        required: true
+        type: string
+      approve_public_beta:
+        description: Approve the exact source-bound Sync public-beta candidate.
+        required: true
+        default: false
+        type: boolean
+      submit_external_beta:
+        description: Upload the candidate and submit it to the selected external TestFlight group and Beta App Review.
+        required: true
+        default: false
+        type: boolean
+      external_group_id:
+        description: Optional App Store Connect external beta group ID; leave blank only when exactly one external group exists.
+        required: false
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: floorp-public-beta-release-${{ github.run_id }}
+  cancel-in-progress: false
+
+env:
+  FLOORP_APP_STORE_ID: "6796708699"
+  FLOORP_MARKETING_VERSION: "0.2.0"
+  FLOORP_BUILD_NUMBER: "4"
+  PROJECT_PATH: firefox-ios/Client.xcodeproj
+  SOURCE_PACKAGES: ${{ runner.temp }}/SourcePackages
+
+jobs:
+  public-beta-release:
+    name: Sign, upload, and submit Floorp public beta
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.approve_public_beta == true
+    environment: floorp-notes-sync-production-qa
+    runs-on: macos-26
+    timeout-minutes: 240
+
+    steps:
+      - name: Check out exact main source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify clean source identity
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Validate QA run selector
+        env:
+          QA_RUN_ID: ${{ inputs.qa_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$QA_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+            printf '%s\n' '[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason=qa_run_id_invalid resume=provide a successful public-beta QA workflow run ID' >&2
+            exit 78
+          }
+
+      - name: Download source-bound public-beta QA evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: floorp-notes-sync-public-beta-qa-${{ inputs.qa_run_id }}
+          path: ${{ runner.temp }}/floorp-public-beta/qa
+          run-id: ${{ inputs.qa_run_id }}
+          repository: ${{ github.repository }}
+          github-token: ${{ github.token }}
+
+      - name: Verify QA evidence binding
+        env:
+          QA_RUN_ID: ${{ inputs.qa_run_id }}
+        run: |
+          set -euo pipefail
+          qa_root="$RUNNER_TEMP/floorp-public-beta/qa"
+          /usr/bin/python3 - "$qa_root" "$GITHUB_SHA" "$QA_RUN_ID" "$GITHUB_ENV" <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+          source_sha = sys.argv[2]
+          run_id = int(sys.argv[3])
+          env_path = Path(sys.argv[4])
+
+          def one(name: str) -> Path:
+              matches = [path for path in root.rglob(name) if path.is_file() and not path.is_symlink()]
+              if len(matches) != 1:
+                  raise SystemExit(f"[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason={name}_ambiguous resume=download one canonical QA artifact")
+              return matches[0]
+
+          summary_path = one("qa-summary.json")
+          capability_path = one("production-qa-capability.json")
+          summary = json.loads(summary_path.read_text(encoding="utf-8"))
+          capability = json.loads(capability_path.read_text(encoding="utf-8"))
+          source = summary.get("source", {})
+          if source.get("head_sha") != source_sha or source.get("workflow_run_id") != run_id:
+              raise SystemExit("[blocked] OID_DRIFT owner=Operations reason=qa_source_mismatch resume=use QA evidence from this exact main source SHA and run")
+          if source.get("job_name") != "notes-sync-public-beta-qa" or source.get("workflow_path") != ".github/workflows/floorp-notes-sync-public-beta-qa.yml":
+              raise SystemExit("[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason=qa_workflow_binding_invalid resume=use the public-beta QA workflow artifact")
+          if summary.get("public_release") is not False or capability.get("public_release") is not False:
+              raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=qa_artifact_is_distributable resume=regenerate the non-distributed public-beta QA artifact")
+          if capability.get("source") != source or capability.get("ios_build_number") != "4":
+              raise SystemExit("[blocked] OID_DRIFT owner=Operations reason=qa_capability_mismatch resume=use matching summary and capability artifacts")
+          desktop_sha = capability.get("desktop", {}).get("source_sha")
+          if not isinstance(desktop_sha, str) or len(desktop_sha) != 40:
+              raise SystemExit("[blocked] UPSTREAM_ARTIFACT_MISSING owner=Operations reason=desktop_source_missing resume=use a source-bound Desktop capability")
+
+          def write_env(name: str, value: str) -> None:
+              env_path.open("a", encoding="utf-8").write(f"{name}={value}\n")
+
+          write_env("FLOORP_PUBLIC_BETA_QA_ROOT", str(root))
+          write_env("FLOORP_PUBLIC_BETA_QA_SUMMARY", str(summary_path))
+          write_env("FLOORP_PUBLIC_BETA_QA_CAPABILITY", str(capability_path))
+          write_env("FLOORP_PUBLIC_BETA_DESKTOP_SHA", desktop_sha)
+          print('{"status":"qa-evidence-bound"}')
+          PY
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Select Xcode
+        run: |
+          set -euo pipefail
+          xcode_version="$(<.xcode-version)"
+          sudo xcode-select --switch "/Applications/Xcode_${xcode_version}.app/Contents/Developer"
+          xcodebuild -version
+
+      - name: Bootstrap generated sources
+        run: ./bootstrap.sh firefox
+        env:
+          CI: "true"
+
+      - name: Resolve Swift packages
+        run: |
+          set -euo pipefail
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT_PATH" \
+            -scheme Floorp \
+            -onlyUsePackageVersionsFromResolvedFile \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES"
+
+      - name: Create explicit public-beta evidence
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/floorp-public-beta/public-beta-evidence.json"
+          /usr/bin/python3 -I scripts/release/create-floorp-notes-sync-public-beta-evidence.py \
+            --summary "$FLOORP_PUBLIC_BETA_QA_SUMMARY" \
+            --capability "$FLOORP_PUBLIC_BETA_QA_CAPABILITY" \
+            --source-sha "$GITHUB_SHA" \
+            --desktop-sha "$FLOORP_PUBLIC_BETA_DESKTOP_SHA" \
+            --build-number "$FLOORP_BUILD_NUMBER" \
+            --operator-id "$GITHUB_ACTOR" \
+            --approve-public-beta \
+            --output "$evidence"
+          printf 'FLOORP_PUBLIC_BETA_EVIDENCE=%s\n' "$evidence" >> "$GITHUB_ENV"
+
+      - name: Install Apple signing and App Store Connect credentials
+        env:
+          APPLE_DEVELOPER_API_KEY_JSON: ${{ secrets.APPLE_DEVELOPER_API_KEY_JSON }}
+          APPLE_DEVELOPER_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_P12_BASE64 }}
+          APPLE_DEVELOPER_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_P12_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          root="$RUNNER_TEMP/floorp-public-beta"
+          test -n "$APPLE_DEVELOPER_API_KEY_JSON"
+          test -n "$APPLE_DEVELOPER_P12_BASE64"
+          test -n "$APPLE_DEVELOPER_P12_PASSWORD"
+          test -n "$APPLE_PROVISIONING_PROFILE_BASE64"
+          api_json="$root/app-store-connect-api.json"
+          p8="$root/AuthKey.p8"
+          p12="$root/AppleDistribution.p12"
+          profile="$root/Floorp-App-Store.mobileprovision"
+          profile_plist="$root/Floorp-App-Store.plist"
+          printf '%s' "$APPLE_DEVELOPER_API_KEY_JSON" > "$api_json"
+          /usr/bin/python3 - "$api_json" "$p8" "$GITHUB_ENV" <<'PY'
+          import base64
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          source, key_path, env_path = map(Path, sys.argv[1:])
+          value = json.loads(source.read_text(encoding="utf-8"))
+          issuer = value.get("issuer_id") or value.get("issuerId") or value.get("issuer")
+          key_id = value.get("key_id") or value.get("keyId") or value.get("key")
+          private_key = value.get("private_key") or value.get("privateKey") or value.get("api_key")
+          if not all(isinstance(item, str) and item for item in (issuer, key_id, private_key)):
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=app_store_connect_api_key_json_incomplete resume=store issuer_id, key_id, and private_key in APPLE_DEVELOPER_API_KEY_JSON")
+          if not re.fullmatch(r"[A-Za-z0-9._-]+", issuer) or not re.fullmatch(r"[A-Za-z0-9._-]+", key_id):
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=app_store_connect_api_key_identity_invalid resume=use the canonical App Store Connect API key JSON")
+          if private_key.lstrip().startswith("-----BEGIN"):
+              raw = private_key.encode("utf-8")
+          else:
+              try:
+                  raw = base64.b64decode(private_key, validate=True)
+              except Exception as error:
+                  raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=app_store_connect_private_key_invalid resume=store a PEM or base64-encoded p8 private_key") from error
+          if b"BEGIN PRIVATE KEY" not in raw:
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=app_store_connect_private_key_invalid resume=store the App Store Connect p8 private key")
+          key_path.write_bytes(raw)
+          os.chmod(key_path, 0o600)
+          with env_path.open("a", encoding="utf-8") as handle:
+              handle.write(f"APP_STORE_CONNECT_ISSUER_ID={issuer}\n")
+              handle.write(f"APP_STORE_CONNECT_KEY_ID={key_id}\n")
+              handle.write(f"APP_STORE_CONNECT_PRIVATE_KEY_PATH={key_path}\n")
+          PY
+          printf '%s' "$APPLE_DEVELOPER_P12_BASE64" | /usr/bin/base64 -D > "$p12"
+          keychain_password_file="$root/keychain-password"
+          /usr/bin/uuidgen > "$keychain_password_file"
+          keychain_password="$(<"$keychain_password_file")"
+          /usr/bin/security create-keychain -p "$keychain_password" "$root/floorp-build.keychain-db"
+          /usr/bin/security set-keychain-settings -lut 21600 "$root/floorp-build.keychain-db"
+          /usr/bin/security unlock-keychain -p "$keychain_password" "$root/floorp-build.keychain-db"
+          /usr/bin/security import "$p12" -k "$root/floorp-build.keychain-db" \
+            -P "$APPLE_DEVELOPER_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          /usr/bin/security set-key-partition-list -S apple-tool:,apple: -s \
+            -k "$keychain_password" "$root/floorp-build.keychain-db" >/dev/null
+          /usr/bin/security list-keychains -d user -s "$root/floorp-build.keychain-db" "$HOME/Library/Keychains/login.keychain-db"
+          printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | /usr/bin/base64 -D > "$profile"
+          /usr/bin/security cms -D -i "$profile" > "$profile_plist"
+          /usr/bin/python3 - "$profile_plist" <<'PY'
+          import plistlib
+          import sys
+          from pathlib import Path
+
+          profile = plistlib.loads(Path(sys.argv[1]).read_bytes())
+          if profile.get("Name") != "Floorp App Store":
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=provisioning_profile_name_invalid resume=use the Floorp App Store profile")
+          if profile.get("TeamIdentifier") != ["DV2U35YBHT"]:
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=provisioning_profile_team_invalid resume=use a DV2U35YBHT distribution profile")
+          if profile.get("Entitlements", {}).get("application-identifier") != "DV2U35YBHT.app.floorp.Floorp":
+              raise SystemExit("[blocked] AUTHORIZATION_MISSING owner=Operations reason=provisioning_profile_bundle_invalid resume=use the app.floorp.Floorp profile")
+          print('{"status":"signing-material-validated"}')
+          PY
+          profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$profile" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
+          printf 'FLOORP_PUBLIC_BETA_KEYCHAIN=%s\n' "$root/floorp-build.keychain-db" >> "$GITHUB_ENV"
+
+      - name: Build signed public-beta archive
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          archive="$root/Floorp.xcarchive"
+          mkdir -p "$root"
+          ./scripts/release/build-floorp-notes-sync-public-beta.sh \
+            --evidence "$FLOORP_PUBLIC_BETA_EVIDENCE" \
+            --source-sha "$GITHUB_SHA" \
+            --output-dir "$root/build" \
+            --archive "$archive"
+          printf 'FLOORP_PUBLIC_BETA_ARCHIVE=%s\n' "$archive" >> "$GITHUB_ENV"
+
+      - name: Export App Store distribution IPA
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          export_options="$root/ExportOptions.plist"
+          export_dir="$root/export"
+          /usr/bin/python3 - "$export_options" <<'PY'
+          import plistlib
+          import sys
+          from pathlib import Path
+
+          value = {
+              "method": "app-store",
+              "signingStyle": "manual",
+              "stripSwiftSymbols": True,
+              "uploadSymbols": True,
+              "teamID": "DV2U35YBHT",
+              "provisioningProfiles": {"app.floorp.Floorp": "Floorp App Store"},
+          }
+          Path(sys.argv[1]).write_bytes(plistlib.dumps(value, fmt=plistlib.FMT_XML, sort_keys=True))
+          PY
+          rm -rf "$export_dir"
+          mkdir -p "$export_dir"
+          xcodebuild -exportArchive \
+            -archivePath "$FLOORP_PUBLIC_BETA_ARCHIVE" \
+            -exportPath "$export_dir" \
+            -exportOptionsPlist "$export_options" \
+            | tee "$root/export.log"
+          ipa="$(find "$export_dir" -maxdepth 1 -type f -name '*.ipa' -print -quit)"
+          test -n "$ipa" && test -f "$ipa"
+          printf 'FLOORP_PUBLIC_BETA_IPA=%s\n' "$ipa" >> "$GITHUB_ENV"
+
+      - name: Validate signed release evidence before upload
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          /bin/bash scripts/release/collect-floorp-release-evidence.sh \
+            --archive "$FLOORP_PUBLIC_BETA_ARCHIVE" \
+            --ipa "$FLOORP_PUBLIC_BETA_IPA" \
+            --source-sha "$GITHUB_SHA" \
+            --export-status ready-for-upload \
+            --output "$root/release-evidence.json"
+          /usr/bin/python3 -I scripts/release/validate-floorp-release-evidence.py \
+            --evidence "$root/release-evidence.json" \
+            --schema scripts/release/floorp-release-evidence.schema.json
+
+      - name: Upload IPA to App Store Connect
+        run: |
+          set -euo pipefail
+          if xcrun altool --help >/dev/null 2>&1; then
+            xcrun altool --upload-app \
+              --file "$FLOORP_PUBLIC_BETA_IPA" \
+              --type ios \
+              --apiKey "$APP_STORE_CONNECT_KEY_ID" \
+              --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
+          else
+            xcrun iTMSTransporter -m upload \
+              -assetFile "$FLOORP_PUBLIC_BETA_IPA" \
+              -apiKey "$APP_STORE_CONNECT_KEY_ID" \
+              -apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
+          fi
+
+      - name: Wait for the uploaded build to process
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          builds="$root/builds.json"
+          build_id_file="$root/build-id"
+          deadline=$((SECONDS + 3600))
+          while (( SECONDS < deadline )); do
+            /usr/bin/python3 scripts/release/app-store-connect-api.py get \
+              "/v1/builds?filter[app]=$FLOORP_APP_STORE_ID&filter[preReleaseVersion.version]=$FLOORP_MARKETING_VERSION&filter[version]=$FLOORP_BUILD_NUMBER&limit=200" \
+              --output "$builds"
+            state="$(/usr/bin/python3 - "$builds" "$build_id_file" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          value = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          rows = value.get("data", [])
+          if not rows:
+              print("pending")
+              raise SystemExit(0)
+          row = rows[0]
+          attributes = row.get("attributes", {})
+          processing = attributes.get("processingState")
+          if processing in {"FAILED", "INVALID"}:
+              print("failed")
+              raise SystemExit(0)
+          if processing != "VALID":
+              print("pending")
+              raise SystemExit(0)
+          Path(sys.argv[2]).write_text(row["id"] + "\n", encoding="utf-8")
+          print("ready")
+          PY
+            )"
+            if [ "$state" = "ready" ]; then
+              break
+            fi
+            if [ "$state" = "failed" ]; then
+              printf '%s\n' '[blocked] UPSTREAM_ARTIFACT_MISSING owner=Apple reason=app_store_build_processing_failed resume=inspect the App Store Connect processing diagnostic for this exact build' >&2
+              exit 1
+            fi
+            sleep 30
+          done
+          test -s "$build_id_file" || {
+            printf '%s\n' '[blocked] UPSTREAM_ARTIFACT_MISSING owner=Apple reason=app_store_build_processing_timeout resume=wait for App Store Connect processing or inspect the uploaded build' >&2
+            exit 1
+          }
+          build_id="$(<"$build_id_file")"
+          printf 'FLOORP_ASC_BUILD_ID=%s\n' "$build_id" >> "$GITHUB_ENV"
+
+      - name: Read external TestFlight group and review details
+        if: inputs.submit_external_beta == true
+        env:
+          FLOORP_EXTERNAL_GROUP_REQUESTED: ${{ inputs.external_group_id }}
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          /usr/bin/python3 scripts/release/app-store-connect-api.py get \
+            "/v1/betaGroups?filter[app]=$FLOORP_APP_STORE_ID&limit=200" \
+            --output "$root/beta-groups-before.json"
+          /usr/bin/python3 scripts/release/app-store-connect-api.py get \
+            "/v1/betaAppReviewDetails?filter[app]=$FLOORP_APP_STORE_ID" \
+            --output "$root/review-details-before.json"
+          /usr/bin/python3 - "$root/beta-groups-before.json" "$FLOORP_EXTERNAL_GROUP_REQUESTED" "$root/external-group-id" "$GITHUB_ENV" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          groups = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("data", [])
+          requested = sys.argv[2].strip()
+          if requested and not re.fullmatch(r"[A-Za-z0-9._-]+", requested):
+              raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=external_group_id_invalid resume=provide the App Store Connect external beta group ID")
+          external = [
+              row for row in groups
+              if isinstance(row, dict)
+              and row.get("attributes", {}).get("isInternalGroup") is False
+          ]
+          if requested:
+              matches = [row for row in external if row.get("id") == requested]
+              if len(matches) != 1:
+                  raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=external_group_id_not_found_or_internal resume=select an existing external TestFlight group")
+              chosen = requested
+          elif len(external) == 1:
+              chosen = external[0].get("id")
+          else:
+              raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=external_group_selection_required resume=provide external_group_id when zero or multiple external groups exist")
+          if not isinstance(chosen, str) or not chosen:
+              raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=external_group_id_missing resume=select an existing external TestFlight group")
+          Path(sys.argv[3]).write_text(chosen + "\n", encoding="utf-8")
+          with Path(sys.argv[4]).open("a", encoding="utf-8") as handle:
+              handle.write(f"FLOORP_EXTERNAL_GROUP_ID={chosen}\n")
+          print('{"status":"external-group-selected"}')
+          PY
+          /usr/bin/python3 - "$root/review-details-before.json" "$root/beta-review-details.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          rows = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8")).get("data", [])
+          if not rows:
+              raise SystemExit("[blocked] AGREEMENT_MISSING owner=Apple reason=beta_app_review_details_missing resume=create the App Store Connect Beta App Review details record")
+          attributes = rows[0].get("attributes", {})
+          required = (
+              "contactEmail", "contactFirstName", "contactLastName", "contactPhone",
+              "demoAccountName", "demoAccountPassword",
+          )
+          if any(not isinstance(attributes.get(name), str) or not attributes[name].strip() for name in required):
+              raise SystemExit("[blocked] EXTERNAL_REVIEW_PENDING owner=Operations reason=beta_app_review_details_incomplete resume=complete the live App Store Connect reviewer contact and demo-account fields")
+          details = {name: attributes[name] for name in (*required, "notes") if name in attributes}
+          Path(sys.argv[2]).write_text(json.dumps(details, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+          print('{"status":"review-details-preflight-passed"}')
+          PY
+
+      - name: Submit processed build to external TestFlight and Beta App Review
+        if: inputs.submit_external_beta == true
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          /bin/bash scripts/release/submit-floorp-external-beta.sh \
+            --client scripts/release/app-store-connect-api.py \
+            --app-id "$FLOORP_APP_STORE_ID" \
+            --build-id "$FLOORP_ASC_BUILD_ID" \
+            --external-group-id "$FLOORP_EXTERNAL_GROUP_ID" \
+            --localization docs/app-store-connect-metadata.json \
+            --review-details "$root/beta-review-details.json" \
+            --before "$root/asc-before.json" \
+            --after "$root/asc-after.json" \
+            --what-to-test-en firefox-ios/TestFlight/WhatToTest.en-US.txt \
+            --what-to-test-ja firefox-ios/TestFlight/WhatToTest.ja-JP.txt \
+            --authorize-mutation \
+            --output "$root/public-beta-submission.json"
+
+      - name: Verify external TestFlight readback
+        if: inputs.submit_external_beta == true
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          /usr/bin/python3 scripts/release/app-store-connect-api.py get \
+            "/v1/betaGroups/$FLOORP_EXTERNAL_GROUP_ID/builds" \
+            --output "$root/external-group-builds-after.json"
+          /usr/bin/python3 scripts/release/app-store-connect-api.py get \
+            "/v1/betaAppReviewSubmissions?filter[build]=$FLOORP_ASC_BUILD_ID" \
+            --output "$root/beta-review-submissions-after.json"
+          /usr/bin/python3 - "$root" "$FLOORP_ASC_BUILD_ID" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          root = Path(sys.argv[1])
+          build_id = sys.argv[2]
+          group = json.loads((root / "external-group-builds-after.json").read_text(encoding="utf-8"))
+          submissions = json.loads((root / "beta-review-submissions-after.json").read_text(encoding="utf-8"))
+          if not any(row.get("id") == build_id for row in group.get("data", [])):
+              raise SystemExit("[blocked] UPSTREAM_ARTIFACT_MISSING owner=Apple reason=external_group_assignment_not_read_back resume=inspect App Store Connect group assignment")
+          submission_rows = submissions.get("data", [])
+          if not submission_rows:
+              raise SystemExit("[blocked] UPSTREAM_ARTIFACT_MISSING owner=Apple reason=beta_app_review_submission_not_read_back resume=inspect App Store Connect Beta App Review submission")
+          result = {
+              "build_id": build_id,
+              "external_group_assignment": True,
+              "beta_app_review_submission": True,
+              "submission_id": submission_rows[0].get("id"),
+              "status": "submitted",
+          }
+          (root / "testflight-readback.json").write_text(json.dumps(result, sort_keys=True) + "\n", encoding="utf-8")
+          print('{"status":"external-testflight-readback-verified"}')
+          PY
+
+      - name: Bind final release evidence to the processed build
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/floorp-public-beta"
+          /bin/bash scripts/release/collect-floorp-release-evidence.sh \
+            --archive "$FLOORP_PUBLIC_BETA_ARCHIVE" \
+            --ipa "$FLOORP_PUBLIC_BETA_IPA" \
+            --source-sha "$GITHUB_SHA" \
+            --app-store-connect-build-id "$FLOORP_ASC_BUILD_ID" \
+            --export-status uploaded-and-processed \
+            --output "$root/release-evidence.json"
+          /usr/bin/python3 -I scripts/release/validate-floorp-release-evidence.py \
+            --evidence "$root/release-evidence.json" \
+            --schema scripts/release/floorp-release-evidence.schema.json
+
+      - name: Upload public-beta release evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: floorp-public-beta-release-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/floorp-public-beta/public-beta-evidence.json
+            ${{ runner.temp }}/floorp-public-beta/public-beta-submission.json
+            ${{ runner.temp }}/floorp-public-beta/testflight-readback.json
+            ${{ runner.temp }}/floorp-public-beta/release-evidence.json
+            ${{ runner.temp }}/floorp-public-beta/build/public-beta-build.json
+            ${{ runner.temp }}/floorp-public-beta/builds.json
+            ${{ runner.temp }}/floorp-public-beta/asc-before.json
+            ${{ runner.temp }}/floorp-public-beta/asc-after.json
+            ${{ runner.temp }}/floorp-public-beta/beta-groups-before.json
+            ${{ runner.temp }}/floorp-public-beta/external-group-builds-after.json
+            ${{ runner.temp }}/floorp-public-beta/beta-review-submissions-after.json
+            ${{ runner.temp }}/floorp-public-beta/build/xcodebuild.log
+            ${{ runner.temp }}/floorp-public-beta/export.log
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Remove signing material and runner-local release material
+        if: always()
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/floorp-public-beta/floorp-build.keychain-db"
+          if [ -e "$keychain" ]; then
+            /usr/bin/security delete-keychain "$keychain" || true
+          fi
+          rm -rf "$RUNNER_TEMP/floorp-public-beta"

--- a/.github/workflows/floorp-public-beta-release.yml
+++ b/.github/workflows/floorp-public-beta-release.yml
@@ -35,7 +35,6 @@ env:
   FLOORP_MARKETING_VERSION: "0.2.0"
   FLOORP_BUILD_NUMBER: "4"
   PROJECT_PATH: firefox-ios/Client.xcodeproj
-  SOURCE_PACKAGES: ${{ runner.temp }}/SourcePackages
 
 jobs:
   public-beta-release:
@@ -152,6 +151,7 @@ jobs:
       - name: Resolve Swift packages
         run: |
           set -euo pipefail
+          printf 'SOURCE_PACKAGES=%s\n' "$RUNNER_TEMP/SourcePackages" >> "$GITHUB_ENV"
           xcodebuild -resolvePackageDependencies \
             -project "$PROJECT_PATH" \
             -scheme Floorp \

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -8,13 +8,15 @@ This document defines the delivery foundation for Floorp for iOS. The repository
 | --- | --- | --- |
 | Pull-request build and unit tests | GitHub Actions | Implemented in `.github/workflows/ci.yml` |
 | Notes Sync production QA | GitHub Actions | Manual, protected workflow in `.github/workflows/floorp-notes-sync-production-qa.yml` |
+| Notes Sync public-beta QA | GitHub Actions | Separate manual, protected two-account workflow in `.github/workflows/floorp-notes-sync-public-beta-qa.yml` |
+| Signed public-beta delivery | GitHub Actions | Manual, source-bound workflow in `.github/workflows/floorp-public-beta-release.yml` |
 | Upstream Firefox synchronization | GitHub Actions | Weekly draft-PR workflow with trusted automation restoration, reviewed localization conflict resolution, and explicit CI dispatch |
 | Signed archive and internal TestFlight | Manual Xcode upload | `0.1.0 (2)` signed, uploaded, and verified by the internal group |
 | Repeatable signed delivery | Xcode Cloud | Scaffold implemented; workflow not yet configured |
 | App Store release | App Store Connect | Manual approval initially |
 | Mozilla/Focus maintenance automation | Git history | Removed pending a Floorp-owned replacement |
 
-GitHub Actions does not receive an Apple certificate or private key. The first build was uploaded manually from a locally signed archive. Xcode Cloud remains the preferred repeatable CD system because it supports cloud-managed signing and direct TestFlight distribution.
+The public-beta release job receives signing and App Store Connect material only as protected GitHub secrets for the one approved run; no certificate, profile, p8 key, or password is committed. The first build was uploaded manually from a locally signed archive. Xcode Cloud remains the preferred repeatable CD system for routine delivery because it supports cloud-managed signing and direct TestFlight distribution.
 
 ### Validated Internal TestFlight baseline
 
@@ -102,7 +104,7 @@ Notes on the live contract:
 
 ## Release readiness
 
-Do not create an App Store archive from `Fennec`; it remains a development configuration. Use the shared `Floorp` scheme and its `FloorpRelease` Archive action. The repository-side release scaffold is implemented; every release candidate still requires a signed archive and Organizer validation before TestFlight distribution. A Notes Sync public-beta candidate uses `scripts/release/create-floorp-notes-sync-public-beta-evidence.py` followed by `scripts/release/build-floorp-notes-sync-public-beta.sh`; the checked-in `FloorpRelease` default remains Sync-disabled.
+Do not create an App Store archive from `Fennec`; it remains a development configuration. Use the shared `Floorp` scheme and its `FloorpRelease` Archive action. The repository-side release scaffold is implemented; every release candidate still requires a signed archive and Organizer validation before TestFlight distribution. A Notes Sync public-beta candidate uses the separate protected `floorp-notes-sync-public-beta-qa.yml` workflow, then `scripts/release/create-floorp-notes-sync-public-beta-evidence.py` and `scripts/release/build-floorp-notes-sync-public-beta.sh`; the checked-in `FloorpRelease` default remains Sync-disabled. The manual `floorp-public-beta-release.yml` workflow can consume that exact QA run, sign and upload the candidate, and submit it to an already-existing external TestFlight group after the live App Store Connect review details pass a read-only preflight.
 
 ### Release build configuration
 
@@ -199,7 +201,7 @@ After the shared `Floorp` scheme archives locally with `FloorpRelease` and passe
 7. After several successful builds, add a `main` or release-tag start condition.
 8. Download and retain each shipped archive and its dSYMs outside Xcode Cloud; Xcode Cloud build information and artifacts are available for only 30 days.
 
-External TestFlight groups, Beta App Review submission, and App Store submission remain manual until internal distribution is stable.
+The public-beta workflow does not create groups or invent reviewer credentials. It selects one existing external group (or requires its explicit ID), reuses complete live Beta App Review details, records before/after state, and stops with a blocker if Apple agreements, review details, or group setup are incomplete.
 
 ## Later hardening
 

--- a/docs/floorp-notes-sync-build-contract.md
+++ b/docs/floorp-notes-sync-build-contract.md
@@ -154,6 +154,14 @@ selector; a passed
 renaming an ordinary FloorpCI result, or reusing the canonical artifact name
 does not satisfy this requirement.
 
+The external public-beta route is intentionally separate from that legacy
+Todo20 admission job. A successful, manually dispatched `main` run of
+`.github/workflows/floorp-notes-sync-public-beta-qa.yml` publishes the same
+metadata-only two-client result under a run-specific artifact name and is
+accepted only as the source of a `public-beta` evidence record. It does not
+consume the stale guarded-merge receipts or owner-waiver variables used by
+the historical production-QA job.
+
 Ordinary PR/main CI compiles only the static preflight selector
 `XCUITests/FloorpNotesSyncTwoClientMatrixTests/testTwoClientProductionMatrix`
 without executing its protected selector. This compile-only output has no
@@ -470,9 +478,10 @@ OUT="$(mktemp -d "${TMPDIR:-/tmp}/floorp-notes-sync-real.XXXXXX")"
 An enabled real build additionally requires current validated evidence whose
 `release_inputs.ios.build_number` is exactly the `FloorpRelease` build number.
 
-The wrapper builds or archives only. It does not export or upload the app,
-publish a release, submit to App Store Connect, or create a TestFlight link.
-Enabled modes do make narrowly scoped GitHub API requests through the pinned
+The public-beta build wrapper builds and archives only. The protected
+`floorp-public-beta-release.yml` workflow performs export, signing, upload,
+and the allowlisted external TestFlight/Beta App Review submission after an
+explicit approval input. Enabled modes do make narrowly scoped GitHub API requests through the pinned
 `gh` copy to validate retrievable evidence and to dispatch and capture the
 validation-clock workflow.
 

--- a/firefox-ios/Floorp/FloorpNotesSync.swift
+++ b/firefox-ios/Floorp/FloorpNotesSync.swift
@@ -911,10 +911,10 @@ enum FloorpNotesSyncReleaseGate {
               ),
               source["event"] as? String == "workflow_dispatch",
               source["head_sha"] as? String == sourceSHA,
-              source["job_name"] as? String == "notes-sync-production-qa",
+              source["job_name"] as? String == "notes-sync-public-beta-qa",
               source["repository"] as? String == "Floorp-Projects/floorp-ios",
               source["workflow_path"] as? String
-                == ".github/workflows/floorp-notes-sync-production-qa.yml",
+                == ".github/workflows/floorp-notes-sync-public-beta-qa.yml",
               isJSONInteger(source["workflow_run_attempt"], greaterThan: 0),
               isJSONInteger(source["workflow_run_id"], greaterThan: 0),
               let qa = root["qa"] as? [String: Any],

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesSyncTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpNotesSyncTests.swift
@@ -2576,11 +2576,11 @@ final class FloorpNotesSyncEngineSelectionTests: XCTestCase {
     func testPublicBetaEvidenceBindsProtectedQAAndExplicitApproval() throws {
         let sourceSHA = String(repeating: "d", count: 40)
         let endpointPolicySHA = "af96437acde3d05eb8f18dc9cc81450aa9d61703579c092b962922de8934c9ca"
-        let workflowPath = ".github/workflows/floorp-notes-sync-production-qa.yml"
+        let workflowPath = ".github/workflows/floorp-notes-sync-public-beta-qa.yml"
         let source: [String: Any] = [
             "event": "workflow_dispatch",
             "head_sha": sourceSHA,
-            "job_name": "notes-sync-production-qa",
+            "job_name": "notes-sync-public-beta-qa",
             "repository": "Floorp-Projects/floorp-ios",
             "workflow_path": workflowPath,
             "workflow_run_attempt": 1,

--- a/scripts/ci/create-floorp-notes-sync-production-qa-capability.py
+++ b/scripts/ci/create-floorp-notes-sync-production-qa-capability.py
@@ -20,6 +20,8 @@ from floorp_notes_sync_production_qa_capability import (  # noqa: E402
     ENVIRONMENT,
     INVARIANT_NAMES,
     JOB_NAME,
+    PUBLIC_BETA_JOB_NAME,
+    PUBLIC_BETA_WORKFLOW_PATH,
     REPOSITORY,
     WORKFLOW_PATH,
     canonical_bytes,
@@ -48,7 +50,15 @@ def required_environment() -> dict[str, str]:
         raise CapabilityCreationError("[blocked] AUTHORIZATION_MISSING owner=Operations reason=execution_context_missing resume=run in the protected workflow")
     if values["GITHUB_EVENT_NAME"] != "workflow_dispatch" or values["GITHUB_REF"] != "refs/heads/main":
         raise CapabilityCreationError("[blocked] AUTHORIZATION_MISSING owner=Operations reason=workflow_binding_invalid resume=dispatch the protected job from main")
-    if values["GITHUB_REPOSITORY"] != REPOSITORY or not values["GITHUB_WORKFLOW_REF"].startswith(f"{REPOSITORY}/{WORKFLOW_PATH}@"):
+    expected_workflow_path = {
+        JOB_NAME: WORKFLOW_PATH,
+        PUBLIC_BETA_JOB_NAME: PUBLIC_BETA_WORKFLOW_PATH,
+    }.get(values["GITHUB_JOB"])
+    if (
+        values["GITHUB_REPOSITORY"] != REPOSITORY
+        or expected_workflow_path is None
+        or not values["GITHUB_WORKFLOW_REF"].startswith(f"{REPOSITORY}/{expected_workflow_path}@")
+    ):
         raise CapabilityCreationError("[blocked] AUTHORIZATION_MISSING owner=Operations reason=workflow_binding_invalid resume=bind the record to the canonical ci workflow")
     if SHA1.fullmatch(values["GITHUB_SHA"]) is None:
         raise CapabilityCreationError("[blocked] AUTHORIZATION_MISSING owner=Operations reason=head_sha_invalid resume=use the immutable workflow head")
@@ -119,7 +129,10 @@ def main(arguments: list[str] | None = None) -> int:
                 "head_sha": environment["GITHUB_SHA"],
                 "job_name": environment["GITHUB_JOB"] or JOB_NAME,
                 "repository": environment["GITHUB_REPOSITORY"],
-                "workflow_path": WORKFLOW_PATH,
+                "workflow_path": {
+                    JOB_NAME: WORKFLOW_PATH,
+                    PUBLIC_BETA_JOB_NAME: PUBLIC_BETA_WORKFLOW_PATH,
+                }[environment["GITHUB_JOB"]],
                 "workflow_run_attempt": int(environment["GITHUB_RUN_ATTEMPT"]),
                 "workflow_run_id": int(environment["GITHUB_RUN_ID"]),
             },

--- a/scripts/ci/floorp_notes_sync_live_executor.py
+++ b/scripts/ci/floorp_notes_sync_live_executor.py
@@ -49,7 +49,13 @@ APPROVED_HOSTS = [
 ENVIRONMENT = "floorp-notes-sync-production-qa"
 REPOSITORY = "Floorp-Projects/floorp-ios"
 WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-production-qa.yml"
+PUBLIC_BETA_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-public-beta-qa.yml"
 JOB_NAME = "notes-sync-production-qa"
+PUBLIC_BETA_JOB_NAME = "notes-sync-public-beta-qa"
+JOB_BINDINGS = {
+    JOB_NAME: WORKFLOW_PATH,
+    PUBLIC_BETA_JOB_NAME: PUBLIC_BETA_WORKFLOW_PATH,
+}
 SHA1 = re.compile(r"[0-9a-f]{40}\Z")
 INVARIANT_CASES = {
     "no-data-loss": frozenset(
@@ -129,7 +135,7 @@ def source_from_environment() -> dict[str, Any]:
             "head_sha": os.environ["GITHUB_SHA"],
             "job_name": os.environ["GITHUB_JOB"],
             "repository": os.environ["GITHUB_REPOSITORY"],
-            "workflow_path": WORKFLOW_PATH,
+            "workflow_path": JOB_BINDINGS.get(os.environ["GITHUB_JOB"], ""),
             "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
             "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
         }
@@ -142,11 +148,11 @@ def source_from_environment() -> dict[str, Any]:
     if (
         source["event"] != "workflow_dispatch"
         or os.environ["GITHUB_REF"] != "refs/heads/main"
-        or source["job_name"] != JOB_NAME
+        or source["job_name"] not in JOB_BINDINGS
         or source["repository"] != REPOSITORY
         or not SHA1.fullmatch(source["head_sha"])
         or not os.environ["GITHUB_WORKFLOW_REF"].startswith(
-            f"{REPOSITORY}/{WORKFLOW_PATH}@"
+            f"{REPOSITORY}/{JOB_BINDINGS[source['job_name']]}@"
         )
     ):
         raise LiveExecutorError(

--- a/scripts/ci/floorp_notes_sync_production_qa_capability.py
+++ b/scripts/ci/floorp_notes_sync_production_qa_capability.py
@@ -15,7 +15,10 @@ CAPABILITY_VERSION = "todo20-production-sync-integrity-v1"
 REPOSITORY = "Floorp-Projects/floorp-ios"
 ENVIRONMENT = "floorp-notes-sync-production-qa"
 WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-production-qa.yml"
+PUBLIC_BETA_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-public-beta-qa.yml"
 JOB_NAME = "notes-sync-production-qa"
+PUBLIC_BETA_JOB_NAME = "notes-sync-public-beta-qa"
+JOB_NAMES = (JOB_NAME, PUBLIC_BETA_JOB_NAME)
 APPROVED_FXA_HOSTS = [
     "accounts.firefox.com",
     "api.accounts.firefox.com",
@@ -158,11 +161,15 @@ def validate_capability(
         {"event", "head_sha", "job_name", "repository", "workflow_path", "workflow_run_attempt", "workflow_run_id"},
         "capability source",
     )
+    expected_workflow_path = {
+        JOB_NAME: WORKFLOW_PATH,
+        PUBLIC_BETA_JOB_NAME: PUBLIC_BETA_WORKFLOW_PATH,
+    }.get(source["job_name"])
     if (
         source["event"] != "workflow_dispatch"
-        or source["job_name"] != JOB_NAME
+        or expected_workflow_path is None
         or source["repository"] != REPOSITORY
-        or source["workflow_path"] != WORKFLOW_PATH
+        or source["workflow_path"] != expected_workflow_path
     ):
         raise CapabilityError("capability source is not the protected workflow")
     source_sha = _sha(source["head_sha"], "source head", SHA1)
@@ -245,6 +252,9 @@ __all__ = [
     "ENVIRONMENT",
     "INVARIANT_NAMES",
     "JOB_NAME",
+    "JOB_NAMES",
+    "PUBLIC_BETA_JOB_NAME",
+    "PUBLIC_BETA_WORKFLOW_PATH",
     "REPOSITORY",
     "WORKFLOW_PATH",
     "canonical_bytes",

--- a/scripts/ci/test_floorp_notes_sync_production_qa_capability.py
+++ b/scripts/ci/test_floorp_notes_sync_production_qa_capability.py
@@ -19,6 +19,8 @@ from floorp_notes_sync_production_qa_capability import (  # noqa: E402
     ENVIRONMENT,
     INVARIANT_NAMES,
     JOB_NAME,
+    PUBLIC_BETA_JOB_NAME,
+    PUBLIC_BETA_WORKFLOW_PATH,
     REPOSITORY,
     WORKFLOW_PATH,
     canonical_bytes,
@@ -77,6 +79,12 @@ class ProductionQACapabilityTests(unittest.TestCase):
         record["public_release"] = True
         with self.assertRaises(CapabilityError):
             validate_capability(record)
+
+    def test_public_beta_job_and_workflow_binding_is_accepted(self) -> None:
+        record = valid_record()
+        record["source"]["job_name"] = PUBLIC_BETA_JOB_NAME
+        record["source"]["workflow_path"] = PUBLIC_BETA_WORKFLOW_PATH
+        self.assertEqual(validate_capability(record)["source"]["job_name"], PUBLIC_BETA_JOB_NAME)
 
     def test_contract_and_endpoint_digests_can_be_bound_to_checked_out_bytes(self) -> None:
         record = valid_record()

--- a/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
@@ -86,6 +86,23 @@ class LiveExecutorContractTests(unittest.TestCase):
             with self.assertRaises(EXECUTOR.LiveExecutorError):
                 EXECUTOR.source_from_environment()
 
+    def test_source_binding_accepts_the_separate_public_beta_workflow(self) -> None:
+        context = {
+            "GITHUB_ACTOR": "operator",
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "GITHUB_JOB": EXECUTOR.PUBLIC_BETA_JOB_NAME,
+            "GITHUB_REF": "refs/heads/main",
+            "GITHUB_REPOSITORY": EXECUTOR.REPOSITORY,
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "123",
+            "GITHUB_SHA": "a" * 40,
+            "GITHUB_WORKFLOW_REF": f"{EXECUTOR.REPOSITORY}/{EXECUTOR.PUBLIC_BETA_WORKFLOW_PATH}@{'a' * 40}",
+        }
+        with patch.dict(os.environ, context, clear=True):
+            source = EXECUTOR.source_from_environment()
+        self.assertEqual(source["job_name"], EXECUTOR.PUBLIC_BETA_JOB_NAME)
+        self.assertEqual(source["workflow_path"], EXECUTOR.PUBLIC_BETA_WORKFLOW_PATH)
+
     def test_xcodebuild_command_contains_no_account_values(self) -> None:
         args = Namespace(
             ios_project=Path("/tmp/project.xcodeproj"),

--- a/scripts/ci/tests/test_validate_floorp_notes_sync_production_qa.py
+++ b/scripts/ci/tests/test_validate_floorp_notes_sync_production_qa.py
@@ -82,6 +82,12 @@ class ValidateFloorpNotesSyncProductionQATests(unittest.TestCase):
         summary = valid_summary()
         self.assertEqual(QA.validate_summary(summary), summary)
 
+    def test_public_beta_workflow_binding_is_accepted(self) -> None:
+        summary = valid_summary()
+        summary["source"]["job_name"] = "notes-sync-public-beta-qa"
+        summary["source"]["workflow_path"] = ".github/workflows/floorp-notes-sync-public-beta-qa.yml"
+        self.assertEqual(QA.validate_summary(summary), summary)
+
     def test_sensitive_fields_and_payload_are_rejected(self) -> None:
         for field in ("password", "notes_payload", "authorization", "email"):
             with self.subTest(field=field):

--- a/scripts/ci/validate-floorp-notes-sync-production-qa.py
+++ b/scripts/ci/validate-floorp-notes-sync-production-qa.py
@@ -37,6 +37,10 @@ APPROVED_SYNC_HOSTS = (
     "token.services.mozilla.com",
 )
 APPROVED_HOSTS = tuple(sorted((*APPROVED_FXA_HOSTS, *APPROVED_SYNC_HOSTS)))
+ALLOWED_SOURCE_BINDINGS = {
+    ("notes-sync-production-qa", ".github/workflows/floorp-notes-sync-production-qa.yml"),
+    ("notes-sync-public-beta-qa", ".github/workflows/floorp-notes-sync-public-beta-qa.yml"),
+}
 REQUIRED_CASES = (
     "desktop-create-mobile-sync-desktop-recheck",
     "mobile-create-desktop-sync-mobile-recheck",
@@ -220,8 +224,10 @@ def validate_summary(summary: Any) -> dict[str, Any]:
     )
     require(source["repository"] == REPOSITORY, "QA source repository is not canonical")
     require(source["event"] == "workflow_dispatch", "QA source is not a manual dispatch")
-    require(source["job_name"] == "notes-sync-production-qa", "QA source job is not canonical")
-    require(source["workflow_path"] == ".github/workflows/floorp-notes-sync-production-qa.yml", "QA source workflow is not canonical")
+    require(
+        (source["job_name"], source["workflow_path"]) in ALLOWED_SOURCE_BINDINGS,
+        "QA source job/workflow is not canonical",
+    )
     safe_string(source["head_sha"], "QA source head SHA", SHA1)
     require(isinstance(source["workflow_run_id"], int) and source["workflow_run_id"] > 0, "QA run ID is invalid")
     require(

--- a/scripts/release/create-floorp-notes-sync-public-beta-evidence.py
+++ b/scripts/release/create-floorp-notes-sync-public-beta-evidence.py
@@ -25,6 +25,8 @@ CONTRACT_PATH = ROOT / "scripts/ci/floorp-notes-sync-g5-operation-contract.json"
 ENDPOINT_POLICY_PATH = ROOT / "docs/floorp-release-endpoints.json"
 REPOSITORY = "Floorp-Projects/floorp-ios"
 WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-production-qa.yml"
+PUBLIC_BETA_WORKFLOW_PATH = ".github/workflows/floorp-notes-sync-public-beta-qa.yml"
+PUBLIC_BETA_JOB_NAME = "notes-sync-public-beta-qa"
 SHA1 = re.compile(r"[0-9a-f]{40}\Z")
 SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 
@@ -110,7 +112,8 @@ def main(arguments: list[str] | None = None) -> int:
         source = summary["source"]
         require(source["repository"] == REPOSITORY, "QA repository is not canonical")
         require(source["head_sha"] == args.source_sha, "QA source SHA does not match the candidate")
-        require(source["workflow_path"] == WORKFLOW_PATH, "QA workflow path is not canonical")
+        require(source["job_name"] == PUBLIC_BETA_JOB_NAME, "QA source job is not the public-beta QA job")
+        require(source["workflow_path"] == PUBLIC_BETA_WORKFLOW_PATH, "QA workflow path is not the public-beta QA workflow")
         require(summary["public_release"] is False, "QA summary must remain non-distributable")
 
         capability = CAPABILITY.load_capability(


### PR DESCRIPTION
## Summary
- add a separate protected two-account public-beta Notes Sync QA workflow
- bind public-beta evidence to the exact main source, QA run, Desktop SHA, endpoint policy, and FloorpRelease build
- add a protected GitHub Actions release workflow for signing, App Store Connect upload, external TestFlight assignment, and Beta App Review submission
- keep the historical Todo20 guarded-merge workflow unchanged and out of the public-beta path

## Validation
- CI test suite: 305 passed
- Release test suite: 39 passed
- Swift parse, YAML parse, shell syntax, and diff checks passed
