### PR TITLE
fix: use absolute simulator coordination tools

### DIFF
--- a/scripts/ci/floorp_notes_sync_live_executor.py
+++ b/scripts/ci/floorp_notes_sync_live_executor.py
@@ -84,6 +84,10 @@ CASE_BLOCKERS = {
         "resume=provide metadata-only base/revision observation before failure and after authoritative commit"
     ),
 }
+# simctl can pass host runtime-root paths as PATH; use the Simulator's absolute
+# tool paths so coordination does not depend on that cross-namespace PATH.
+SIMULATOR_MKDIR = "/bin/mkdir"
+SIMULATOR_CHMOD = "/bin/chmod"
 
 
 class LiveExecutorError(RuntimeError):
@@ -195,8 +199,8 @@ class SimulatorCoordination:
 
     def prepare(self) -> None:
         script = (
-            f"umask 077; mkdir -p {shlex.quote(self.events)}; "
-            f"chmod 700 {shlex.quote(self.root)} {shlex.quote(self.events)}"
+            f"umask 077; {SIMULATOR_MKDIR} -p {shlex.quote(self.events)}; "
+            f"{SIMULATOR_CHMOD} 700 {shlex.quote(self.root)} {shlex.quote(self.events)}"
         )
         self._spawn(["/bin/sh", "-c", script])
 
@@ -229,7 +233,7 @@ class SimulatorCoordination:
         script = (
             f"umask 077; set -C; "
             f"printf %s {shlex.quote(payload)} > {shlex.quote(path)}; "
-            f"chmod 600 {shlex.quote(path)}"
+            f"{SIMULATOR_CHMOD} 600 {shlex.quote(path)}"
         )
         result = self._spawn(["/bin/sh", "-c", script], check=False)
         if result.returncode != 0:

--- a/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
@@ -66,6 +66,27 @@ class LiveExecutorContractTests(unittest.TestCase):
         self.assertEqual(private["SAFE_MARKER"], "retained")
         self.assertTrue(all(name not in private for name in EXECUTOR.SECRET_ENV_NAMES))
 
+    @patch.object(EXECUTOR.subprocess, "run")
+    def test_simulator_coordination_uses_absolute_tool_paths(self, run) -> None:
+        run.return_value = SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        coordination = EXECUTOR.SimulatorCoordination(
+            "simulator-udid", "/tmp/floorp-notes-sync-test"
+        )
+
+        coordination.prepare()
+        coordination.write(
+            actor="desktop",
+            case_name=EXECUTOR.CASE_NAMES[0],
+            phase="request",
+            outcome="ready",
+            sequence=1,
+        )
+
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertIn("/bin/mkdir", commands[0][-1])
+        self.assertIn("/bin/chmod", commands[0][-1])
+        self.assertIn("/bin/chmod", commands[1][-1])
+
     def test_source_binding_requires_manual_main_workflow(self) -> None:
         context = {
             "GITHUB_ACTOR": "operator",


### PR DESCRIPTION
## Summary
- use absolute `/bin/mkdir` and `/bin/chmod` paths inside Simulator coordination scripts
- add a contract test for the Simulator command paths

## Evidence
- CI test suite: 306 tests passed
- live iOS 26.2 Simulator coordination prepare/write/read/cleanup check passed
- fixes repeated `simctl spawn` failures caused by the host runtime PATH crossing into the Simulator namespace