### PR TITLE
fix: retry transient simulator spawn aborts

### DIFF
--- a/scripts/ci/floorp_notes_sync_live_executor.py
+++ b/scripts/ci/floorp_notes_sync_live_executor.py
@@ -88,6 +88,8 @@ CASE_BLOCKERS = {
 # tool paths so coordination does not depend on that cross-namespace PATH.
 SIMULATOR_MKDIR = "/bin/mkdir"
 SIMULATOR_CHMOD = "/bin/chmod"
+SIMULATOR_SPAWN_RETRY_ATTEMPTS = 3
+SIMULATOR_SPAWN_RETRY_DELAY_SECONDS = 5.0
 
 
 class LiveExecutorError(RuntimeError):
@@ -188,14 +190,32 @@ class SimulatorCoordination:
         input_bytes: bytes | None = None,
         check: bool = True,
     ) -> subprocess.CompletedProcess[bytes]:
-        return subprocess.run(
-            ["xcrun", "simctl", "spawn", self.udid, *command],
-            input=input_bytes,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=private_environment(),
-            check=check,
-        )
+        simctl_command = ["xcrun", "simctl", "spawn", self.udid, *command]
+        result: subprocess.CompletedProcess[bytes] | None = None
+        for attempt in range(SIMULATOR_SPAWN_RETRY_ATTEMPTS):
+            result = subprocess.run(
+                simctl_command,
+                input=input_bytes,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=private_environment(),
+                check=False,
+            )
+            if (
+                result.returncode != 134
+                or attempt == SIMULATOR_SPAWN_RETRY_ATTEMPTS - 1
+            ):
+                break
+            time.sleep(SIMULATOR_SPAWN_RETRY_DELAY_SECONDS)
+        assert result is not None
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                simctl_command,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
 
     def prepare(self) -> None:
         script = (

--- a/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
@@ -87,6 +87,22 @@ class LiveExecutorContractTests(unittest.TestCase):
         self.assertIn("/bin/chmod", commands[0][-1])
         self.assertIn("/bin/chmod", commands[1][-1])
 
+    @patch.object(EXECUTOR.time, "sleep")
+    @patch.object(EXECUTOR.subprocess, "run")
+    def test_simulator_coordination_retries_transient_spawn_abort(self, run, sleep) -> None:
+        run.side_effect = [
+            SimpleNamespace(returncode=134, stdout=b"", stderr=b""),
+            SimpleNamespace(returncode=0, stdout=b"", stderr=b""),
+        ]
+        coordination = EXECUTOR.SimulatorCoordination(
+            "simulator-udid", "/tmp/floorp-notes-sync-test"
+        )
+
+        coordination.prepare()
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(EXECUTOR.SIMULATOR_SPAWN_RETRY_DELAY_SECONDS)
+
     def test_source_binding_requires_manual_main_workflow(self) -> None:
         context = {
             "GITHUB_ACTOR": "operator",


### PR DESCRIPTION
## Summary
- retry transient CoreSimulator `simctl spawn` exit 134 failures during boot
- preserve immediate failure for all other exit codes
- add a contract test for the retry boundary

## Evidence
- CI test suite: 307 tests passed
- prior public-beta QA runs reproduced the same exit 134 during Simulator coordination
- local iOS 26.2 Simulator coordination prepare/write/read/cleanup check passed