### PR TITLE
fix: bypass transient simulator launchd aborts

### DIFF
--- a/scripts/ci/floorp_notes_sync_live_executor.py
+++ b/scripts/ci/floorp_notes_sync_live_executor.py
@@ -86,8 +86,13 @@ CASE_BLOCKERS = {
 }
 # simctl can pass host runtime-root paths as PATH; use the Simulator's absolute
 # tool paths so coordination does not depend on that cross-namespace PATH.
+# GitHub's macOS 26 runners can also abort the launchd-backed spawn path while
+# the booted iOS 26.2 Simulator is otherwise ready. Standalone spawn uses the
+# Simulator's direct posix_spawn path and keeps this metadata-only bridge
+# independent of launchd's transient state.
 SIMULATOR_MKDIR = "/bin/mkdir"
 SIMULATOR_CHMOD = "/bin/chmod"
+SIMULATOR_SPAWN_MODE = "--standalone"
 SIMULATOR_SPAWN_RETRY_ATTEMPTS = 3
 SIMULATOR_SPAWN_RETRY_DELAY_SECONDS = 5.0
 
@@ -190,7 +195,14 @@ class SimulatorCoordination:
         input_bytes: bytes | None = None,
         check: bool = True,
     ) -> subprocess.CompletedProcess[bytes]:
-        simctl_command = ["xcrun", "simctl", "spawn", self.udid, *command]
+        simctl_command = [
+            "xcrun",
+            "simctl",
+            "spawn",
+            SIMULATOR_SPAWN_MODE,
+            self.udid,
+            *command,
+        ]
         result: subprocess.CompletedProcess[bytes] | None = None
         for attempt in range(SIMULATOR_SPAWN_RETRY_ATTEMPTS):
             result = subprocess.run(

--- a/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
@@ -102,6 +102,10 @@ class LiveExecutorContractTests(unittest.TestCase):
 
         self.assertEqual(run.call_count, 2)
         sleep.assert_called_once_with(EXECUTOR.SIMULATOR_SPAWN_RETRY_DELAY_SECONDS)
+        self.assertEqual(
+            run.call_args_list[0].args[0][:5],
+            ["xcrun", "simctl", "spawn", EXECUTOR.SIMULATOR_SPAWN_MODE, "simulator-udid"],
+        )
 
     def test_source_binding_requires_manual_main_workflow(self) -> None:
         context = {


### PR DESCRIPTION
## Summary
- use `simctl spawn --standalone` for the protected Simulator coordination bridge
- retain the bounded exit-134 retry for other transient CoreSimulator failures
- cover the spawn mode in the contract test

## Verification
- `python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py'` (307 passed)\n- capability tests (5 passed)\n- local iOS 26.2 Simulator standalone coordination probe passed\n\nThe preceding QA run reproduced exit 134 in the launchd-backed spawn path after the absolute tool-path fix; credentials and secret scans passed, and no public-beta artifact was produced.