### PR TITLE
ci: install Deno for protected Sync QA

### DIFF
--- a/.github/workflows/floorp-notes-sync-production-qa.yml
+++ b/.github/workflows/floorp-notes-sync-production-qa.yml
@@ -793,6 +793,11 @@ jobs:
           git -C "$GITHUB_WORKSPACE" checkout --detach --force FETCH_HEAD
           test "$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)" = "$GITHUB_SHA"
 
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        with:
+          deno-version: v2.x
+
       - name: Check guarded merge artifact selector
         run: |
           set -euo pipefail

--- a/.github/workflows/floorp-notes-sync-public-beta-qa.yml
+++ b/.github/workflows/floorp-notes-sync-public-beta-qa.yml
@@ -67,6 +67,11 @@ jobs:
           token: ""
           package-manager-cache: false
 
+      - name: Set up Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
+        with:
+          deno-version: v2.x
+
       - name: Validate protected Sync operation contract
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- install the pinned Deno v2 runtime in the public-beta QA workflow
- install the same runtime in the canonical production QA workflow

## Evidence
- QA run 32538436638 reached Simulator coordination successfully with `simctl spawn --standalone`
- the next failure was `[Errno 2] No such file or directory: deno` while starting the reviewed Desktop stage
- local Python contract suite remains passing

This supplies the runtime required by the reviewed Desktop commit; it does not change credentials, endpoints, or QA authorization.