### PR TITLE
ci: install reviewed Desktop dependencies

### DIFF
--- a/.github/workflows/floorp-notes-sync-production-qa.yml
+++ b/.github/workflows/floorp-notes-sync-production-qa.yml
@@ -963,6 +963,12 @@ jobs:
           test "$(git -C "$desktop_root" rev-parse HEAD)" = "$FLOORP_DESKTOP_COMMIT"
           printf 'FLOORP_NOTES_SYNC_DESKTOP_ROOT=%s\n' "$desktop_root" >> "$GITHUB_ENV"
 
+      - name: Install reviewed Desktop Deno dependencies
+        run: |
+          set -euo pipefail
+          cd "$FLOORP_NOTES_SYNC_DESKTOP_ROOT"
+          deno install --allow-scripts
+
       - name: Validate Todo 20 contract semantics in protected QA path
         run: |
           set -euo pipefail

--- a/.github/workflows/floorp-notes-sync-public-beta-qa.yml
+++ b/.github/workflows/floorp-notes-sync-public-beta-qa.yml
@@ -95,6 +95,12 @@ jobs:
           test "$(git -C "$desktop_root" rev-parse HEAD)" = "$FLOORP_DESKTOP_COMMIT"
           printf 'FLOORP_NOTES_SYNC_DESKTOP_ROOT=%s\n' "$desktop_root" >> "$GITHUB_ENV"
 
+      - name: Install reviewed Desktop Deno dependencies
+        run: |
+          set -euo pipefail
+          cd "$FLOORP_NOTES_SYNC_DESKTOP_ROOT"
+          deno install --allow-scripts
+
       - name: Create public-beta QA capability
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- install the reviewed Desktop checkout's Deno/npm dependencies before staging it in protected QA
- use the same `deno install --allow-scripts` flow as the reviewed Desktop CI

## Evidence
- QA run 32541971946 passed Simulator coordination and Deno setup, then failed only because the Desktop stage lacked `npm:fflate` in `node_modules`
- local reproduction at Desktop SHA 8462074ce18ab63d9be4def199b33de1d6bb554a failed before install with the same dependency error
- after `deno install --allow-scripts`, the local stage built, started all Vite servers, launched the locked Runtime, and reached Marionette port 2828

No credentials, endpoints, or QA authorization semantics changed.