### PR TITLE
ci: support redesigned Desktop Sync controls

### DIFF
--- a/scripts/ci/floorp_notes_sync_live_executor.py
+++ b/scripts/ci/floorp_notes_sync_live_executor.py
@@ -443,12 +443,56 @@ class DesktopNotesClient:
             self.browser.execute(
                 """
                 const pattern = new RegExp(arguments[0], "i");
-                const nodes = [...document.querySelectorAll("button,a,input[type=submit]")];
-                const node = nodes.find((candidate) => pattern.test(
-                  String(candidate.textContent || "") + " " +
-                  String(candidate.getAttribute("aria-label") || "") + " " +
-                  String(candidate.getAttribute("data-l10n-id") || "")
-                ));
+                const selectors = [
+                  "button",
+                  "a",
+                  "input[type=submit]",
+                  "moz-box-link",
+                  "moz-box-button",
+                  "moz-button",
+                ];
+                const roots = [document];
+                for (let index = 0; index < roots.length; index += 1) {
+                  for (const element of roots[index].querySelectorAll("*")) {
+                    if (element.shadowRoot) roots.push(element.shadowRoot);
+                  }
+                }
+                const nodes = roots.flatMap((root) => [
+                  ...root.querySelectorAll(selectors.join(",")),
+                ]);
+                const isVisible = (candidate) => {
+                  for (
+                    let current = candidate;
+                    current;
+                    current = current.parentElement
+                  ) {
+                    if (current.hidden || current.getAttribute("aria-hidden") === "true") {
+                      return false;
+                    }
+                    const style = current.ownerDocument.defaultView?.getComputedStyle(current);
+                    if (style?.display === "none" || style?.visibility === "hidden") {
+                      return false;
+                    }
+                  }
+                  return true;
+                };
+                const node = nodes.find((candidate) => {
+                  if (candidate.disabled || !isVisible(candidate)) return false;
+                  return pattern.test(
+                    [
+                      candidate.textContent,
+                      candidate.getAttribute("aria-label"),
+                      candidate.getAttribute("data-l10n-id"),
+                      candidate.getAttribute("label"),
+                      candidate.getAttribute("title"),
+                      candidate.getAttribute("value"),
+                      candidate.id,
+                    ]
+                      .filter(Boolean)
+                      .join(" ")
+                      .replace(/[-_]/g, " ")
+                  );
+                });
                 if (!node) return false;
                 node.click();
                 return true;

--- a/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
+++ b/scripts/ci/tests/test_floorp_notes_sync_live_executor.py
@@ -174,6 +174,14 @@ class LiveExecutorContractTests(unittest.TestCase):
         client._assert_page_scope()
         self.assertEqual(observed, {"accounts.firefox.com"})
 
+    def test_desktop_click_text_supports_settings_redesign_controls(self) -> None:
+        source = MODULE_PATH.read_text(encoding="utf-8")
+        for selector in ("moz-box-link", "moz-box-button", "moz-button"):
+            self.assertIn(f'"{selector}"', source)
+        self.assertIn("element.shadowRoot", source)
+        self.assertIn("replace(/[-_]/g, \" \")", source)
+        self.assertIn("current.hidden", source)
+
     def test_unobserved_matrix_boundaries_fail_closed(self) -> None:
         self.assertIn("legacy_client_artifact_and_driver_missing", EXECUTOR.CASE_BLOCKERS[EXECUTOR.CASE_NAMES[7]])
         self.assertIn("upload_save_commit_failure_observation_missing", EXECUTOR.CASE_BLOCKERS[EXECUTOR.CASE_NAMES[5]])


### PR DESCRIPTION
## Summary\n- support Firefox's redesigned moz-box-link, moz-box-button, and moz-button controls in the live Desktop Sync executor\n- traverse open Shadow DOM roots and ignore hidden controls\n- normalize hyphenated Fluent IDs for sign-in/sign-out matching\n\n## Verification\n- python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py'\n- 308 tests passed\n- git diff --check