### PR TITLE
ci: sanitize public beta waiver test environment

### DIFF
--- a/.github/workflows/floorp-notes-sync-public-beta-qa.yml
+++ b/.github/workflows/floorp-notes-sync-public-beta-qa.yml
@@ -360,11 +360,13 @@ jobs:
       - name: Run repository contract tests
         run: |
           set -euo pipefail
-          /usr/bin/python3 -m unittest discover \
+          env -u GITHUB_API_URL -u GITHUB_SERVER_URL \
+            /usr/bin/python3 -m unittest discover \
             -s scripts/ci/tests \
             -p 'test_*.py' \
             | tee "$RUNNER_TEMP/public-beta-waiver-repository-tests.log"
-          /usr/bin/python3 -m unittest discover \
+          env -u GITHUB_API_URL -u GITHUB_SERVER_URL \
+            /usr/bin/python3 -m unittest discover \
             -s scripts/release/tests \
             -p 'test_*.py' \
             | tee -a "$RUNNER_TEMP/public-beta-waiver-repository-tests.log"


### PR DESCRIPTION
## Summary
- unset GitHub API redirect environment variables while running the public-beta waiver contract tests
- keep the workflow fail-closed without changing production validation logic

## Verification
- `env -u GITHUB_API_URL -u GITHUB_SERVER_URL python3 -m unittest discover -s scripts/ci/tests -p test_*.py` (308 tests)
- `env -u GITHUB_API_URL -u GITHUB_SERVER_URL python3 -m unittest discover -s scripts/release/tests -p test_*.py` (44 tests)