### PR TITLE
Add explicit Xcode Cloud TestFlight deploy workflow

### DIFF
--- a/.github/workflows/floorp-xcode-cloud-testflight.yml
+++ b/.github/workflows/floorp-xcode-cloud-testflight.yml
@@ -1,0 +1,136 @@
+name: Floorp TestFlight Deploy (Xcode Cloud)
+
+on:
+  workflow_dispatch:
+    inputs:
+      wait_for_completion:
+        description: Wait for Xcode Cloud to finish the archive and App Store Connect distribution.
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: floorp-xcode-cloud-testflight
+  cancel-in-progress: false
+
+env:
+  FLOORP_APP_ID: "6796708699"
+  FLOORP_TEAM_ID: "74c6a531-19e2-4ed5-a34b-915003cc10f9"
+  FLOORP_XCODE_CLOUD_WORKFLOW_ID: "f75adb00-1ca4-4b24-9bec-f6b5b943903a"
+  FLOORP_XCODE_CLOUD_WORKFLOW_NAME: "Floorp TestFlight Manual"
+  FLOORP_XCODE_CLOUD_REPOSITORY: "https://github.com/Floorp-Projects/floorp-ios.git"
+  FLOORP_XCODE_CLOUD_BRANCH: "main"
+
+jobs:
+  deploy:
+    name: Start and monitor Floorp TestFlight deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 195
+    environment: floorp-testflight
+
+    steps:
+      - name: Check out the exact main source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify source identity
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Prepare App Store Connect API key
+        env:
+          APPLE_DEVELOPER_API_KEY_JSON: ${{ secrets.APPLE_DEVELOPER_API_KEY_JSON }}
+        run: |
+          set -euo pipefail
+          umask 077
+          test -n "$APPLE_DEVELOPER_API_KEY_JSON"
+          api_json="$RUNNER_TEMP/app-store-connect-api.json"
+          printf '%s' "$APPLE_DEVELOPER_API_KEY_JSON" > "$api_json"
+          /usr/bin/python3 - "$api_json" "$RUNNER_TEMP/AuthKey.p8" "$GITHUB_ENV" <<'PY'
+          import base64
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          source_path, key_path, env_path = sys.argv[1:]
+          value = json.loads(Path(source_path).read_text(encoding="utf-8"))
+          issuer = value.get("issuer_id") or value.get("issuerId") or value.get("issuer")
+          key_id = value.get("key_id") or value.get("keyId") or value.get("key")
+          private_key = value.get("private_key") or value.get("privateKey") or value.get("api_key")
+          if not all(isinstance(item, str) and item for item in (issuer, key_id, private_key)):
+              raise SystemExit("App Store Connect API key JSON must contain issuer_id, key_id, and private_key")
+          if not re.fullmatch(r"[A-Za-z0-9._-]+", issuer) or not re.fullmatch(r"[A-Za-z0-9._-]+", key_id):
+              raise SystemExit("App Store Connect API key identity is invalid")
+          if private_key.lstrip().startswith("-----BEGIN"):
+              raw = private_key.encode("utf-8")
+          else:
+              raw = base64.b64decode(private_key, validate=True)
+          if b"BEGIN PRIVATE KEY" not in raw:
+              raise SystemExit("App Store Connect private key is not a PKCS#8 PEM")
+          Path(key_path).write_bytes(raw)
+          os.chmod(key_path, 0o600)
+          with Path(env_path).open("a", encoding="utf-8") as handle:
+              handle.write(f"APP_STORE_CONNECT_ISSUER_ID={issuer}\n")
+              handle.write(f"APP_STORE_CONNECT_KEY_ID={key_id}\n")
+              handle.write(f"APP_STORE_CONNECT_PRIVATE_KEY_PATH={key_path}\n")
+          PY
+
+      - name: Start Xcode Cloud and optionally wait for completion
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/floorp-xcode-cloud-run.json"
+          args=(
+            --workflow-id "$FLOORP_XCODE_CLOUD_WORKFLOW_ID"
+            --expected-workflow-name "$FLOORP_XCODE_CLOUD_WORKFLOW_NAME"
+            --expected-repository "$FLOORP_XCODE_CLOUD_REPOSITORY"
+            --branch "$FLOORP_XCODE_CLOUD_BRANCH"
+            --expected-head "$GITHUB_SHA"
+            --team-id "$FLOORP_TEAM_ID"
+            --app-id "$FLOORP_APP_ID"
+            --output "$output"
+            --authorize-mutation
+          )
+          if [[ "${{ inputs.wait_for_completion }}" == "true" ]]; then
+            args+=(--wait)
+          fi
+          python3 scripts/release/trigger-xcode-cloud.py "${args[@]}"
+          printf 'FLOORP_XCODE_CLOUD_RUN=%s\n' "$output" >> "$GITHUB_ENV"
+
+      - name: Publish deployment summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Floorp TestFlight deployment"
+            echo
+            echo "- Source: `main` (`$GITHUB_SHA`)"
+            echo "- Xcode Cloud workflow: `$FLOORP_XCODE_CLOUD_WORKFLOW_NAME`"
+            if [[ -n "${FLOORP_XCODE_CLOUD_RUN:-}" && -f "$FLOORP_XCODE_CLOUD_RUN" ]]; then
+              /usr/bin/python3 - "$FLOORP_XCODE_CLOUD_RUN" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          run = report.get("run") or {}
+          attributes = run.get("attributes") or {}
+          print(f"- Xcode Cloud run: `{run.get('id', 'unknown')}`")
+          print(f"- Progress: `{attributes.get('executionProgress', 'unknown')}`")
+          print(f"- Completion: `{attributes.get('completionStatus', 'unknown')}`")
+          print(f"- [Open App Store Connect build]({report['build_url']})")
+          PY
+            else
+              echo "- Xcode Cloud run report was not produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/floorp-xcode-cloud-testflight.yml
+++ b/.github/workflows/floorp-xcode-cloud-testflight.yml
@@ -113,8 +113,11 @@ jobs:
           set -euo pipefail
           {
             printf '%s\n\n' '## Floorp TestFlight deployment'
-            printf -- '- Source: `main` (`%s`)\n' "$GITHUB_SHA"
-            printf -- '- Xcode Cloud workflow: `%s`\n' "$FLOORP_XCODE_CLOUD_WORKFLOW_NAME"
+            code_span="$(printf '\140')"
+            printf -- '- Source: %smain%s (%s%s%s)\n' \
+              "$code_span" "$code_span" "$code_span" "$GITHUB_SHA" "$code_span"
+            printf -- '- Xcode Cloud workflow: %s%s%s\n' \
+              "$code_span" "$FLOORP_XCODE_CLOUD_WORKFLOW_NAME" "$code_span"
             if [[ -n "${FLOORP_XCODE_CLOUD_RUN:-}" && -f "$FLOORP_XCODE_CLOUD_RUN" ]]; then
               /usr/bin/python3 - "$FLOORP_XCODE_CLOUD_RUN" <<'PY'
           import json

--- a/.github/workflows/floorp-xcode-cloud-testflight.yml
+++ b/.github/workflows/floorp-xcode-cloud-testflight.yml
@@ -112,10 +112,9 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "## Floorp TestFlight deployment"
-            echo
-            echo "- Source: `main` (`$GITHUB_SHA`)"
-            echo "- Xcode Cloud workflow: `$FLOORP_XCODE_CLOUD_WORKFLOW_NAME`"
+            printf '%s\n\n' '## Floorp TestFlight deployment'
+            printf -- '- Source: `main` (`%s`)\n' "$GITHUB_SHA"
+            printf -- '- Xcode Cloud workflow: `%s`\n' "$FLOORP_XCODE_CLOUD_WORKFLOW_NAME"
             if [[ -n "${FLOORP_XCODE_CLOUD_RUN:-}" && -f "$FLOORP_XCODE_CLOUD_RUN" ]]; then
               /usr/bin/python3 - "$FLOORP_XCODE_CLOUD_RUN" <<'PY'
           import json

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,6 +1,6 @@
 # Floorp for iOS CI/CD
 
-This document defines the delivery foundation for Floorp for iOS. The repository has a reproducible pull-request gate, a dedicated release configuration, and a validated signed Internal TestFlight baseline. Repeatable cloud delivery, retained main-app capabilities, and service ownership still need to be finalized before public distribution.
+This document defines the delivery foundation for Floorp for iOS. The repository has a reproducible pull-request gate, a dedicated release configuration, a validated signed Internal TestFlight baseline, and an explicit cloud-delivery path for routine TestFlight builds.
 
 ## Architecture
 
@@ -10,13 +10,14 @@ This document defines the delivery foundation for Floorp for iOS. The repository
 | Notes Sync production QA | GitHub Actions | Manual, protected workflow in `.github/workflows/floorp-notes-sync-production-qa.yml` |
 | Notes Sync public-beta QA | GitHub Actions | Separate manual, protected two-account workflow in `.github/workflows/floorp-notes-sync-public-beta-qa.yml` |
 | Signed public-beta delivery | GitHub Actions | Manual, source-bound workflow in `.github/workflows/floorp-public-beta-release.yml` |
+| Xcode Cloud TestFlight trigger | GitHub Actions | Manual `workflow_dispatch` bridge in `.github/workflows/floorp-xcode-cloud-testflight.yml` |
 | Upstream Firefox synchronization | GitHub Actions | Weekly draft-PR workflow with trusted automation restoration, reviewed localization conflict resolution, and explicit CI dispatch |
 | Signed archive and internal TestFlight | Manual Xcode upload | `0.1.0 (2)` signed, uploaded, and verified by the internal group |
-| Repeatable signed delivery | Xcode Cloud | Scaffold implemented; workflow not yet configured |
+| Repeatable signed delivery | Xcode Cloud | Configured as `Floorp TestFlight Manual`; archive, signing, and App Store Connect distribution run in Xcode Cloud |
 | App Store release | App Store Connect | Manual approval initially |
 | Mozilla/Focus maintenance automation | Git history | Removed pending a Floorp-owned replacement |
 
-The public-beta release job receives signing and App Store Connect material only as protected GitHub secrets for the one approved run; no certificate, profile, p8 key, or password is committed. The first build was uploaded manually from a locally signed archive. Xcode Cloud remains the preferred repeatable CD system for routine delivery because it supports cloud-managed signing and direct TestFlight distribution.
+The public-beta release job receives signing and App Store Connect material only as protected GitHub secrets for the one approved run; no certificate, profile, p8 key, or password is committed. The routine TestFlight path does not sign in GitHub Actions: the Actions bridge only starts and monitors the pinned Xcode Cloud workflow, while Xcode Cloud performs the archive, signing, and App Store Connect distribution.
 
 ### Validated Internal TestFlight baseline
 
@@ -160,7 +161,7 @@ The primary classic and Liquid Glass icon sources render the Floorp logo, and `F
 
 ## Apple account checklist
 
-Complete the remaining unchecked steps before enabling repeatable Xcode Cloud distribution or public beta delivery:
+Complete the remaining unchecked steps before broad public distribution:
 
 - [ ] Decide whether the Apple Developer account is permanently owned by a Floorp organization or an individual; avoid a later transfer if possible.
 - [x] Confirm the Apple Developer Team ID: `DV2U35YBHT`.
@@ -183,6 +184,7 @@ Complete the remaining unchecked steps before enabling repeatable Xcode Cloud di
 - [x] Create the `Floorp Internal` TestFlight group and add the initial tester.
 - [ ] Assign an owner and safe client-side value for each external service setting used by the release configuration.
 - [x] Produce a signed `Floorp` archive, upload it, and install the processed build through Internal TestFlight.
+- [ ] Add `APPLE_DEVELOPER_API_KEY_JSON` to the `floorp-testflight` GitHub Environment for the Actions-to-Xcode-Cloud trigger; keep signing certificates and profiles out of GitHub.
 
 Do not commit certificates, provisioning profiles, `.p8` API keys, `.p12` files, or passwords.
 
@@ -190,15 +192,15 @@ Do not commit certificates, provisioning profiles, `.p8` API keys, `.p12` files,
 
 The repository includes `firefox-ios/ci_scripts/ci_post_clone.sh`. Xcode Cloud discovers it next to `Client.xcodeproj`; it downloads the `.nvmrc` Node.js release with a pinned checksum and runs the root bootstrap in the clean clone. `.nvmrc` and `.xcode-version` are declarations for developers and GitHub Actions, not settings that Xcode Cloud applies automatically.
 
-After the shared `Floorp` scheme archives locally with `FloorpRelease` and passes Organizer validation:
+The shared `Floorp` scheme now archives with `FloorpRelease` in Xcode Cloud. The existing workflow is manually started in App Store Connect, and the repository also provides a GitHub Actions bridge for the same explicit operation:
 
 1. In Signing & Capabilities, explicitly confirm the main `app.floorp.Floorp` bundle ID once before initial setup because the project derives it from an `.xcconfig` file. Register extension IDs only when those targets return to the release.
 2. Connect `Floorp-Projects/Floorp-iOS` to Xcode Cloud from Xcode's Report navigator. A GitHub organization owner must authorize the first connection.
-3. Create a manually started development build workflow first. Select the repository's pinned Xcode version where Xcode Cloud offers it and verify the post-clone bootstrap.
-4. After the development build is stable, create a manually started archive workflow for the Floorp release scheme with internal TestFlight distribution as the post-action.
+3. Keep `Floorp TestFlight Manual` manually started and restricted to `main`; App Store Connect remains the direct fallback for starting a build.
+4. Use `.github/workflows/floorp-xcode-cloud-testflight.yml` when the deployment should be visible as an explicit GitHub Actions run. It validates the pinned workflow and repository, starts the Xcode Cloud run through `POST /v1/ciBuildRuns`, and optionally waits for completion.
 5. Let Xcode Cloud manage signing; verify the Client-only app is signed by the Floorp team and inspect its production entitlements. Repeat this check for each extension if one is restored later.
 6. Confirm `firefox-ios/TestFlight/WhatToTest.en-US.txt` appears in the TestFlight build and invite the internal group.
-7. After several successful builds, add a `main` or release-tag start condition.
+7. Add a separate ordinary App Store workflow later by reusing `scripts/release/trigger-xcode-cloud.py` with its own pinned Xcode Cloud workflow ID and distribution target.
 8. Download and retain each shipped archive and its dSYMs outside Xcode Cloud; Xcode Cloud build information and artifacts are available for only 30 days.
 
 The public-beta workflow does not create groups or invent reviewer credentials. It selects one existing external group (or requires its explicit ID), reuses complete live Beta App Review details, records before/after state, and stops with a blocker if Apple agreements, review details, or group setup are incomplete.
@@ -208,7 +210,7 @@ The public-beta workflow does not create groups or invent reviewer credentials. 
 - Add a non-blocking manual or scheduled full `UnitTest` run with `.xcresult` retention while the remaining suites are repaired and promoted into `FloorpCI`.
 - Restore a legacy maintenance workflow from Git history only after assigning a Floorp owner, removing Mozilla secrets and destinations, and pinning every external action.
 - Split stable UI smoke tests into a nightly workflow after the simulator unit-test gate is reliable.
-- Add a protected GitHub `testflight` environment only if distribution later moves from Xcode Cloud to GitHub Actions.
+- Keep the `floorp-testflight` GitHub Environment limited to the App Store Connect API key needed to start and monitor Xcode Cloud; do not add signing certificates or profiles.
 - Keep the pinned Nimbus script revision aligned with Application Services updates during upstream synchronization.
 - Add CODEOWNERS for `.github/workflows/`, `scripts/ci/`, and `firefox-ios/ci_scripts/` after the Floorp GitHub maintainer team slug is known.
 
@@ -230,7 +232,8 @@ against `scripts/release/floorp-release-evidence.schema.json` and rejects mixed
 build IDs, forbidden entitlements, missing dSYMs, and digest mismatches.
 
 `scripts/release/app-store-connect-api.py` is the only App Store Connect
-surface. Its read allowlist covers the required GETs and its write allowlist is
+surface. Its read allowlist covers the required workflow, repository, and Git
+reference GETs and its write allowlist is
 exactly `POST /v1/ciBuildRuns`, `POST /v1/betaBuildLocalizations`,
 `PATCH /v1/betaBuildLocalizations/{id}`, `PATCH /v1/betaAppReviewDetails/{id}`,
 `POST /v1/betaAppReviewSubmissions`, and

--- a/scripts/release/app-store-connect-api.py
+++ b/scripts/release/app-store-connect-api.py
@@ -12,7 +12,8 @@ Read allowlist (GET):
   /v1/ciProducts, /v1/ciWorkflows, /v1/ciBuildRuns, /v1/ciRuns,
   /v1/ciRuns/{id}/artifacts, /v1/betaGroups, /v1/betaGroups/{id}/builds,
   /v1/betaBuildLocalizations, /v1/betaAppReviewDetails,
-  /v1/betaAppReviewSubmissions
+  /v1/betaAppReviewSubmissions, /v1/scmRepositories/{id},
+  /v1/scmRepositories/{id}/gitReferences
 
 Write allowlist (exact):
   POST /v1/ciBuildRuns
@@ -31,6 +32,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -40,7 +42,16 @@ from typing import Optional
 
 
 API_BASE = "https://api.appstoreconnect.apple.com"
-OPENSSL3 = "/opt/homebrew/opt/openssl@3/bin/openssl"
+_OPENSSL_CANDIDATES = (
+    os.environ.get("FLOORP_OPENSSL3"),
+    "/opt/homebrew/opt/openssl@3/bin/openssl",
+    "/usr/local/opt/openssl@3/bin/openssl",
+    shutil.which("openssl"),
+)
+OPENSSL3 = next(
+    (candidate for candidate in _OPENSSL_CANDIDATES if candidate and Path(candidate).is_file()),
+    "openssl",
+)
 
 READ_ROUTES = [
     r"^/v1/apps$",
@@ -55,6 +66,8 @@ READ_ROUTES = [
     r"^/v1/ciBuildRuns/[^/]+/actions$",
     r"^/v1/ciBuildActions/[^/]+$",
     r"^/v1/ciBuildActions/[^/]+/artifacts$",
+    r"^/v1/scmRepositories/[^/]+$",
+    r"^/v1/scmRepositories/[^/]+/gitReferences$",
     r"^/v1/betaGroups$",
     r"^/v1/betaGroups/[^/]+/builds$",
     r"^/v1/betaBuildLocalizations$",

--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -31,6 +31,8 @@ class AllowlistTests(unittest.TestCase):
             "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376/actions",
             "/v1/ciBuildActions/4294e7e3-8adf-47fe-8f7c-02456baba2bb",
             "/v1/ciBuildActions/4294e7e3-8adf-47fe-8f7c-02456baba2bb/artifacts",
+            "/v1/scmRepositories/repo-1",
+            "/v1/scmRepositories/repo-1/gitReferences",
             "/v1/builds",
             "/v1/betaGroups",
             "/v1/betaAppReviewDetails",

--- a/scripts/release/tests/test_trigger_xcode_cloud.py
+++ b/scripts/release/tests/test_trigger_xcode_cloud.py
@@ -1,0 +1,164 @@
+"""Contract tests for the Xcode Cloud deployment trigger."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).parent.parent / "trigger-xcode-cloud.py"
+    spec = importlib.util.spec_from_file_location("trigger_xcode_cloud", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+trigger = load_module()
+
+
+WORKFLOW_ID = "workflow-1"
+REPOSITORY_ID = "repository-1"
+REFERENCE_ID = "reference-main"
+WORKFLOW_NAME = "Floorp TestFlight Manual"
+REPOSITORY_URL = "https://github.com/Floorp-Projects/floorp-ios.git"
+
+
+def workflow_response():
+    return {
+        "data": {
+            "type": "ciWorkflows",
+            "id": WORKFLOW_ID,
+            "attributes": {"name": WORKFLOW_NAME, "isEnabled": True},
+            "relationships": {
+                "repository": {
+                    "data": {"type": "scmRepositories", "id": REPOSITORY_ID}
+                }
+            },
+        },
+        "included": [
+            {
+                "type": "scmRepositories",
+                "id": REPOSITORY_ID,
+                "attributes": {"httpCloneUrl": REPOSITORY_URL},
+            }
+        ],
+    }
+
+
+def references_response(rows=None):
+    return {
+        "data": rows
+        if rows is not None
+        else [
+            {
+                "type": "scmGitReferences",
+                "id": REFERENCE_ID,
+                "attributes": {
+                    "name": "main",
+                    "canonicalName": "refs/heads/main",
+                    "isDeleted": False,
+                },
+            }
+        ]
+    }
+
+
+class FakeAPI:
+    def __init__(self, workflow=None, references=None):
+        self.workflow = workflow or workflow_response()
+        self.references = references or references_response()
+        self.calls = []
+
+    def __call__(self, method, path, body=None):
+        self.calls.append((method, path, body))
+        if path.startswith(f"/v1/ciWorkflows/{WORKFLOW_ID}"):
+            return self.workflow
+        if path.startswith(f"/v1/scmRepositories/{REPOSITORY_ID}/gitReferences"):
+            return self.references
+        raise AssertionError(f"unexpected API request: {method} {path}")
+
+
+class TriggerContractTests(unittest.TestCase):
+    def test_build_request_binds_workflow_and_main_reference(self):
+        self.assertEqual(
+            trigger.build_request(WORKFLOW_ID, REFERENCE_ID),
+            {
+                "data": {
+                    "type": "ciBuildRuns",
+                    "attributes": {},
+                    "relationships": {
+                        "workflow": {
+                            "data": {"type": "ciWorkflows", "id": WORKFLOW_ID}
+                        },
+                        "sourceBranchOrTag": {
+                            "data": {
+                                "type": "scmGitReferences",
+                                "id": REFERENCE_ID,
+                            }
+                        },
+                    },
+                }
+            },
+        )
+
+    def test_verify_workflow_accepts_the_pinned_xcode_cloud_repository(self):
+        api = FakeAPI()
+        workflow, repository_id, repository = trigger.verify_workflow(
+            api, WORKFLOW_ID, WORKFLOW_NAME, REPOSITORY_URL
+        )
+        self.assertEqual(workflow["id"], WORKFLOW_ID)
+        self.assertEqual(repository_id, REPOSITORY_ID)
+        self.assertEqual(repository["attributes"]["httpCloneUrl"], REPOSITORY_URL)
+
+    def test_verify_workflow_rejects_a_different_repository(self):
+        api = FakeAPI()
+        with self.assertRaisesRegex(ValueError, "repository mismatch"):
+            trigger.verify_workflow(
+                api,
+                WORKFLOW_ID,
+                WORKFLOW_NAME,
+                "https://github.com/other/project.git",
+            )
+
+    def test_verify_workflow_rejects_a_different_workflow_name(self):
+        api = FakeAPI()
+        with self.assertRaisesRegex(ValueError, "workflow name mismatch"):
+            trigger.verify_workflow(api, WORKFLOW_ID, "Other workflow", REPOSITORY_URL)
+
+    def test_resolve_branch_rejects_deleted_or_duplicate_references(self):
+        api = FakeAPI(
+            references=references_response(
+                [
+                    {
+                        "type": "scmGitReferences",
+                        "id": "deleted-main",
+                        "attributes": {
+                            "name": "main",
+                            "canonicalName": "refs/heads/main",
+                            "isDeleted": True,
+                        },
+                    },
+                    {
+                        "type": "scmGitReferences",
+                        "id": "other-main",
+                        "attributes": {
+                            "name": "main",
+                            "canonicalName": "refs/heads/main",
+                            "isDeleted": False,
+                        },
+                    },
+                ]
+            )
+        )
+        self.assertEqual(
+            trigger.resolve_branch(api, REPOSITORY_ID, "main")["id"], "other-main"
+        )
+
+    def test_resolve_branch_requires_exactly_one_live_match(self):
+        api = FakeAPI(references=references_response([]))
+        with self.assertRaisesRegex(ValueError, "expected one live Git reference"):
+            trigger.resolve_branch(api, REPOSITORY_ID, "main")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/trigger-xcode-cloud.py
+++ b/scripts/release/trigger-xcode-cloud.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Start one approved Xcode Cloud workflow for a specific Git reference.
+
+This is the small control-plane used by GitHub Actions. Xcode Cloud remains
+responsible for the Apple build, signing, archive, and App Store Connect
+distribution. The script validates the workflow and repository before it
+performs the sole write: POST /v1/ciBuildRuns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable
+
+
+CLIENT_PATH = Path(__file__).with_name("app-store-connect-api.py")
+
+
+def load_client():
+    spec = importlib.util.spec_from_file_location("floorp_app_store_connect_api", CLIENT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load App Store Connect client: {CLIENT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def resource_data(response: dict[str, Any], expected_type: str, expected_id: str) -> dict[str, Any]:
+    value = response.get("data")
+    if not isinstance(value, dict):
+        raise ValueError("App Store Connect response has no resource data")
+    if value.get("type") != expected_type or value.get("id") != expected_id:
+        raise ValueError(
+            f"unexpected resource identity: type={value.get('type')!r} id={value.get('id')!r}"
+        )
+    return value
+
+
+def relationship_id(resource: dict[str, Any], *names: str) -> str | None:
+    relationships = resource.get("relationships")
+    if not isinstance(relationships, dict):
+        return None
+    for name in names:
+        relationship = relationships.get(name)
+        data = relationship.get("data") if isinstance(relationship, dict) else None
+        if isinstance(data, dict) and isinstance(data.get("id"), str) and data.get("id"):
+            return data["id"]
+    return None
+
+
+def included_resource(
+    response: dict[str, Any], resource_type: str, resource_id: str
+) -> dict[str, Any] | None:
+    included = response.get("included")
+    if not isinstance(included, list):
+        return None
+    return next(
+        (
+            item
+            for item in included
+            if isinstance(item, dict)
+            and item.get("type") == resource_type
+            and item.get("id") == resource_id
+        ),
+        None,
+    )
+
+
+def normalize_repository_url(value: str) -> str:
+    normalized = value.strip().lower().rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    return normalized
+
+
+def verify_workflow(
+    api: Callable[..., dict[str, Any]],
+    workflow_id: str,
+    expected_name: str,
+    expected_repository: str,
+) -> tuple[dict[str, Any], str, dict[str, Any]]:
+    response = api("GET", f"/v1/ciWorkflows/{workflow_id}?include=repository")
+    workflow = resource_data(response, "ciWorkflows", workflow_id)
+    attributes = workflow.get("attributes")
+    if not isinstance(attributes, dict):
+        raise ValueError("Xcode Cloud workflow has no attributes")
+    if attributes.get("name") != expected_name:
+        raise ValueError(
+            f"workflow name mismatch: expected {expected_name!r}, got {attributes.get('name')!r}"
+        )
+    if attributes.get("isEnabled") is False:
+        raise ValueError("Xcode Cloud workflow is disabled")
+
+    repository_id = relationship_id(workflow, "repository", "primaryRepository")
+    if repository_id is None:
+        raise ValueError("Xcode Cloud workflow has no repository relationship")
+    repository = included_resource(response, "scmRepositories", repository_id)
+    if repository is None:
+        repository_response = api("GET", f"/v1/scmRepositories/{repository_id}")
+        repository = resource_data(repository_response, "scmRepositories", repository_id)
+    repository_attributes = repository.get("attributes")
+    if not isinstance(repository_attributes, dict):
+        raise ValueError("Xcode Cloud repository has no attributes")
+    actual_url = repository_attributes.get("httpCloneUrl")
+    if not isinstance(actual_url, str) or normalize_repository_url(actual_url) != normalize_repository_url(expected_repository):
+        raise ValueError(
+            f"repository mismatch: expected {expected_repository!r}, got {actual_url!r}"
+        )
+    return workflow, repository_id, repository
+
+
+def resolve_branch(
+    api: Callable[..., dict[str, Any]], repository_id: str, branch: str
+) -> dict[str, Any]:
+    response = api(
+        "GET",
+        f"/v1/scmRepositories/{repository_id}/gitReferences"
+        f"?include=repository&limit=200",
+    )
+    rows = response.get("data")
+    if not isinstance(rows, list):
+        raise ValueError("App Store Connect returned no Git references")
+    canonical = f"refs/heads/{branch}"
+    matches = []
+    for row in rows:
+        if not isinstance(row, dict) or row.get("type") != "scmGitReferences":
+            continue
+        attributes = row.get("attributes")
+        if not isinstance(attributes, dict) or attributes.get("isDeleted") is True:
+            continue
+        if attributes.get("name") == branch or attributes.get("canonicalName") == canonical:
+            matches.append(row)
+    if len(matches) != 1:
+        raise ValueError(f"expected one live Git reference for {branch!r}, found {len(matches)}")
+    return matches[0]
+
+
+def build_request(workflow_id: str, reference_id: str) -> dict[str, Any]:
+    return {
+        "data": {
+            "type": "ciBuildRuns",
+            "attributes": {},
+            "relationships": {
+                "workflow": {
+                    "data": {"type": "ciWorkflows", "id": workflow_id}
+                },
+                "sourceBranchOrTag": {
+                    "data": {"type": "scmGitReferences", "id": reference_id}
+                },
+            },
+        }
+    }
+
+
+def credentials(client) -> tuple[str, str, Path]:
+    arguments = SimpleNamespace(issuer_id=None, key_id=None, private_key=None)
+    return client.load_credentials(arguments)
+
+
+def run(arguments: argparse.Namespace) -> dict[str, Any]:
+    if not arguments.authorize_mutation:
+        raise ValueError("refusing to start a build without --authorize-mutation")
+    if arguments.branch != "main":
+        raise ValueError("the release workflow only permits the main branch")
+
+    client = load_client()
+    issuer_id, key_id, private_key = credentials(client)
+
+    def api(method: str, path: str, body: bytes | None = None) -> dict[str, Any]:
+        token = client.make_jwt(issuer_id, key_id, private_key, int(time.time()))
+        return client.api_call(method, path, token, body=body)
+
+    _workflow, repository_id, repository = verify_workflow(
+        api,
+        arguments.workflow_id,
+        arguments.expected_workflow_name,
+        arguments.expected_repository,
+    )
+    reference = resolve_branch(api, repository_id, arguments.branch)
+    reference_id = reference.get("id")
+    if not isinstance(reference_id, str) or not reference_id:
+        raise ValueError("resolved Git reference has no ID")
+
+    body = json.dumps(
+        build_request(arguments.workflow_id, reference_id), separators=(",", ":")
+    ).encode()
+    start_response = api("POST", "/v1/ciBuildRuns", body=body)
+    start_data = start_response.get("data")
+    start_id = start_data.get("id") if isinstance(start_data, dict) else None
+    run_resource = resource_data(start_response, "ciBuildRuns", str(start_id or ""))
+    run_id = run_resource["id"]
+    terminal_response = None
+    if arguments.wait:
+        with tempfile.TemporaryDirectory(prefix="floorp-xcode-cloud-") as temporary:
+            terminal_path = Path(temporary) / "terminal.json"
+            polling_client = client.build_polling_client(
+                issuer_id, key_id, private_key, dry_run=False
+            )
+            client.wait_ci_run(
+                polling_client,
+                run_id,
+                arguments.expected_head,
+                terminal_path,
+                dry_run=False,
+            )
+            terminal_response = json.loads(terminal_path.read_text(encoding="utf-8"))
+
+    final_resource = (
+        terminal_response.get("data") if isinstance(terminal_response, dict) else run_resource
+    )
+    report = {
+        "workflow": {
+            "id": arguments.workflow_id,
+            "name": arguments.expected_workflow_name,
+        },
+        "repository": {
+            "id": repository_id,
+            "http_clone_url": repository.get("attributes", {}).get("httpCloneUrl"),
+        },
+        "source": {
+            "branch": arguments.branch,
+            "reference_id": reference_id,
+            "expected_head": arguments.expected_head,
+        },
+        "run": final_resource,
+        "build_url": (
+            f"https://appstoreconnect.apple.com/teams/{arguments.team_id}/apps/"
+            f"{arguments.app_id}/ci/builds/{run_id}/summary"
+        ),
+    }
+    return report
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow-id", required=True)
+    parser.add_argument("--expected-workflow-name", required=True)
+    parser.add_argument("--expected-repository", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--team-id", required=True)
+    parser.add_argument("--app-id", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--authorize-mutation", action="store_true")
+    parser.add_argument("--wait", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = parse_arguments(argv)
+    try:
+        report = run(arguments)
+        arguments.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        run_data = report.get("run") if isinstance(report.get("run"), dict) else {}
+        attributes = run_data.get("attributes") if isinstance(run_data, dict) else {}
+        status = attributes.get("completionStatus") if isinstance(attributes, dict) else None
+        progress = attributes.get("executionProgress") if isinstance(attributes, dict) else None
+        print(f"Xcode Cloud build run {run_data.get('id')} progress={progress} status={status}")
+        print(f"Build URL: {report['build_url']}")
+        return 0
+    except Exception as error:
+        print(f"BLOCKED: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions bridge for the existing Floorp TestFlight Xcode Cloud workflow
- validate the pinned workflow, repository, and `main` Git reference before starting a run
- keep archive, signing, and App Store Connect distribution in Xcode Cloud
- add App Store Connect SCM reference reads and portable OpenSSL discovery for the API client
- document the future App Store workflow reuse path

## Validation
- actionlint
- `python3 -m unittest discover -s scripts/release/tests -p 'test_*.py'`
- `env -u GITHUB_API_URL -u GITHUB_SERVER_URL python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py'`

## Setup required before first dispatch
Add `APPLE_DEVELOPER_API_KEY_JSON` to the `floorp-testflight` GitHub Environment. This key only starts and monitors Xcode Cloud; signing certificates and provisioning profiles remain in Xcode Cloud.
