### PR TITLE
Show Xcode Cloud build URL immediately in Actions

### DIFF
--- a/.github/workflows/floorp-xcode-cloud-testflight.yml
+++ b/.github/workflows/floorp-xcode-cloud-testflight.yml
@@ -86,7 +86,7 @@ jobs:
               handle.write(f"APP_STORE_CONNECT_PRIVATE_KEY_PATH={key_path}\n")
           PY
 
-      - name: Start Xcode Cloud and optionally wait for completion
+      - name: Start Xcode Cloud
         run: |
           set -euo pipefail
           output="$RUNNER_TEMP/floorp-xcode-cloud-run.json"
@@ -101,11 +101,67 @@ jobs:
             --output "$output"
             --authorize-mutation
           )
-          if [[ "${{ inputs.wait_for_completion }}" == "true" ]]; then
-            args+=(--wait)
-          fi
           python3 scripts/release/trigger-xcode-cloud.py "${args[@]}"
           printf 'FLOORP_XCODE_CLOUD_RUN=%s\n' "$output" >> "$GITHUB_ENV"
+
+          /usr/bin/python3 - "$output" "$GITHUB_ENV" "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          run = report.get("run") or {}
+          run_id = run.get("id")
+          build_url = report.get("build_url")
+          if not isinstance(run_id, str) or not run_id:
+              raise SystemExit("Xcode Cloud response did not contain a run ID")
+          if not isinstance(build_url, str) or not build_url:
+              raise SystemExit("Xcode Cloud response did not contain a build URL")
+
+          with Path(sys.argv[2]).open("a", encoding="utf-8") as handle:
+              handle.write(f"FLOORP_XCODE_CLOUD_RUN_ID={run_id}\n")
+          with Path(sys.argv[3]).open("a", encoding="utf-8") as summary:
+              summary.write("### Xcode Cloud build started\n\n")
+              summary.write(f"- Xcode Cloud run: `{run_id}`\n")
+              summary.write(f"- [Open App Store Connect build]({build_url})\n")
+          print(f"Xcode Cloud build URL: {build_url}")
+          PY
+
+      - name: Wait for Xcode Cloud to finish
+        if: inputs.wait_for_completion == true
+        run: |
+          set -euo pipefail
+          terminal="$RUNNER_TEMP/floorp-xcode-cloud-terminal.json"
+          if /usr/bin/python3 scripts/release/app-store-connect-api.py wait-ci-run \
+            --run-id "$FLOORP_XCODE_CLOUD_RUN_ID" \
+            --expected-head "$GITHUB_SHA" \
+            --output "$terminal"; then
+            wait_status=0
+          else
+            wait_status=$?
+          fi
+
+          if [[ -f "$terminal" ]]; then
+            /usr/bin/python3 - "$FLOORP_XCODE_CLOUD_RUN" "$terminal" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          report_path = Path(sys.argv[1])
+          terminal_path = Path(sys.argv[2])
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          terminal = json.loads(terminal_path.read_text(encoding="utf-8"))
+          run = terminal.get("data")
+          if not isinstance(run, dict):
+              raise SystemExit("Xcode Cloud completion response did not contain run data")
+          report["run"] = run
+          report_path.write_text(
+              json.dumps(report, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          fi
+          exit "$wait_status"
 
       - name: Publish deployment summary
         if: always()

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -197,7 +197,7 @@ The shared `Floorp` scheme now archives with `FloorpRelease` in Xcode Cloud. The
 1. In Signing & Capabilities, explicitly confirm the main `app.floorp.Floorp` bundle ID once before initial setup because the project derives it from an `.xcconfig` file. Register extension IDs only when those targets return to the release.
 2. Connect `Floorp-Projects/Floorp-iOS` to Xcode Cloud from Xcode's Report navigator. A GitHub organization owner must authorize the first connection.
 3. Keep `Floorp TestFlight Manual` manually started and restricted to `main`; App Store Connect remains the direct fallback for starting a build.
-4. Use `.github/workflows/floorp-xcode-cloud-testflight.yml` when the deployment should be visible as an explicit GitHub Actions run. It validates the pinned workflow and repository, starts the Xcode Cloud run through `POST /v1/ciBuildRuns`, and optionally waits for completion.
+4. Use `.github/workflows/floorp-xcode-cloud-testflight.yml` when the deployment should be visible as an explicit GitHub Actions run. It validates the pinned workflow and repository, starts the Xcode Cloud run through `POST /v1/ciBuildRuns`, writes the App Store Connect build URL to the Actions log and summary immediately, and optionally waits for completion.
 5. Let Xcode Cloud manage signing; verify the Client-only app is signed by the Floorp team and inspect its production entitlements. Repeat this check for each extension if one is restored later.
 6. Confirm `firefox-ios/TestFlight/WhatToTest.en-US.txt` appears in the TestFlight build and invite the internal group.
 7. Add a separate ordinary App Store workflow later by reusing `scripts/release/trigger-xcode-cloud.py` with its own pinned Xcode Cloud workflow ID and distribution target.


### PR DESCRIPTION
## Summary
- start Xcode Cloud without blocking the URL publication
- expose the App Store Connect build URL in the Actions log and step summary immediately
- keep optional completion polling and final status reporting

## Validation
- actionlint 1.7.12
- git diff --check