### PR TITLE
Fix panel completion and account icon layout

### DIFF
--- a/firefox-ios/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
+++ b/firefox-ios/Client/Frontend/Settings/Main/Account/ConnectSetting.swift
@@ -38,9 +38,14 @@ class ConnectSetting: WithoutAccountSetting {
 
     override func onConfigureCell(_ cell: UITableViewCell, theme: Theme) {
         super.onConfigureCell(cell, theme: theme)
-        cell.imageView?.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.logoFloorp)
-        cell.imageView?.tintColor = theme.colors.textDisabled
-        cell.imageView?.layer.cornerRadius = (cell.imageView?.frame.size.width)! / 2
-        cell.imageView?.layer.masksToBounds = true
+        guard let imageView = cell.imageView else { return }
+        imageView.subviews.forEach { $0.removeFromSuperview() }
+        imageView.frame = CGRect(width: 30, height: 30)
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage.templateImageNamed(StandardImageIdentifiers.Large.logoFloorp)?
+            .createScaled(CGSize(width: 30, height: 30))
+        imageView.tintColor = theme.colors.textDisabled
+        imageView.layer.cornerRadius = 15
+        imageView.layer.masksToBounds = true
     }
 }

--- a/firefox-ios/Floorp/FloorpPanelRegistryViewController.swift
+++ b/firefox-ios/Floorp/FloorpPanelRegistryViewController.swift
@@ -606,10 +606,17 @@ final class FloorpPanelRegistryViewController: UIViewController,
     }
 
     @objc private func editTapped() {
-        setEditing(!isEditing, animated: true)
+        setEditing(true, animated: true)
+    }
+
+    @objc private func doneEditingTapped() {
+        setEditing(false, animated: true)
     }
 
     @objc private func doneTapped() {
+        if isEditing {
+            setEditing(false, animated: false)
+        }
         if let onDone {
             onDone()
         } else {
@@ -653,7 +660,7 @@ final class FloorpPanelRegistryViewController: UIViewController,
         editButton = UIBarButtonItem(
             barButtonSystemItem: editing ? .done : .edit,
             target: self,
-            action: #selector(editTapped)
+            action: editing ? #selector(doneEditingTapped) : #selector(editTapped)
         )
         editButton.accessibilityLabel = editing
             ? FloorpStrings.PanelRegistry.doneEditing

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpPanelPreferencesTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpPanelPreferencesTests.swift
@@ -822,6 +822,29 @@ final class FloorpPanelRegistryAutoUnloadTests: XCTestCase {
         XCTAssertTrue(fixture.manager.config.autoUnload)
     }
 
+    func testDoneEditingButtonLeavesPanelEditingMode() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+        let controller = fixture.makeController()
+        let host = host(controller)
+        defer { host.cleanup() }
+
+        controller.setEditing(true, animated: false)
+        XCTAssertTrue(controller.isEditing)
+
+        let doneButton = try XCTUnwrap(controller.navigationItem.rightBarButtonItems?.last)
+        XCTAssertEqual(doneButton.accessibilityLabel, FloorpStrings.PanelRegistry.doneEditing)
+        let action = try XCTUnwrap(doneButton.action)
+        let target = try XCTUnwrap(doneButton.target as? NSObject)
+        _ = target.perform(action)
+
+        XCTAssertFalse(controller.isEditing)
+        XCTAssertEqual(
+            controller.navigationItem.rightBarButtonItems?.last?.accessibilityLabel,
+            FloorpStrings.PanelRegistry.edit
+        )
+    }
+
     private func assertInitialState(isOn: Bool) throws {
         let fixture = try makeFixture(initialAutoUnload: isOn)
         defer { fixture.cleanup() }


### PR DESCRIPTION
## Summary
- Use an explicit action for the panel registry right-side Done button so it reliably exits edit mode.
- Constrain the signed-out account icon to the same 30pt layout as the signed-in account icon.
- Add a regression test for the panel Done action.

## Validation
- Swift syntax parsing passed for the changed source and test files.
- git diff --check passed.
- The focused simulator test was attempted, but the local Xcode environment stopped before test execution because existing dependencies could not be resolved: Shared/Common, and with explicit modules disabled, ActionExtensionKit.