### PR TITLE
Fix Extensions alert crash on iOS 26

### DIFF
--- a/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
+++ b/firefox-ios/Client/Coordinators/Router/DefaultRouter.swift
@@ -29,7 +29,14 @@ class DefaultRouter: NSObject, Router {
             completions[viewController] = completion
         }
 
-        viewController.presentationController?.delegate = self
+        // UIAlertController owns its presentation-controller delegate. On
+        // iOS 26, assigning the router to that delegate triggers UIKit's
+        // assertion and terminates the app before the alert can be shown.
+        // Other presentation controllers continue to use the router for
+        // adaptive-dismissal callbacks.
+        if !(viewController is UIAlertController) {
+            viewController.presentationController?.delegate = self
+        }
         navigationController.present(viewController, animated: animated, completion: nil)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -6,6 +6,7 @@ import XCTest
 @testable import Client
 
 final class DefaultRouterTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var navigationController: MockNavigationController!
 
     override func setUp() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/DefaultRouterTests.swift
@@ -39,6 +39,16 @@ final class DefaultRouterTests: XCTestCase {
     }
 
     @MainActor
+    func testPresentAlert_doesNotReplaceUIKitPresentationDelegate() {
+        let subject = DefaultRouter(navigationController: navigationController)
+        let alert = UIAlertController(title: "Extensions", message: nil, preferredStyle: .alert)
+
+        subject.present(alert)
+
+        XCTAssertEqual(navigationController.presentCalled, 1)
+    }
+
+    @MainActor
     func testPresentViewController_dismissModalCompletionCalled() {
         let subject = DefaultRouter(navigationController: navigationController)
         let viewController = UIViewController()


### PR DESCRIPTION
## Summary
- avoid assigning a router delegate to UIKit-owned `UIAlertController` presentation controllers
- retain adaptive-dismissal handling for all other presentation controllers
- add a regression test for alert presentation through `DefaultRouter`

## Evidence
- TestFlight 0.2.0 (58) crash on iPhone Air / iOS 26.5.2 symbolicates to `DefaultRouter.present` called by `BrowserCoordinator.presentWebExtensionActionsAlert`

## Verification
- local targeted simulator test was attempted but XcodeBuildMCP timed out before executing tests
- GitHub Actions CI pending