### PR TITLE
fix: resolve curated catalog candidate build

### DIFF
--- a/.github/workflows/floorp-curated-catalog-external-testflight.yml
+++ b/.github/workflows/floorp-curated-catalog-external-testflight.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       build_id:
-        description: Processed App Store Connect build ID produced by that Xcode Cloud run.
-        required: true
+        description: Optional processed App Store Connect build ID. When omitted, resolve the sole build produced by the Xcode Cloud run.
+        required: false
         type: string
       external_group_id:
         description: Existing external TestFlight group ID; leave blank only when exactly one exists.
@@ -163,10 +163,51 @@ jobs:
               handle.write(f"APP_STORE_CONNECT_PRIVATE_KEY_PATH={key_path}\n")
           PY
 
-      - name: Bind the processed App Store build to the exact candidate
+      - name: Resolve the sole processed App Store build from the candidate Xcode Cloud run
         env:
           FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID: ${{ inputs.xcode_cloud_run_id }}
           FLOORP_REQUESTED_BUILD_ID: ${{ inputs.build_id }}
+        run: |
+          set -euo pipefail
+          [[ "$FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]
+          root="$RUNNER_TEMP/floorp-curated-catalog-submission-binding"
+          mkdir -p "$root"
+          python3 scripts/release/app-store-connect-api.py get \
+            "/v1/ciBuildRuns/$FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID/relationships/builds" \
+            --output "$root/xcode-cloud-builds.json"
+          /usr/bin/python3 - "$root/xcode-cloud-builds.json" \
+            "$FLOORP_REQUESTED_BUILD_ID" "$GITHUB_ENV" <<'PY'
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          response_path = Path(sys.argv[1])
+          requested = sys.argv[2].strip()
+          environment_path = Path(sys.argv[3])
+          response = json.loads(response_path.read_text(encoding="utf-8"))
+          rows = response.get("data")
+          if not isinstance(rows, list) or len(rows) != 1:
+              raise SystemExit("Xcode Cloud run must produce exactly one App Store build")
+          build = rows[0]
+          build_id = build.get("id") if isinstance(build, dict) else None
+          if (
+              not isinstance(build, dict)
+              or build.get("type") != "builds"
+              or not isinstance(build_id, str)
+              or re.fullmatch(r"[A-Za-z0-9._-]+", build_id) is None
+          ):
+              raise SystemExit("Xcode Cloud run build relationship is invalid")
+          if requested and requested != build_id:
+              raise SystemExit("requested App Store build does not match the Xcode Cloud run output")
+          with environment_path.open("a", encoding="utf-8") as stream:
+              stream.write(f"FLOORP_RESOLVED_BUILD_ID={build_id}\n")
+          PY
+
+      - name: Bind the processed App Store build to the exact candidate
+        env:
+          FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID: ${{ inputs.xcode_cloud_run_id }}
+          FLOORP_REQUESTED_BUILD_ID: ${{ env.FLOORP_RESOLVED_BUILD_ID }}
         run: |
           set -euo pipefail
           evidence="$RUNNER_TEMP/floorp-curated-catalog-submission-binding.json"
@@ -253,7 +294,7 @@ jobs:
 
       - name: Submit the verified build to Beta App Review
         env:
-          FLOORP_REQUESTED_BUILD_ID: ${{ inputs.build_id }}
+          FLOORP_REQUESTED_BUILD_ID: ${{ env.FLOORP_RESOLVED_BUILD_ID }}
         run: |
           set -euo pipefail
           root="$FLOORP_CURATED_CATALOG_SUBMISSION_ROOT"

--- a/scripts/release/tests/test_curated_catalog_external_testflight_workflow.py
+++ b/scripts/release/tests/test_curated_catalog_external_testflight_workflow.py
@@ -87,6 +87,25 @@ class CuratedCatalogExternalTestFlightWorkflowTests(unittest.TestCase):
             self.workflow.index("- name: Submit the verified build to Beta App Review"),
         )
 
+    def test_resolves_only_the_sole_build_from_the_candidate_xcode_cloud_run(self) -> None:
+        for required in (
+            "- name: Resolve the sole processed App Store build from the candidate Xcode Cloud run",
+            "/v1/ciBuildRuns/$FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID/relationships/builds",
+            '[[ "$FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]]',
+            "Xcode Cloud run must produce exactly one App Store build",
+            "FLOORP_RESOLVED_BUILD_ID",
+            "requested App Store build does not match the Xcode Cloud run output",
+        ):
+            self.assertIn(required, self.workflow)
+        self.assertLess(
+            self.workflow.index("- name: Prepare App Store Connect API key"),
+            self.workflow.index("- name: Resolve the sole processed App Store build from the candidate Xcode Cloud run"),
+        )
+        self.assertLess(
+            self.workflow.index("- name: Resolve the sole processed App Store build from the candidate Xcode Cloud run"),
+            self.workflow.index("- name: Bind the processed App Store build to the exact candidate"),
+        )
+
     def test_submits_only_to_an_existing_external_group_and_keeps_evidence_non_secret(self) -> None:
         for required in (
             "select exactly one existing external TestFlight group",
@@ -113,6 +132,7 @@ class CuratedCatalogExternalTestFlightWorkflowTests(unittest.TestCase):
             "FLOORP_REQUESTED_CANDIDATE_TAG: ${{ inputs.candidate_tag }}",
             "FLOORP_REQUESTED_XCODE_CLOUD_RUN_ID: ${{ inputs.xcode_cloud_run_id }}",
             "FLOORP_REQUESTED_BUILD_ID: ${{ inputs.build_id }}",
+            "FLOORP_REQUESTED_BUILD_ID: ${{ env.FLOORP_RESOLVED_BUILD_ID }}",
         ):
             self.assertIn(required, self.workflow)
 


### PR DESCRIPTION
## Summary
- Resolve the single App Store build linked to the candidate Xcode Cloud run inside the external TestFlight workflow.
- Keep a supplied build ID as an optional cross-check, and retain the existing strict submission binding verification.
- Cover resolver ordering and validation in the workflow tests.

## Validation
- `python3 -m unittest scripts.release.tests.test_curated_catalog_external_testflight_workflow scripts.release.tests.test_app_store_connect_api`
- `git diff --check`