### PR TITLE
fix: include Xcode Cloud relationships in submission binding

### DIFF
--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -28,6 +28,7 @@ class AllowlistTests(unittest.TestCase):
             "/v1/ciProducts/37C53C81-4C23-4E04-ADBB-1F238907A310/buildRuns",
             "/v1/ciWorkflows/D00DF3AC-15CD-430A-9FCB-39F876242926",
             "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376",
+            "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376?include=workflow,sourceBranchOrTag",
             "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376/relationships/builds",
             "/v1/ciBuildRuns/bfd267d8-696a-4394-94db-570f0aa9b376/actions",
             "/v1/ciBuildActions/4294e7e3-8adf-47fe-8f7c-02456baba2bb",

--- a/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
@@ -81,7 +81,7 @@ class FakeAPI:
                     "isDeleted": False,
                 },
             }]}
-        if path == f"/v1/ciBuildRuns/{RUN_ID}":
+        if path == f"/v1/ciBuildRuns/{RUN_ID}?include=workflow,sourceBranchOrTag":
             return {"data": {
                 "type": "ciBuildRuns",
                 "id": RUN_ID,
@@ -131,11 +131,19 @@ class CuratedCatalogSubmissionTests(unittest.TestCase):
         )
 
     def test_accepts_the_single_processed_build_from_the_exact_tag_run(self):
-        result = self.verify(FakeAPI())
+        api = FakeAPI()
+        result = self.verify(api)
         self.assertEqual(result["status"], "verified")
         self.assertEqual(result["candidateTag"], TAG)
         self.assertEqual(result["buildID"], BUILD_ID)
         self.assertEqual(result["buildNumber"], "5")
+        self.assertIn(
+            (
+                "GET",
+                f"/v1/ciBuildRuns/{RUN_ID}?include=workflow,sourceBranchOrTag",
+            ),
+            api.calls,
+        )
 
     def test_rejects_a_run_with_a_different_source_commit(self):
         api = FakeAPI()

--- a/scripts/release/verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/verify_curated_catalog_testflight_submission.py
@@ -112,7 +112,15 @@ def verify_submission(
     reference_id = reference.get("id")
     _require(isinstance(reference_id, str) and RESOURCE_ID.fullmatch(reference_id) is not None, "candidate tag has no valid App Store Connect reference")
 
-    run = _resource(api("GET", f"/v1/ciBuildRuns/{xcode_cloud_run_id}"), "ciBuildRuns", xcode_cloud_run_id, "Xcode Cloud run")
+    run = _resource(
+        api(
+            "GET",
+            f"/v1/ciBuildRuns/{xcode_cloud_run_id}?include=workflow,sourceBranchOrTag",
+        ),
+        "ciBuildRuns",
+        xcode_cloud_run_id,
+        "Xcode Cloud run",
+    )
     attributes = run.get("attributes")
     _require(isinstance(attributes, dict), "Xcode Cloud run attributes are missing")
     source_commit = attributes.get("sourceCommit")


### PR DESCRIPTION
## Summary
- Request the Xcode Cloud workflow and source-tag relationships explicitly when binding a processed build to a curated-catalog candidate.
- Preserve fail-closed checks and cover the request shape in unit tests.

## Validation
- `python3 -m unittest scripts.release.tests.test_verify_curated_catalog_testflight_submission scripts.release.tests.test_app_store_connect_api scripts.release.tests.test_curated_catalog_external_testflight_workflow`
- `git diff --check`