### PR TITLE
fix: include App Store build relationship in submission binding

### DIFF
--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -36,6 +36,7 @@ class AllowlistTests(unittest.TestCase):
             "/v1/scmRepositories/repo-1",
             "/v1/scmRepositories/repo-1/gitReferences",
             "/v1/builds",
+            "/v1/builds/build-1?include=preReleaseVersion",
             "/v1/builds/build-1/preReleaseVersion",
             "/v1/betaGroups",
             "/v1/betaAppReviewDetails",

--- a/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
@@ -97,7 +97,7 @@ class FakeAPI:
             }}
         if path == f"/v1/ciBuildRuns/{RUN_ID}/relationships/builds":
             return {"data": [{"type": "builds", "id": self.build_link}]}
-        if path == f"/v1/builds/{BUILD_ID}":
+        if path == f"/v1/builds/{BUILD_ID}?include=preReleaseVersion":
             return {"data": {
                 "type": "builds",
                 "id": BUILD_ID,
@@ -142,6 +142,10 @@ class CuratedCatalogSubmissionTests(unittest.TestCase):
                 "GET",
                 f"/v1/ciBuildRuns/{RUN_ID}?include=workflow,sourceBranchOrTag",
             ),
+            api.calls,
+        )
+        self.assertIn(
+            ("GET", f"/v1/builds/{BUILD_ID}?include=preReleaseVersion"),
             api.calls,
         )
 

--- a/scripts/release/verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/verify_curated_catalog_testflight_submission.py
@@ -136,7 +136,12 @@ def verify_submission(
     linked = linked_builds[0]
     _require(isinstance(linked, dict) and linked.get("type") == "builds" and linked.get("id") == build_id, "selected App Store build is not the Xcode Cloud run output")
 
-    build = _resource(api("GET", f"/v1/builds/{build_id}"), "builds", build_id, "App Store build")
+    build = _resource(
+        api("GET", f"/v1/builds/{build_id}?include=preReleaseVersion"),
+        "builds",
+        build_id,
+        "App Store build",
+    )
     build_attributes = build.get("attributes")
     _require(isinstance(build_attributes, dict), "App Store build attributes are missing")
     _require(build_attributes.get("processingState") == "VALID", "App Store build has not processed successfully")


### PR DESCRIPTION
Requests the build resource with its required pre-release relationship before fail-closed verification. Adds exact request and route-allowlist coverage.