### PR TITLE
fix: include prerelease app relationship in submission binding

### DIFF
--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -37,6 +37,7 @@ class AllowlistTests(unittest.TestCase):
             "/v1/scmRepositories/repo-1/gitReferences",
             "/v1/builds",
             "/v1/builds/build-1?include=preReleaseVersion",
+            "/v1/builds/build-1/preReleaseVersion?include=app",
             "/v1/builds/build-1/preReleaseVersion",
             "/v1/betaGroups",
             "/v1/betaAppReviewDetails",

--- a/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/tests/test_verify_curated_catalog_testflight_submission.py
@@ -104,7 +104,7 @@ class FakeAPI:
                 "attributes": {"processingState": self.processing_state, "version": "5"},
                 "relationships": {"preReleaseVersion": {"data": {"type": "preReleaseVersions", "id": "pre-1"}}},
             }}
-        if path == f"/v1/builds/{BUILD_ID}/preReleaseVersion":
+        if path == f"/v1/builds/{BUILD_ID}/preReleaseVersion?include=app":
             return {"data": {
                 "type": "preReleaseVersions",
                 "id": "pre-1",
@@ -146,6 +146,10 @@ class CuratedCatalogSubmissionTests(unittest.TestCase):
         )
         self.assertIn(
             ("GET", f"/v1/builds/{BUILD_ID}?include=preReleaseVersion"),
+            api.calls,
+        )
+        self.assertIn(
+            ("GET", f"/v1/builds/{BUILD_ID}/preReleaseVersion?include=app"),
             api.calls,
         )
 

--- a/scripts/release/verify_curated_catalog_testflight_submission.py
+++ b/scripts/release/verify_curated_catalog_testflight_submission.py
@@ -149,7 +149,7 @@ def verify_submission(
     _require(isinstance(build_number, str) and re.fullmatch(r"[1-9][0-9]*", build_number) is not None, "App Store build number is invalid")
 
     prerelease = _resource(
-        api("GET", f"/v1/builds/{build_id}/preReleaseVersion"),
+        api("GET", f"/v1/builds/{build_id}/preReleaseVersion?include=app"),
         "preReleaseVersions",
         _relationship_id(build, "preReleaseVersion", "preReleaseVersions", "App Store build"),
         "pre-release version",


### PR DESCRIPTION
Requests the pre-release version resource with its required app relationship before fail-closed verification. Adds exact request and route-allowlist coverage.