### PR TITLE
fix: make Dark Reader messaging reliable

### DIFF
--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -951,12 +951,16 @@ class Tab: NSObject,
     private var floorpWebExtensionTabIdentifier: Int {
         // Stable within a restored tab, without exposing the browser's UUID to
         // an extension API. FNV-1a gives a deterministic, process-local ID.
+        // Keep the result within JavaScript's exact integer range because tab
+        // IDs make a JSON Number round trip through extension code.
         var hash: UInt64 = 1_469_598_103_934_665_603
         for byte in tabUUID.utf8 {
             hash ^= UInt64(byte)
             hash &*= 1_099_511_628_211
         }
-        return Int(truncatingIfNeeded: hash & UInt64(Int.max))
+        let maximumJavaScriptSafeInteger = (UInt64(1) << 53) - 1
+        let identifier = hash & maximumJavaScriptSafeInteger
+        return Int(identifier == 0 ? 1 : identifier)
     }
 
     var floorpWebExtensionTabID: Int {

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
@@ -167,10 +167,27 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         let reloadProperties: TabsReloadPropertiesRequest?
     }
 
+    private struct TabsSendMessageOptionsRequest: Decodable {
+        private enum CodingKeys: String, CodingKey, CaseIterable {
+            case frameId
+            case documentId
+        }
+
+        let frameId: Int?
+        let documentId: String?
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(in: decoder, allowing: Set(CodingKeys.allCases.map(\.rawValue)))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            frameId = try container.decodeIfPresent(Int.self, forKey: .frameId)
+            documentId = try container.decodeIfPresent(String.self, forKey: .documentId)
+        }
+    }
+
     private struct TabsSendMessageRequest: Decodable {
         let tabId: Int
         let message: FloorpWebExtensionJSONValue
-        let options: [String: FloorpWebExtensionJSONValue]?
+        let options: TabsSendMessageOptionsRequest?
     }
 
     private struct AlarmNameRequest: Decodable {
@@ -2125,7 +2142,9 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
             request.message,
             to: request.tabId,
             for: sender.extensionID,
-            sender: sender
+            sender: sender,
+            frameID: request.options?.frameId,
+            documentID: request.options?.documentId
         )
         return try reply.map { try response($0) }
     }

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
@@ -48,6 +48,46 @@ struct FloorpWebExtensionRuntimeMessageSender: Equatable, Sendable, FloorpWebExt
     let url: URL
     let isMainFrame: Bool
     let isPrivate: Bool
+
+    var frameID: Int {
+        isMainFrame ? 0 : -1
+    }
+
+    var documentID: String {
+        if isMainFrame {
+            return FloorpWebExtensionDocumentIdentity.mainFrameID(
+                tabID: tabID,
+                documentGeneration: documentGeneration
+            )
+        }
+        return FloorpWebExtensionDocumentIdentity.unsupportedSubframeID(
+            tabID: tabID,
+            documentGeneration: documentGeneration
+        )
+    }
+}
+
+/// Stable API-visible identity for the current main-frame document. The
+/// browser-owned tab generation changes on every committed navigation, while
+/// hashing keeps those internal counters out of extension-visible messages.
+enum FloorpWebExtensionDocumentIdentity {
+    static func mainFrameID(tabID: Int, documentGeneration: UInt64) -> String {
+        let source = Data("\(tabID):\(documentGeneration):0".utf8)
+        return SHA256.hash(data: source).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// We do not currently expose a stable native ID for individual
+    /// subframes. Still provide a generation-bound opaque value so extension
+    /// code cannot accidentally turn an unavailable subframe target into an
+    /// unconstrained main-frame tabs.sendMessage call when JSON omits nil.
+    static func unsupportedSubframeID(tabID: Int, documentGeneration: UInt64) -> String {
+        let source = Data("\(tabID):\(documentGeneration):unsupported-subframe".utf8)
+        return SHA256.hash(data: source).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func mainFrameID(for tab: FloorpWebExtensionTabContext) -> String {
+        mainFrameID(tabID: tab.tabID, documentGeneration: tab.documentGeneration)
+    }
 }
 
 /// Sender identity for an action popup or options page.  Its opaque origin and
@@ -59,6 +99,26 @@ struct FloorpWebExtensionPageRuntimeMessageSender: Equatable, Sendable, FloorpWe
     let packageGeneration: String
     let originHost: String
     let surface: FloorpWebExtensionPageSurface
+    /// The authenticated WebKit URL that produced the message. This retains
+    /// the exact package-relative path so a receiving package WebView can map
+    /// it onto its own loadable transport origin.
+    let transportURL: URL?
+
+    init(
+        extensionID: FloorpWebExtensionID,
+        profileKey: FloorpWebExtensionCoordinatorProfileKey,
+        packageGeneration: String,
+        originHost: String,
+        surface: FloorpWebExtensionPageSurface,
+        transportURL: URL? = nil
+    ) {
+        self.extensionID = extensionID
+        self.profileKey = profileKey
+        self.packageGeneration = packageGeneration
+        self.originHost = originHost
+        self.surface = surface
+        self.transportURL = transportURL
+    }
 
     var isPrivate: Bool {
         profileKey.isPrivateBrowsing
@@ -565,13 +625,14 @@ final class FloorpWebExtensionMessageRuntime {
                     page.authorizesDocument(url, isMainFrame: isMainFrame)
             },
             scheduleRequest: scheduleBridgeRequest,
-            makeSender: { _, _ in
+            makeSender: { url, _ in
                 FloorpWebExtensionPageRuntimeMessageSender(
                     extensionID: page.extensionID,
                     profileKey: page.profileKey,
                     packageGeneration: page.packageGeneration,
                     originHost: page.originHost,
-                    surface: page.surface
+                    surface: page.surface,
+                    transportURL: url
                 )
             }
         )
@@ -1140,6 +1201,47 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
           const tabsOnRemoved = makeEvent();
           const storageOnChanged = makeEvent();
           const serializeResponse = (value) => JSON.stringify(value === undefined ? null : value);
+          const backgroundStartupActivity = (() => {
+            let pendingNativeRequests = 0;
+            let pendingResources = 0;
+            let didFinishScripts = false;
+            let lastActivity = performance.now();
+            const touch = () => { lastActivity = performance.now(); };
+            return Object.freeze({
+              nativeRequestStarted() {
+                pendingNativeRequests += 1;
+                touch();
+              },
+              nativeRequestFinished() {
+                pendingNativeRequests = Math.max(0, pendingNativeRequests - 1);
+                touch();
+              },
+              resourceStarted() {
+                pendingResources += 1;
+                touch();
+              },
+              resourceFinished() {
+                pendingResources = Math.max(0, pendingResources - 1);
+                touch();
+              },
+              scriptsFinished() {
+                didFinishScripts = true;
+                touch();
+              },
+              isIdleFor(milliseconds) {
+                return didFinishScripts &&
+                  pendingNativeRequests === 0 &&
+                  pendingResources === 0 &&
+                  performance.now() - lastActivity >= milliseconds;
+              }
+            });
+          })();
+          Object.defineProperty(globalThis, "__floorpWebExtensionBackgroundStartupActivity", {
+            value: backgroundStartupActivity,
+            enumerable: false,
+            configurable: false,
+            writable: false
+          });
           const request = (operation, payload = {}) => {
             const requestId = `${Date.now()}:${++nextRequest}`;
             let serialized;
@@ -1158,7 +1260,21 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             if (typeof serialized !== "string") {
               return Promise.reject(new Error("WebExtension message is not JSON serializable"));
             }
-            return nativeHandler.postMessage(serialized).then((rawReply) => {
+            // Message delivery can re-enter this same lazy background while
+            // it is starting. Waiting for that request here would make the
+            // inner delivery wait for itself forever. Ordinary initialization
+            // APIs (storage, i18n, permissions, and so on) remain tracked.
+            const tracksStartupActivity = operation !== "runtime.sendMessage" &&
+              operation !== "tabs.sendMessage";
+            if (tracksStartupActivity) backgroundStartupActivity.nativeRequestStarted();
+            let nativeReply;
+            try {
+              nativeReply = nativeHandler.postMessage(serialized);
+            } catch (error) {
+              if (tracksStartupActivity) backgroundStartupActivity.nativeRequestFinished();
+              return Promise.reject(error);
+            }
+            return Promise.resolve(nativeReply).then((rawReply) => {
               const reply = JSON.parse(rawReply);
               if (!reply || reply.requestId !== requestId) {
                 throw new Error("Invalid WebExtension bridge reply");
@@ -1169,6 +1285,8 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
                 throw error;
               }
               return reply.hasPayload ? reply.payload : undefined;
+            }).finally(() => {
+              if (tracksStartupActivity) backgroundStartupActivity.nativeRequestFinished();
             });
           };
           Object.defineProperty(globalThis, \(javaScriptLiteral(FloorpWebExtensionMessageRuntime.frameAuthorizationFunctionName)), {
@@ -1207,6 +1325,10 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
                 new Promise((resolve) => setTimeout(() => resolve(undefined), 5_000))
               ]);
             }
+            // Chrome treats a synchronous false return as "this listener did
+            // not respond". It must not consume the message or become a false
+            // response payload; a later listener may still handle it.
+            if (result === false) return undefined;
             return result;
           };
           const deliverTabsMessage = async (message, sender) => {
@@ -1657,13 +1779,16 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
               return Promise.resolve(false);
             }
           });
+          const packageRuntimeBaseURL = new URL("/", globalThis.location.href);
           const packageRuntimeURL = (path = "") => {
             if (globalThis.location?.protocol !== "floorp-extension:") {
               throw new Error("runtime.getURL is unavailable outside a package origin");
             }
             const normalized = String(path).replace(/^\\/+/, "");
-            const value = new URL(normalized, `${globalThis.location.origin}/`);
-            if (value.origin !== globalThis.location.origin) {
+            const value = new URL(normalized, packageRuntimeBaseURL);
+            if (value.protocol !== packageRuntimeBaseURL.protocol ||
+                value.host !== packageRuntimeBaseURL.host ||
+                value.username || value.password) {
               throw new Error("runtime.getURL rejected a cross-origin path");
             }
             return value.href;

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPageHost.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPageHost.swift
@@ -409,7 +409,7 @@ final class FloorpWebExtensionPageSchemeHandler: NSObject, WKURLSchemeHandler {
         return .init(response: response, data: data)
     }
 
-    static func packagePath(from url: URL) -> String? {
+    nonisolated static func packagePath(from url: URL) -> String? {
         guard let encodedPath = URLComponents(
             url: url,
             resolvingAgainstBaseURL: false
@@ -490,6 +490,7 @@ final class FloorpWebExtensionBackgroundSchemeHandler: NSObject, WKURLSchemeHand
 
     private let identity: FloorpWebExtensionBackgroundBridgeIdentity
     private let entryHTML: Data
+    private let activityTrackerPath: String
     private let readinessPath: String
     private let packageHandler: FloorpWebExtensionPageSchemeHandler
 
@@ -504,10 +505,26 @@ final class FloorpWebExtensionBackgroundSchemeHandler: NSObject, WKURLSchemeHand
             navigationPolicy: .init(originHost: identity.originHost),
             resolver: resolver
         )
+        activityTrackerPath = identity.entryPath.replacingOccurrences(
+            of: ".html",
+            with: ".activity.js"
+        )
         readinessPath = identity.entryPath.replacingOccurrences(
             of: ".html",
             with: ".ready.js"
         )
+        guard let activityTrackerURL = Self.resourceURL(
+            originHost: identity.originHost,
+            path: activityTrackerPath
+        ) else {
+            throw FloorpWebExtensionPageHostError.invalidResourceURL
+        }
+        // The bridge bootstrap is installed as a page-world WKUserScript at
+        // document start. The parser encounters this first external script
+        // afterward, so its activity object already exists before wrapping
+        // package XHR/fetch calls.
+        let escapedActivityTrackerURL = Self.escapeHTMLAttribute(activityTrackerURL.absoluteString)
+        let activityTrackerTag = "<script src=\"\(escapedActivityTrackerURL)\"></script>"
         let scriptTags = try background.scripts.map { source -> String in
             guard let url = Self.resourceURL(originHost: identity.originHost, path: source.path) else {
                 throw FloorpWebExtensionPageHostError.invalidResourceURL
@@ -523,7 +540,9 @@ final class FloorpWebExtensionBackgroundSchemeHandler: NSObject, WKURLSchemeHand
         }
         let readinessType = background.loadsAsModule ? " type=\"module\"" : ""
         let readinessTag = "<script\(readinessType) src=\"\(Self.escapeHTMLAttribute(readinessURL.absoluteString))\"></script>"
-        entryHTML = Data("<!doctype html><meta charset=\"utf-8\">\n\(scriptTags)\n\(readinessTag)".utf8)
+        entryHTML = Data(
+            "<!doctype html><meta charset=\"utf-8\">\n\(activityTrackerTag)\n\(scriptTags)\n\(readinessTag)".utf8
+        )
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
@@ -566,7 +585,8 @@ final class FloorpWebExtensionBackgroundSchemeHandler: NSObject, WKURLSchemeHand
            url.user == nil,
            url.password == nil,
            url.port == nil,
-           FloorpWebExtensionPageSchemeHandler.packagePath(from: url) == readinessPath {
+           let path = FloorpWebExtensionPageSchemeHandler.packagePath(from: url),
+           path == activityTrackerPath || path == readinessPath {
             guard let response = HTTPURLResponse(
                 url: url,
                 statusCode: 200,
@@ -580,13 +600,81 @@ final class FloorpWebExtensionBackgroundSchemeHandler: NSObject, WKURLSchemeHand
             ) else {
                 throw FloorpWebExtensionPageHostError.invalidResourceURL
             }
-            return .init(
-                response: response,
-                data: Data("globalThis.__floorpWebExtensionBackgroundScriptsReady = true;".utf8)
-            )
+            let source = path == activityTrackerPath
+                ? Self.activityTrackerJavaScript
+                : """
+                  globalThis.__floorpWebExtensionBackgroundScriptsReady = true;
+                  globalThis.__floorpWebExtensionBackgroundStartupActivity?.scriptsFinished();
+                  """
+            return .init(response: response, data: Data(source.utf8))
         }
         return try packageHandler.response(for: request)
     }
+
+    private static let activityTrackerJavaScript = """
+    (() => {
+      const activity = globalThis.__floorpWebExtensionBackgroundStartupActivity;
+      if (!activity) return;
+
+      const isPackageURL = (value) => {
+        try {
+          return new URL(String(value), globalThis.location.href).protocol === "floorp-extension:";
+        } catch (_) {
+          return false;
+        }
+      };
+
+      if (typeof XMLHttpRequest === "function") {
+        const packageRequests = new WeakSet();
+        const originalOpen = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function(method, url, ...args) {
+          packageRequests.delete(this);
+          if (isPackageURL(url)) packageRequests.add(this);
+          return originalOpen.call(this, method, url, ...args);
+        };
+        const originalSend = XMLHttpRequest.prototype.send;
+        XMLHttpRequest.prototype.send = function(...args) {
+          if (!packageRequests.has(this)) return originalSend.apply(this, args);
+          activity.resourceStarted();
+          let finished = false;
+          const finish = () => {
+            if (finished) return;
+            finished = true;
+            activity.resourceFinished();
+          };
+          for (const event of ["loadend", "error", "abort", "timeout"]) {
+            this.addEventListener(event, finish, {once: true});
+          }
+          try {
+            return originalSend.apply(this, args);
+          } catch (error) {
+            finish();
+            throw error;
+          }
+        };
+      }
+
+      if (typeof globalThis.fetch === "function") {
+        const originalFetch = globalThis.fetch.bind(globalThis);
+        globalThis.fetch = (...args) => {
+          const input = args[0];
+          const requestURL = input && typeof input === "object" && "url" in input
+            ? input.url
+            : input;
+          if (!isPackageURL(requestURL)) return originalFetch(...args);
+          activity.resourceStarted();
+          try {
+            return Promise.resolve(originalFetch(...args)).finally(
+              () => activity.resourceFinished()
+            );
+          } catch (error) {
+            activity.resourceFinished();
+            throw error;
+          }
+        };
+      }
+    })();
+    """
 
     private static func resourceURL(originHost: String, path: String) -> URL? {
         var components = URLComponents()
@@ -702,7 +790,7 @@ final class FloorpWebExtensionWKBackgroundEventHandler: NSObject,
         }
 
         let messageJSON = try Self.jsonString(from: message.jsonData)
-        let senderJSON = try Self.senderJSON(sender)
+        let senderJSON = try senderJSON(sender)
         let rawResult: Any?
         do {
             rawResult = try await callBackgroundJavaScript(
@@ -858,9 +946,13 @@ final class FloorpWebExtensionWKBackgroundEventHandler: NSObject,
             }
         }
         guard !scriptsReady else { return }
-        for _ in 0..<250 {
+        for _ in 0..<500 {
             let ready = try await callBackgroundJavaScript(
-                "return globalThis.__floorpWebExtensionBackgroundScriptsReady === true"
+                """
+                const scriptsReady = globalThis.__floorpWebExtensionBackgroundScriptsReady === true;
+                const activity = globalThis.__floorpWebExtensionBackgroundStartupActivity;
+                return scriptsReady && activity?.isIdleFor(100) === true;
+                """
             ) as? Bool
             if ready == true {
                 scriptsReady = true
@@ -945,7 +1037,7 @@ final class FloorpWebExtensionWKBackgroundEventHandler: NSObject,
         return value
     }
 
-    private static func senderJSON(_ sender: any FloorpWebExtensionMessageSender) throws -> String {
+    private func senderJSON(_ sender: any FloorpWebExtensionMessageSender) throws -> String {
         var object: [String: Any] = [
             "id": sender.extensionID.rawValue,
             "isPrivate": sender.isPrivate
@@ -957,16 +1049,33 @@ final class FloorpWebExtensionWKBackgroundEventHandler: NSObject,
                 "url": tab.url.absoluteString,
                 "isPrivate": tab.isPrivate
             ]
-            object["frameId"] = tab.isMainFrame ? 0 : -1
+            object["frameId"] = tab.frameID
+            object["documentId"] = tab.documentID
             object["documentGeneration"] = tab.documentGeneration
         } else if let page = sender as? FloorpWebExtensionPageRuntimeMessageSender {
-            object["url"] = "floorp-extension://\(page.originHost)/"
+            guard let transportURL = page.transportURL,
+                  FloorpWebExtensionPageNavigationPolicy(
+                      originHost: page.originHost
+                  ).isPackageURL(transportURL),
+                  transportURL.query == nil,
+                  let path = FloorpWebExtensionPageSchemeHandler.packagePath(from: transportURL),
+                  let receiverURL = Self.resourceURL(
+                      originHost: identity.originHost,
+                      path: path
+                  ) else {
+                throw FloorpWebExtensionMessageError.malformedEnvelope
+            }
+            // WebKit makes each package WebView a distinct random custom-
+            // scheme origin. Map the authenticated sender path onto this
+            // receiving background's loadable origin so Chrome-style
+            // comparisons with runtime.getURL preserve package identity.
+            object["url"] = receiverURL.absoluteString
             object["page"] = [
                 "originHost": page.originHost,
                 "surface": page.surface == .actionPopup ? "actionPopup" : "options"
             ]
-        } else if let background = sender as? FloorpWebExtensionBackgroundRuntimeMessageSender {
-            object["url"] = "floorp-extension://\(background.originHost)/"
+        } else if sender is FloorpWebExtensionBackgroundRuntimeMessageSender {
+            object["url"] = "\(FloorpWebExtensionPageNavigationPolicy.resourceScheme)://\(identity.originHost)/"
         }
         let data = try JSONSerialization.data(withJSONObject: object)
         guard data.count <= FloorpWebExtensionMessagePayload.maximumByteCount,

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionTabs.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionTabs.swift
@@ -168,7 +168,8 @@ final class FloorpWebExtensionProfileTabsHost: FloorpWebExtensionTabsHostAdaptin
         }
 
         let messageJSON = try jsonLiteral(message)
-        let senderJSON = try jsonLiteral(FloorpWebExtensionTabMessageSenderPayload(sender: sender))
+        let senderPayload = try FloorpWebExtensionTabMessageSenderPayload(sender: sender)
+        let senderJSON = try jsonLiteral(senderPayload)
         let script = "return await globalThis.__floorpWebExtensionDeliverTabsMessage(\(messageJSON), \(senderJSON))"
         let contentWorld = WKContentWorld.world(
             name: FloorpWebExtensionMessageRuntime.isolatedContentWorldName(for: sender.extensionID)
@@ -288,7 +289,7 @@ final class FloorpWebExtensionProfileTabsHost: FloorpWebExtensionTabsHostAdaptin
         let tab: TabPayload?
         let page: PagePayload?
 
-        init(sender: any FloorpWebExtensionMessageSender) {
+        init(sender: any FloorpWebExtensionMessageSender) throws {
             extensionId = sender.extensionID.rawValue
             isPrivate = sender.isPrivate
             if let tabSender = sender as? FloorpWebExtensionRuntimeMessageSender {
@@ -305,7 +306,15 @@ final class FloorpWebExtensionProfileTabsHost: FloorpWebExtensionTabsHostAdaptin
             } else if let pageSender = sender as? FloorpWebExtensionPageRuntimeMessageSender {
                 tabId = nil
                 documentGeneration = nil
-                url = "floorp-extension://\(pageSender.originHost)/"
+                guard let transportURL = pageSender.transportURL,
+                      FloorpWebExtensionPageNavigationPolicy(
+                          originHost: pageSender.originHost
+                      ).isPackageURL(transportURL),
+                      FloorpWebExtensionPageSchemeHandler.packagePath(from: transportURL) != nil,
+                      transportURL.query == nil else {
+                    throw FloorpWebExtensionMessageError.malformedEnvelope
+                }
+                url = transportURL.absoluteString
                 isMainFrame = true
                 tab = nil
                 switch pageSender.surface {
@@ -314,6 +323,13 @@ final class FloorpWebExtensionProfileTabsHost: FloorpWebExtensionTabsHostAdaptin
                 case .options:
                     page = .init(originHost: pageSender.originHost, surface: "options")
                 }
+            } else if let backgroundSender = sender as? FloorpWebExtensionBackgroundRuntimeMessageSender {
+                tabId = nil
+                documentGeneration = nil
+                url = "\(FloorpWebExtensionPageNavigationPolicy.resourceScheme)://\(backgroundSender.originHost)/"
+                isMainFrame = nil
+                tab = nil
+                page = nil
             } else {
                 tabId = nil
                 documentGeneration = nil
@@ -363,6 +379,8 @@ protocol FloorpWebExtensionTabsHostAdapting: AnyObject {
 /// and private-mode escape paths at this API boundary.
 @MainActor
 final class FloorpWebExtensionTabsService {
+    private static let maximumJavaScriptSafeInteger = 9_007_199_254_740_991
+
     private let profileIdentifier: String
     private let isPrivateBrowsing: Bool
     private let host: any FloorpWebExtensionTabsHostAdapting
@@ -475,13 +493,20 @@ final class FloorpWebExtensionTabsService {
         _ message: FloorpWebExtensionJSONValue,
         to tabID: Int,
         for extensionID: FloorpWebExtensionID,
-        sender: any FloorpWebExtensionMessageSender
+        sender: any FloorpWebExtensionMessageSender,
+        frameID: Int? = nil,
+        documentID: String? = nil
     ) async throws -> FloorpWebExtensionJSONValue? {
         guard sender.extensionID == extensionID,
               sender.isPrivate == isPrivateBrowsing else {
             throw FloorpWebExtensionMessageError.unauthorizedDocument
         }
         let tab = try tab(withID: tabID)
+        let currentDocumentID = FloorpWebExtensionDocumentIdentity.mainFrameID(for: tab.context)
+        guard frameID == nil || frameID == 0,
+              documentID == nil || documentID == currentDocumentID else {
+            throw FloorpWebExtensionTabsError.messageDeliveryFailed
+        }
         try await requireContentAccess(to: tab.context, for: extensionID)
         do {
             return try await host.deliverMessage(message, sender: sender, to: tab.context)
@@ -509,7 +534,8 @@ final class FloorpWebExtensionTabsService {
 
     private func validate(_ tab: FloorpWebExtensionHostTab) throws -> FloorpWebExtensionHostTab {
         guard tab.context.isPrivate == isPrivateBrowsing,
-              tab.context.tabID >= 0 else {
+              tab.context.tabID > 0,
+              tab.context.tabID <= Self.maximumJavaScriptSafeInteger else {
             throw FloorpWebExtensionTabsError.hostTabInvariantViolation
         }
         return tab

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
@@ -290,13 +290,31 @@ final class FloorpWebExtensionAPIHostTests: XCTestCase {
             payload: try payload([
                 "tabId": target.tabID,
                 "message": ["kind": "ping"],
-                "options": [:]
+                "options": [
+                    "frameId": 0,
+                    "documentId": FloorpWebExtensionDocumentIdentity.mainFrameID(for: target)
+                ]
             ]),
             sender: sourceSender
         )
 
         let deliveredSender = try XCTUnwrap(tabsHost.lastSender as? FloorpWebExtensionRuntimeMessageSender)
         XCTAssertEqual(deliveredSender, sourceSender)
+
+        do {
+            _ = try await host.dispatch(
+                operation: "tabs.sendMessage",
+                payload: try payload([
+                    "tabId": target.tabID,
+                    "message": ["kind": "stale"],
+                    "options": ["documentId": "stale-document"]
+                ]),
+                sender: sourceSender
+            )
+            XCTFail("Expected a stale document target to fail closed")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionTabsError, .messageDeliveryFailed)
+        }
     }
 
     func testWebKitBootstrapUsesNativeStorageAndI18nThroughIsolatedWorld() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionMessageRuntimeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionMessageRuntimeTests.swift
@@ -10,6 +10,38 @@ import XCTest
 final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
     private let extensionID = FloorpWebExtensionID(rawValue: "message-fixture")!
 
+    func testRuntimeSenderAlwaysExposesOpaqueDocumentIdentityForSubframes() {
+        let main = FloorpWebExtensionRuntimeMessageSender(
+            extensionID: extensionID,
+            tabID: 41,
+            documentGeneration: 9,
+            url: URL(string: "https://allowed.example/main")!,
+            isMainFrame: true,
+            isPrivate: false
+        )
+        let subframe = FloorpWebExtensionRuntimeMessageSender(
+            extensionID: extensionID,
+            tabID: 41,
+            documentGeneration: 9,
+            url: URL(string: "https://allowed.example/frame")!,
+            isMainFrame: false,
+            isPrivate: false
+        )
+
+        XCTAssertEqual(main.frameID, 0)
+        XCTAssertEqual(subframe.frameID, -1)
+        XCTAssertEqual(main.documentID.count, 64)
+        XCTAssertEqual(subframe.documentID.count, 64)
+        XCTAssertNotEqual(subframe.documentID, main.documentID)
+        XCTAssertEqual(
+            subframe.documentID,
+            FloorpWebExtensionDocumentIdentity.unsupportedSubframeID(
+                tabID: 41,
+                documentGeneration: 9
+            )
+        )
+    }
+
     func testLazyBackgroundActivatesOnFirstMessageAndReusesHandler() async throws {
         let host = FloorpWebExtensionLazyBackgroundHost()
         var factoryCalls = 0
@@ -142,7 +174,6 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(firstReply.senderId, extensionID.rawValue)
         XCTAssertEqual(firstReply.tabId, 41)
         XCTAssertEqual(firstReply.runtimeId, extensionID.rawValue)
-        XCTAssertTrue(firstReply.packageURL.hasPrefix("floorp-extension://background-"))
         XCTAssertTrue(firstReply.packageURL.hasSuffix("/dependency.js"))
         XCTAssertEqual(host.snapshot(for: extensionID).activationCount, 1)
         let firstNativeSender = try XCTUnwrap(
@@ -151,6 +182,10 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(firstNativeSender.profileKey, profileKey)
         XCTAssertEqual(firstNativeSender.packageGeneration, "generation-1")
         XCTAssertTrue(firstNativeSender.originHost.hasPrefix("background-"))
+        XCTAssertEqual(
+            firstReply.packageURL,
+            "floorp-extension://\(firstNativeSender.originHost)/dependency.js"
+        )
 
         let secondResources = [
             "background.js": worker,
@@ -263,6 +298,108 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(host.snapshot(for: extensionID).activationCount, 1)
     }
 
+    func testPackageBackgroundWaitsForStartupAPIAndResourceActivityBeforeFirstMessage() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "async-background-startup-profile",
+            isPrivateBrowsing: false
+        )
+        let host = FloorpWebExtensionLazyBackgroundHost()
+        let dispatcher = AsyncNativeAPIDispatchGate()
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: host,
+            nativeAPIDispatcher: dispatcher,
+            profileKey: profileKey
+        )
+        let resources = [
+            "background.js": Data("""
+            globalThis.startupValue = null;
+            browser.i18n.getUILanguage().then(() => new Promise((resolve, reject) => {
+              const request = new XMLHttpRequest();
+              request.open("GET", "config/startup.config", true);
+              request.onload = () => resolve(request.responseText);
+              request.onerror = () => reject(new Error("startup config failed"));
+              request.send();
+            })).then((value) => { globalThis.startupValue = value; });
+            browser.runtime.onMessage.addListener(() => ({startupValue: globalThis.startupValue}));
+            """.utf8),
+            "config/startup.config": Data("startup-ready".utf8)
+        ]
+        let package = try makeBackgroundInstalledPackage(
+            generation: "async-background-startup-generation",
+            resources: resources
+        )
+        let resolver = FloorpWebExtensionPageResourceResolver { request in
+            guard let data = resources[request.path] else {
+                throw FloorpWebExtensionPackageStoreError.resourceUnavailable(request.path)
+            }
+            return data
+        }
+        try runtime.registerPackageBackground(
+            package: package,
+            packageProfileKey: .init(
+                profileIdentifier: profileKey.profileIdentifier,
+                isPrivateBrowsing: profileKey.isPrivateBrowsing
+            ),
+            resolver: resolver
+        )
+
+        let replyTask = Task { @MainActor in
+            try await host.dispatch(
+                FloorpWebExtensionMessagePayload(Ping(type: "ping")),
+                sender: testSender(extensionID: extensionID)
+            )
+        }
+        await dispatcher.waitUntilStarted()
+        try await Task.sleep(nanoseconds: 200_000_000)
+        dispatcher.succeed()
+
+        let replyPayload = try await replyTask.value
+        let reply = try XCTUnwrap(try replyPayload?.decode(StartupBackgroundReply.self))
+        XCTAssertEqual(reply.startupValue, "startup-ready")
+    }
+
+    func testPackageBackgroundStartupRuntimeMessageDoesNotDeadlockReadiness() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "self-message-background-startup-profile",
+            isPrivateBrowsing: false
+        )
+        let host = FloorpWebExtensionLazyBackgroundHost()
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: host,
+            profileKey: profileKey
+        )
+        let resources = [
+            "background.js": Data("""
+            chrome.runtime.onMessage.addListener((message) => ({type: message.type}));
+            void chrome.runtime.sendMessage({type: "startup-self-message"});
+            """.utf8)
+        ]
+        let package = try makeBackgroundInstalledPackage(
+            generation: "self-message-background-startup-generation",
+            resources: resources
+        )
+        try runtime.registerPackageBackground(
+            package: package,
+            packageProfileKey: .init(
+                profileIdentifier: profileKey.profileIdentifier,
+                isPrivateBrowsing: profileKey.isPrivateBrowsing
+            ),
+            resolver: .init { request in
+                guard let data = resources[request.path] else {
+                    throw FloorpWebExtensionPackageStoreError.resourceUnavailable(request.path)
+                }
+                return data
+            }
+        )
+
+        let replyPayload = try await host.dispatch(
+            FloorpWebExtensionMessagePayload(Ping(type: "outer-message")),
+            sender: testSender(extensionID: extensionID)
+        )
+        let reply = try XCTUnwrap(try replyPayload?.decode(StartupSelfMessageReply.self))
+        XCTAssertEqual(reply.type, "outer-message")
+    }
+
     func testBackgroundRegistrationIsStrictlyExtensionScoped() async throws {
         let host = FloorpWebExtensionLazyBackgroundHost()
         host.register(extensionID: extensionID) { EchoBackgroundHandler() }
@@ -358,11 +495,18 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
                 resolve(chrome.runtime.lastError?.code || null);
               });
             });
+            let contentGetURLRejected = false;
+            try {
+              chrome.runtime.getURL("package-resource.js");
+            } catch (_) {
+              contentGetURLRejected = true;
+            }
             return {
               permission,
               enabledRulesets,
               callbackError,
               leakedLastError: chrome.runtime.lastError !== null,
+              contentGetURLRejected,
               runtimeId: chrome.runtime.id,
               dynamicLimit: browser.declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES
             };
@@ -374,6 +518,7 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(result?["enabledRulesets"] as? [String], ["base"])
         XCTAssertEqual(result?["callbackError"] as? String, "unsupported_code_execution")
         XCTAssertEqual(result?["leakedLastError"] as? Bool, false)
+        XCTAssertEqual(result?["contentGetURLRejected"] as? Bool, true)
         XCTAssertEqual(result?["runtimeId"] as? String, extensionID.rawValue)
         XCTAssertEqual(result?["dynamicLimit"] as? Int, 5_000)
         XCTAssertEqual(
@@ -391,6 +536,47 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         )
         XCTAssertEqual((registeredObject["scripts"] as? [[String: Any]])?.first?["id"] as? String,
                        "registered-from-worker")
+    }
+
+    func testWebKitTabsBridgePreservesJavaScriptSafeTabIdentifier() async throws {
+        let tabID = 5_484_014_516_345_869
+        let dispatcher = SafeTabIdentifierDispatcher(tabID: tabID)
+        let runtime = FloorpWebExtensionMessageRuntime(nativeAPIDispatcher: dispatcher)
+        let configuration = WKWebViewConfiguration()
+        let tab = testTab()
+        runtime.installBridge(
+            for: extensionID,
+            tab: tab,
+            on: configuration.userContentController,
+            authorizeDocument: { _, isMainFrame, trustedTab in
+                isMainFrame && trustedTab == tab
+            }
+        )
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.loadHTMLString("<html><body>tabs bridge</body></html>", baseURL: tab.url)
+        try await waitForLoad(webView)
+
+        let result = try await webView.callAsyncJavaScript(
+            """
+            const [queriedTab] = await browser.tabs.query({active: true});
+            const roundTrippedID = JSON.parse(JSON.stringify({id: queriedTab.id})).id;
+            const fetchedTab = await browser.tabs.get(roundTrippedID);
+            const reply = await browser.tabs.sendMessage(roundTrippedID, {type: "ping"});
+            return {
+              id: queriedTab.id,
+              safe: Number.isSafeInteger(queriedTab.id),
+              fetchedID: fetchedTab.id,
+              reply: reply.reply
+            };
+            """,
+            contentWorld: .world(name: FloorpWebExtensionMessageRuntime.isolatedContentWorldName(for: extensionID))
+        ) as? [String: Any]
+
+        XCTAssertEqual(result?["id"] as? Int, tabID)
+        XCTAssertEqual(result?["safe"] as? Bool, true)
+        XCTAssertEqual(result?["fetchedID"] as? Int, tabID)
+        XCTAssertEqual(result?["reply"] as? String, "ok")
+        XCTAssertEqual(dispatcher.receivedTabIDs, [tabID, tabID])
     }
 
     func testDocumentAuthorizationRunsBeforeLazyBackgroundActivation() async throws {
@@ -495,6 +681,7 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(sender.packageGeneration, package.generation)
         XCTAssertEqual(sender.originHost, originHost)
         XCTAssertEqual(sender.surface, .actionPopup)
+        XCTAssertEqual(sender.transportURL, page.webView.url)
 
         runtime.removeExtension(extensionID)
         XCTAssertTrue(page.webView.configuration.userContentController.userScripts.isEmpty)
@@ -506,6 +693,99 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         ) as? String
         XCTAssertEqual(bridgeType, "undefined")
         XCTAssertEqual(nativeDispatcher.receivedSenders.count, 1)
+    }
+
+    func testExtensionPageMessageNormalizesSenderPathForBackgroundAndFalseListenerDoesNotConsumeIt() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "page-to-background-profile",
+            isPrivateBrowsing: false
+        )
+        let host = FloorpWebExtensionLazyBackgroundHost()
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: host,
+            profileKey: profileKey
+        )
+        let resources = [
+            "background.js": Data("""
+            chrome.runtime.onMessage.addListener(() => false);
+            chrome.runtime.onMessage.addListener((message, sender) => ({
+              handledBy: "second-listener",
+              senderURL: sender.url,
+              expectedURL: chrome.runtime.getURL("/ui/popup/index.html"),
+              backgroundTransportURL: chrome.runtime.getURL("/")
+            }));
+            """.utf8),
+            "ui/popup/index.html": Data("<html><body>Popup bridge</body></html>".utf8),
+            "assets/runtime.config": Data("transport-resource-ready".utf8)
+        ]
+        let installedPackage = try makeBackgroundInstalledPackage(
+            generation: "page-to-background-generation",
+            resources: resources
+        )
+        let resolver = FloorpWebExtensionPageResourceResolver { request in
+            guard let data = resources[request.path] else {
+                throw FloorpWebExtensionPackageStoreError.resourceUnavailable(request.path)
+            }
+            return data
+        }
+        try runtime.registerPackageBackground(
+            package: installedPackage,
+            packageProfileKey: .init(
+                profileIdentifier: profileKey.profileIdentifier,
+                isPrivateBrowsing: profileKey.isPrivateBrowsing
+            ),
+            resolver: resolver
+        )
+        let pagePackage = try FloorpWebExtensionPagePackageGeneration(
+            installedPackage: installedPackage
+        )
+        let page = try FloorpWebExtensionPageViewController(
+            surface: .actionPopup,
+            package: pagePackage,
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: resolver,
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        page.loadViewIfNeeded()
+        try await waitForLoad(page.webView)
+
+        let result = try await page.webView.callAsyncJavaScript(
+            """
+            const resourceURL = chrome.runtime.getURL("/assets/runtime.config");
+            const resourceText = await new Promise((resolve, reject) => {
+              const request = new XMLHttpRequest();
+              request.open("GET", resourceURL, true);
+              request.onload = () => resolve(request.responseText);
+              request.onerror = () => reject(new Error("Package XHR failed"));
+              request.send();
+            });
+            return {
+              reply: await browser.runtime.sendMessage({type: "popup-data"}),
+              resourceURL,
+              resourceText
+            };
+            """,
+            contentWorld: .page
+        ) as? [String: Any]
+        let reply = result?["reply"] as? [String: Any]
+        let pageTransportHost = try XCTUnwrap(page.webView.url?.host)
+        let backgroundTransportURL = try XCTUnwrap(reply?["backgroundTransportURL"] as? String)
+        let expectedSenderURL = try XCTUnwrap(
+            URL(string: backgroundTransportURL)?.appendingPathComponent("ui/popup/index.html")
+        )
+
+        XCTAssertEqual(reply?["handledBy"] as? String, "second-listener")
+        XCTAssertEqual(reply?["senderURL"] as? String, expectedSenderURL.absoluteString)
+        XCTAssertEqual(reply?["expectedURL"] as? String, expectedSenderURL.absoluteString)
+        XCTAssertEqual(result?["resourceText"] as? String, "transport-resource-ready")
+        XCTAssertEqual(
+            result?["resourceURL"] as? String,
+            "floorp-extension://\(pageTransportHost)/assets/runtime.config"
+        )
+        XCTAssertTrue(pageTransportHost.hasPrefix("page-"))
+        XCTAssertTrue(URL(string: backgroundTransportURL)?.host?.hasPrefix("background-") == true)
+        XCTAssertNotEqual(URL(string: backgroundTransportURL)?.host, pageTransportHost)
     }
 
     func testRuntimeTearDownInvalidatesBackgroundRegistrations() async throws {
@@ -979,6 +1259,42 @@ private final class BootstrapSurfaceDispatcher: FloorpWebExtensionNativeAPIDispa
 }
 
 @MainActor
+private final class SafeTabIdentifierDispatcher: FloorpWebExtensionNativeAPIDispatching {
+    let tabID: Int
+    private(set) var receivedTabIDs = [Int]()
+
+    init(tabID: Int) {
+        self.tabID = tabID
+    }
+
+    func dispatch(
+        operation: String,
+        payload: FloorpWebExtensionMessagePayload,
+        sender: any FloorpWebExtensionMessageSender
+    ) async throws -> FloorpWebExtensionMessagePayload? {
+        _ = sender
+        let tab = """
+        {"id":\(tabID),"active":true,"isPrivate":false,"url":"https://allowed.example/bridge","title":"Safe"}
+        """
+        switch operation {
+        case "tabs.query":
+            return try .init(jsonData: Data("[\(tab)]".utf8))
+        case "tabs.get", "tabs.sendMessage":
+            let object = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: payload.jsonData) as? [String: Any]
+            )
+            receivedTabIDs.append(try XCTUnwrap(object["tabId"] as? Int))
+            if operation == "tabs.get" {
+                return try .init(jsonData: Data(tab.utf8))
+            }
+            return try .init(jsonData: Data(#"{"reply":"ok"}"#.utf8))
+        default:
+            throw FloorpWebExtensionMessageError.unsupportedOperation
+        }
+    }
+}
+
+@MainActor
 private final class AsyncReplyGate: FloorpWebExtensionBackgroundEventHandling {
     private var startedContinuation: CheckedContinuation<Void, Never>?
     private var releaseContinuation: CheckedContinuation<Void, Never>?
@@ -1178,6 +1494,14 @@ private struct ScriptArrayBackgroundReply: Codable, Equatable {
     let order: [String]
     let alarmName: String?
     let scheduledTime: Double?
+}
+
+private struct StartupBackgroundReply: Codable, Equatable {
+    let startupValue: String?
+}
+
+private struct StartupSelfMessageReply: Codable, Equatable {
+    let type: String
 }
 
 private struct EventRuntimePing: Codable, Equatable {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPageHostTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPageHostTests.swift
@@ -129,6 +129,11 @@ final class FloorpWebExtensionPageHostTests: XCTestCase {
         let html = try XCTUnwrap(String(data: entry.data, encoding: .utf8))
         XCTAssertTrue(html.contains("type=\"module\""))
         XCTAssertTrue(html.contains("floorp-extension://\(originHost)/background/main.js"))
+        let activityPosition = try XCTUnwrap(html.range(of: "__floorp_background_test.activity.js"))
+        let mainPosition = try XCTUnwrap(html.range(of: "background/main.js"))
+        let readinessPosition = try XCTUnwrap(html.range(of: "__floorp_background_test.ready.js"))
+        XCTAssertLessThan(activityPosition.lowerBound, mainPosition.lowerBound)
+        XCTAssertLessThan(mainPosition.lowerBound, readinessPosition.lowerBound)
         XCTAssertFalse(html.contains("<script>"))
         XCTAssertEqual(
             entry.response.value(forHTTPHeaderField: "Content-Security-Policy"),
@@ -142,6 +147,28 @@ final class FloorpWebExtensionPageHostTests: XCTestCase {
             try handler.response(for: URLRequest(url: scriptURL)).data,
             resources["background/main.js"]
         )
+        let activityURL = try XCTUnwrap(URL(
+            string: "floorp-extension://\(originHost)/__floorp_background_test.activity.js"
+        ))
+        let activityScript = try XCTUnwrap(String(
+            data: handler.response(for: URLRequest(url: activityURL)).data,
+            encoding: .utf8
+        ))
+        XCTAssertTrue(activityScript.contains("XMLHttpRequest.prototype.send"))
+        XCTAssertTrue(activityScript.contains("XMLHttpRequest.prototype.open"))
+        XCTAssertTrue(activityScript.contains("protocol === \"floorp-extension:\""))
+        XCTAssertTrue(activityScript.contains("if (!packageRequests.has(this))"))
+        XCTAssertTrue(activityScript.contains("if (!isPackageURL(requestURL))"))
+        XCTAssertTrue(activityScript.contains("activity.resourceFinished()"))
+
+        let readinessURL = try XCTUnwrap(URL(
+            string: "floorp-extension://\(originHost)/__floorp_background_test.ready.js"
+        ))
+        let readinessScript = try XCTUnwrap(String(
+            data: handler.response(for: URLRequest(url: readinessURL)).data,
+            encoding: .utf8
+        ))
+        XCTAssertTrue(readinessScript.contains("scriptsFinished()"))
         for rejectedValue in [
             "floorp-extension://another-origin/background/main.js",
             "floorp-extension://\(originHost)/background/missing.js",

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionTabsTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionTabsTests.swift
@@ -118,6 +118,47 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
         XCTAssertEqual(deliveredSender.extensionID, extensionID)
         XCTAssertEqual(deliveredSender.tabID, sourceSender.tabID)
         XCTAssertEqual(deliveredSender.documentGeneration, sourceSender.documentGeneration)
+
+        let targetDocumentID = FloorpWebExtensionDocumentIdentity.mainFrameID(
+            tabID: 3,
+            documentGeneration: 30
+        )
+        let targetedReply = try await service.sendMessage(
+            message,
+            to: 3,
+            for: extensionID,
+            sender: sourceSender,
+            frameID: 0,
+            documentID: targetDocumentID
+        )
+        XCTAssertEqual(targetedReply, .object(["ok": .bool(true)]))
+
+        let unsupportedSubframeID = FloorpWebExtensionDocumentIdentity.unsupportedSubframeID(
+            tabID: 3,
+            documentGeneration: 30
+        )
+        let rejectedTargets: [(frameID: Int?, documentID: String?)] = [
+            (1, targetDocumentID),
+            (0, "stale-document"),
+            (nil, unsupportedSubframeID),
+            (-1, nil),
+            (-1, unsupportedSubframeID)
+        ]
+        for (frameID, documentID) in rejectedTargets {
+            do {
+                _ = try await service.sendMessage(
+                    message,
+                    to: 3,
+                    for: extensionID,
+                    sender: sourceSender,
+                    frameID: frameID,
+                    documentID: documentID
+                )
+                XCTFail("Expected an unsupported or stale message target to fail closed")
+            } catch {
+                XCTAssertEqual(error as? FloorpWebExtensionTabsError, .messageDeliveryFailed)
+            }
+        }
     }
 
     func testPrivateTabsRequireExplicitPrivateAccessAndHostInvariantsAreClosed() async throws {
@@ -171,6 +212,37 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
         } catch {
             XCTAssertEqual(error as? FloorpWebExtensionTabsError, .hostTabInvariantViolation)
         }
+
+        let maximumSafeInteger = 9_007_199_254_740_991
+        let maximumSafeIntegerHost = TabsHost(tabs: [
+            tab(id: maximumSafeInteger, url: "https://safe-integer.example/", title: nil, active: true)
+        ])
+        let maximumSafeIntegerService = try FloorpWebExtensionTabsService(
+            profileIdentifier: "normal",
+            isPrivateBrowsing: false,
+            host: maximumSafeIntegerHost,
+            permissionBroker: broker
+        )
+        let maximumSafeIntegerTab = try await maximumSafeIntegerService.get(maximumSafeInteger, for: extensionID)
+        XCTAssertEqual(maximumSafeIntegerTab.id, maximumSafeInteger)
+
+        for invalidID in [0, maximumSafeInteger + 1] {
+            let invalidIntegerHost = TabsHost(tabs: [
+                tab(id: invalidID, url: "https://invalid-integer.example/", title: nil, active: true)
+            ])
+            let invalidIntegerService = try FloorpWebExtensionTabsService(
+                profileIdentifier: "normal",
+                isPrivateBrowsing: false,
+                host: invalidIntegerHost,
+                permissionBroker: broker
+            )
+            do {
+                _ = try await invalidIntegerService.query(.active, for: extensionID)
+                XCTFail("Expected an invalid JavaScript tab ID to fail closed")
+            } catch {
+                XCTAssertEqual(error as? FloorpWebExtensionTabsError, .hostTabInvariantViolation)
+            }
+        }
     }
 
     @MainActor
@@ -214,6 +286,10 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
             profile: profile,
             windowUUID: manager.windowUUID
         )
+        // This UUID previously produced 3_437_226_930_572_663_821, which a
+        // JavaScript Number rounded before tabs.get/tabs.sendMessage returned
+        // it to native code.
+        originalTab.tabUUID = "28241FDC-A11F-48F2-94B3-2F2B9666957E"
         let originalWebView = MockTabWebView(
             frame: .zero,
             configuration: .init(),
@@ -239,6 +315,13 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
         let queried = try await service.query(.active, for: extensionID)
         XCTAssertEqual(queried.first?.url?.host, "start.example")
         XCTAssertEqual(queried.first?.title, "Start")
+        let queriedID = try XCTUnwrap(queried.first?.id)
+        XCTAssertEqual(queriedID, 5_484_014_516_345_869)
+        XCTAssertLessThanOrEqual(queriedID, 9_007_199_254_740_991)
+        let javaScriptRoundTrippedID = Int(Double(queriedID))
+        XCTAssertEqual(javaScriptRoundTrippedID, queriedID)
+        let roundTrippedTab = try await service.get(javaScriptRoundTrippedID, for: extensionID)
+        XCTAssertEqual(roundTrippedTab.url?.host, "start.example")
 
         let createdURL = try XCTUnwrap(URL(string: "https://created.example/new"))
         let created: FloorpWebExtensionTab
@@ -263,7 +346,7 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
         do {
             reply = try await service.sendMessage(
                 .object(["type": .string("ping")]),
-                to: created.id,
+                to: javaScriptRoundTrippedID,
                 for: extensionID,
                 sender: sourceSender
             )
@@ -272,6 +355,59 @@ final class FloorpWebExtensionTabsTests: XCTestCase {
         }
         XCTAssertEqual(reply, .object(["reply": .string("ok")]))
         XCTAssertTrue(javaScriptEvaluator.scripts.contains { $0.contains("__floorpWebExtensionDeliverTabsMessage") })
+
+        let pageOriginHost = "page-" + UUID().uuidString.lowercased()
+        let pageTransportURL = try XCTUnwrap(URL(
+            string: "floorp-extension://\(pageOriginHost)/ui/popup/index.html"
+        ))
+        let pageSender = FloorpWebExtensionPageRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: .init(
+                profileIdentifier: profileIdentifier,
+                isPrivateBrowsing: false
+            ),
+            packageGeneration: "popup-generation",
+            originHost: pageOriginHost,
+            surface: .actionPopup,
+            transportURL: pageTransportURL
+        )
+        _ = try await service.sendMessage(
+            .object(["type": .string("popup-to-tab")]),
+            to: created.id,
+            for: extensionID,
+            sender: pageSender
+        )
+        let pageDeliveryScript = try XCTUnwrap(javaScriptEvaluator.scripts.last)
+            .replacingOccurrences(of: "\\/", with: "/")
+        XCTAssertTrue(
+            pageDeliveryScript.contains(
+                "\"url\":\"\(pageTransportURL.absoluteString)\""
+            )
+        )
+
+        let backgroundSender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: .init(
+                profileIdentifier: profileIdentifier,
+                isPrivateBrowsing: false
+            ),
+            packageGeneration: "background-generation",
+            originHost: "background-" + UUID().uuidString.lowercased()
+        )
+        _ = try await service.sendMessage(
+            .object(["type": .string("background-to-tab")]),
+            to: created.id,
+            for: extensionID,
+            sender: backgroundSender
+        )
+        let backgroundTransportURL = "floorp-extension://\(backgroundSender.originHost)/"
+        let backgroundDeliveryScript = try XCTUnwrap(javaScriptEvaluator.scripts.last)
+            .replacingOccurrences(of: "\\/", with: "/")
+        XCTAssertTrue(
+            backgroundDeliveryScript.contains(
+                "\"url\":\"\(backgroundTransportURL)\""
+            )
+        )
 
         let requestedUpdateURL = try XCTUnwrap(URL(string: "https://updated.example/next"))
         let updateStarted: FloorpWebExtensionTab


### PR DESCRIPTION
## :scroll: Tickets

- Jira: N/A — user-reported regression
- GitHub issue: N/A

## :bulb: Description

Fixes the bundled Dark Reader action popup remaining on Loading and the extension failing to modify ordinary web pages.

The failure had four interacting causes:

- WebKit package pages kept different transport origins, while Dark Reader compares popup sender URLs against the background package URL.
- A synchronous `false` from a runtime listener was incorrectly treated as a response instead of allowing later listeners to respond.
- The first content message could reach the lazy background before native storage and package configuration fetches had settled.
- Native tab identifiers exceeded JavaScript's safe integer range, so `tabs.query()` IDs were rounded before `tabs.get()` and `tabs.sendMessage()` returned them to native code.

This change preserves the authenticated package transport origin, normalizes the sender path for the receiving background, waits for startup API/resource activity to become idle, propagates and validates document targeting, and constrains tab identifiers to `1...Number.MAX_SAFE_INTEGER`. Unsupported subframes and stale documents fail closed.

Validation:

- 53 focused WebExtension XCTest cases passed with 0 failures, including a real WebKit JSON round trip through `tabs.query`, `tabs.get`, and `tabs.sendMessage`.
- Strict SwiftLint passed with 0 violations across all 9 changed files.
- `swiftc -parse`, `git diff --check`, and `npm run build` passed.
- iPhone 17 / iOS 26.5 Simulator with Dark Reader 4.9.129: `example.com` was darkened at launch and after reload; the action popup rendered, showed `example.com`, and no longer remained on Loading or fell back to `about:`.

## :movie_camera: Demos

| Before | After |
| - | - |
| Popup remains on Loading or shows `about:` as a protected page | Popup renders Dark Reader controls and identifies `example.com` |
| Page remains unmodified | `example.com` is darkened on launch and after reload |

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked and implemented accessibility (N/A: no product UI changes)
- [x] If adding telemetry, I read the data stewardship requirements and will request a data review (N/A: no telemetry changes)
- [x] If adding or modifying strings, I read the guidelines and will request a string review from l10n (N/A: no string changes)
- [x] If needed, I updated documentation and added comments to complex code
