### PR TITLE
fix: complete Dark Reader popup integration

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -568,9 +568,16 @@ final class BrowserCoordinator: BaseCoordinator,
 
     func showWebExtensionActions() {
         guard FloorpFlags.isWebExtensionFeatureEnabled(.core) else { return }
-        let isPrivateBrowsing = tabManager.selectedTab?.isPrivate ?? false
+        guard let selectedTab = tabManager.selectedTab else {
+            presentWebExtensionActionsUnavailable()
+            return
+        }
+        let isPrivateBrowsing = selectedTab.isPrivate
         let profileIdentifier = profile.localName()
         guard let store = FloorpWebExtensionPackageStoreRegistry.store(
+            for: profileIdentifier,
+            isPrivateBrowsing: isPrivateBrowsing
+        ), let packageManager = FloorpWebExtensionPackageStoreRegistry.manager(
             for: profileIdentifier,
             isPrivateBrowsing: isPrivateBrowsing
         ), let apiHost = FloorpWebExtensionAPIHostRegistry.host(
@@ -584,10 +591,13 @@ final class BrowserCoordinator: BaseCoordinator,
             return
         }
         let resolver = store.makePageResourceResolver()
-        Task { [weak self, store, apiHost, messageRuntime] in
+        Task { [weak self, store, packageManager, apiHost, messageRuntime, selectedTab] in
             let packages = await store.installedPackages()
             var popups = [FloorpWebExtensionActionPopup]()
             for package in packages where package.isEnabled {
+                if isPrivateBrowsing && !package.grants.privateBrowsingEnabled {
+                    continue
+                }
                 let persistedState = await apiHost.actions.state(for: package.extensionID)
                 if let popup = Self.actionPopup(
                     for: package,
@@ -596,11 +606,16 @@ final class BrowserCoordinator: BaseCoordinator,
                     popups.append(popup)
                 }
             }
-            guard let self, !Task.isCancelled else { return }
+            guard let self,
+                  !Task.isCancelled,
+                  self.tabManager.selectedTab === selectedTab,
+                  selectedTab.isPrivate == isPrivateBrowsing else { return }
             self.presentWebExtensionActions(
                 popups,
                 resolver: resolver,
                 messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
                 isPrivateBrowsing: isPrivateBrowsing
             )
         }
@@ -616,6 +631,84 @@ final class BrowserCoordinator: BaseCoordinator,
         let package: FloorpWebExtensionInstalledPackage
         let actionState: FloorpWebExtensionActionState
         let title: String
+    }
+
+    enum FloorpWebExtensionActionSiteAccessChoice: Equatable {
+        case currentSite
+        case allRequestedSites
+        case cancel
+    }
+
+    struct FloorpWebExtensionActionSiteAccessPlan: Equatable {
+        let currentSite: FloorpWebExtensionMatchPattern?
+        let currentHost: String?
+        let previouslySelectedSites: Set<FloorpWebExtensionMatchPattern>
+        let requestedSiteCount: Int
+        let requestsEveryWebsite: Bool
+        let isPrivateBrowsing: Bool
+
+        func access(
+            for choice: FloorpWebExtensionActionSiteAccessChoice
+        ) -> FloorpWebExtensionHostAccess? {
+            switch choice {
+            case .currentSite:
+                guard let currentSite else { return nil }
+                return .selectedSites(previouslySelectedSites.union([currentSite]))
+            case .allRequestedSites:
+                return .allRequestedSites
+            case .cancel:
+                return nil
+            }
+        }
+    }
+
+    /// Builds product-owned consent only when the action's current page is
+    /// declared by the package but is not covered by the profile's grant.
+    static func webExtensionActionSiteAccessPlan(
+        currentURL: URL?,
+        requestedHosts: Set<FloorpWebExtensionMatchPattern>,
+        hostAccess: FloorpWebExtensionHostAccess,
+        isPrivateBrowsing: Bool
+    ) -> FloorpWebExtensionActionSiteAccessPlan? {
+        guard !requestedHosts.isEmpty,
+              let currentURL,
+              requestedHosts.contains(where: { $0.matches(currentURL) }) else {
+            return nil
+        }
+        let previouslySelectedSites: Set<FloorpWebExtensionMatchPattern>
+        switch hostAccess {
+        case .denied:
+            previouslySelectedSites = []
+        case .selectedSites(let sites):
+            guard !sites.contains(where: { $0.matches(currentURL) }) else { return nil }
+            previouslySelectedSites = sites
+        case .allRequestedSites:
+            return nil
+        }
+        let currentSite = currentSitePattern(for: currentURL).flatMap { site in
+            requestedHosts.contains(where: { $0.covers(site) }) ? site : nil
+        }
+        return .init(
+            currentSite: currentSite,
+            currentHost: currentSite == nil ? nil : currentURL.host?.lowercased(),
+            previouslySelectedSites: previouslySelectedSites,
+            requestedSiteCount: requestedHosts.count,
+            requestsEveryWebsite: requestedHosts.contains {
+                $0.original == "<all_urls>" || $0.original == "*://*/*"
+            },
+            isPrivateBrowsing: isPrivateBrowsing
+        )
+    }
+
+    private static func currentSitePattern(
+        for url: URL
+    ) -> FloorpWebExtensionMatchPattern? {
+        guard let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = url.host?.lowercased() else {
+            return nil
+        }
+        return try? FloorpWebExtensionMatchPattern("\(scheme)://\(host)/*")
     }
 
     private static func actionPopup(
@@ -650,6 +743,8 @@ final class BrowserCoordinator: BaseCoordinator,
         _ popups: [FloorpWebExtensionActionPopup],
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
         isPrivateBrowsing: Bool
     ) {
         guard !popups.isEmpty else {
@@ -664,6 +759,8 @@ final class BrowserCoordinator: BaseCoordinator,
                 popup,
                 resolver: resolver,
                 messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
                 isPrivateBrowsing: isPrivateBrowsing
             )
             return
@@ -679,6 +776,8 @@ final class BrowserCoordinator: BaseCoordinator,
                     popup,
                     resolver: resolver,
                     messageRuntime: messageRuntime,
+                    packageManager: packageManager,
+                    selectedTab: selectedTab,
                     isPrivateBrowsing: isPrivateBrowsing
                 )
             })
@@ -692,6 +791,200 @@ final class BrowserCoordinator: BaseCoordinator,
     }
 
     private func presentWebExtensionActionPopup(
+        _ popup: FloorpWebExtensionActionPopup,
+        resolver: FloorpWebExtensionPageResourceResolver,
+        messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
+        isPrivateBrowsing: Bool
+    ) {
+        guard tabManager.selectedTab === selectedTab,
+              selectedTab.isPrivate == isPrivateBrowsing else { return }
+        let consentedURL = selectedTab.url
+        Task { [weak self, weak selectedTab, packageManager] in
+            do {
+                let context = try await packageManager.authorizePermissionMutationWithPackageSnapshot(
+                    for: popup.package.extensionID,
+                    expectedGeneration: popup.package.generation
+                )
+                guard let self,
+                      let selectedTab,
+                      !Task.isCancelled,
+                      self.tabManager.selectedTab === selectedTab,
+                      selectedTab.isPrivate == isPrivateBrowsing,
+                      selectedTab.url == consentedURL else { return }
+                guard !isPrivateBrowsing || context.package.grants.privateBrowsingEnabled else {
+                    self.presentWebExtensionActionsUnavailable()
+                    return
+                }
+                let currentPopup = FloorpWebExtensionActionPopup(
+                    package: context.package,
+                    actionState: popup.actionState,
+                    title: popup.title
+                )
+                let hostAccess = isPrivateBrowsing
+                    ? context.package.grants.privateHostAccess
+                    : context.package.grants.normalHostAccess
+                if let accessPlan = Self.webExtensionActionSiteAccessPlan(
+                    currentURL: consentedURL,
+                    requestedHosts: context.package.grants.requestedHosts,
+                    hostAccess: hostAccess,
+                    isPrivateBrowsing: isPrivateBrowsing
+                ) {
+                    self.presentWebExtensionActionSiteAccess(
+                        accessPlan,
+                        authorization: context.authorization,
+                        consentedURL: consentedURL,
+                        popup: currentPopup,
+                        resolver: resolver,
+                        messageRuntime: messageRuntime,
+                        packageManager: packageManager,
+                        selectedTab: selectedTab,
+                        isPrivateBrowsing: isPrivateBrowsing
+                    )
+                } else {
+                    self.presentWebExtensionActionPage(
+                        currentPopup,
+                        resolver: resolver,
+                        messageRuntime: messageRuntime,
+                        isPrivateBrowsing: isPrivateBrowsing
+                    )
+                }
+            } catch {
+                self?.presentWebExtensionActionsAlert(
+                    title: "Extension action could not open",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func presentWebExtensionActionSiteAccess(
+        _ plan: FloorpWebExtensionActionSiteAccessPlan,
+        authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
+        consentedURL: URL?,
+        popup: FloorpWebExtensionActionPopup,
+        resolver: FloorpWebExtensionPageResourceResolver,
+        messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
+        isPrivateBrowsing: Bool
+    ) {
+        var message = [
+            "This extension cannot read or change the current page until you allow site access.",
+            "The page will reload after access is allowed."
+        ].joined(separator: " ")
+        if plan.requestsEveryWebsite {
+            message += " All requested sites include every HTTP and HTTPS website."
+        } else if plan.requestedSiteCount > 1 {
+            message += " This extension requested access to \(plan.requestedSiteCount) site patterns."
+        }
+        if plan.isPrivateBrowsing {
+            message += " This choice applies only in Private Browsing."
+        }
+        let alert = UIAlertController(
+            title: "Allow site access for \(popup.title)?",
+            message: message,
+            preferredStyle: .actionSheet
+        )
+        alert.view.accessibilityIdentifier = "Floorp.WebExtensions.ActionSiteAccessConsent"
+        if let currentHost = plan.currentHost,
+           let access = plan.access(for: .currentSite) {
+            alert.addAction(UIAlertAction(title: "Allow on \(currentHost)", style: .default) { [weak self] _ in
+                self?.applyWebExtensionActionSiteAccess(
+                    access,
+                    authorization: authorization,
+                    consentedURL: consentedURL,
+                    popup: popup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    packageManager: packageManager,
+                    selectedTab: selectedTab,
+                    isPrivateBrowsing: isPrivateBrowsing
+                )
+            })
+        }
+        if let access = plan.access(for: .allRequestedSites) {
+            alert.addAction(UIAlertAction(title: "Allow on All Requested Sites", style: .default) { [weak self] _ in
+                self?.applyWebExtensionActionSiteAccess(
+                    access,
+                    authorization: authorization,
+                    consentedURL: consentedURL,
+                    popup: popup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    packageManager: packageManager,
+                    selectedTab: selectedTab,
+                    isPrivateBrowsing: isPrivateBrowsing
+                )
+            })
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = browserViewController.view
+            popover.sourceRect = browserViewController.view.bounds
+        }
+        present(alert)
+    }
+
+    private func applyWebExtensionActionSiteAccess(
+        _ access: FloorpWebExtensionHostAccess,
+        authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
+        consentedURL: URL?,
+        popup: FloorpWebExtensionActionPopup,
+        resolver: FloorpWebExtensionPageResourceResolver,
+        messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
+        isPrivateBrowsing: Bool
+    ) {
+        guard tabManager.selectedTab === selectedTab,
+              selectedTab.isPrivate == isPrivateBrowsing,
+              selectedTab.url == consentedURL else { return }
+        Task { [weak self, weak selectedTab, packageManager] in
+            do {
+                let previousGrants = popup.package.grants
+                let replacement = FloorpWebExtensionPermissionSnapshot(
+                    apiPermissions: previousGrants.apiPermissions,
+                    requestedHosts: previousGrants.requestedHosts,
+                    normalHostAccess: isPrivateBrowsing ? previousGrants.normalHostAccess : access,
+                    privateHostAccess: isPrivateBrowsing ? access : previousGrants.privateHostAccess,
+                    privateBrowsingEnabled: previousGrants.privateBrowsingEnabled
+                )
+                try await packageManager.updateGrants(
+                    replacement,
+                    authorization: authorization
+                ) { [weak self, weak selectedTab] in
+                    guard let self, let selectedTab else { return false }
+                    return self.tabManager.selectedTab === selectedTab &&
+                        selectedTab.isPrivate == isPrivateBrowsing &&
+                        selectedTab.url == consentedURL
+                }
+                guard let self,
+                      let selectedTab,
+                      !Task.isCancelled,
+                      self.tabManager.selectedTab === selectedTab,
+                      selectedTab.isPrivate == isPrivateBrowsing,
+                      selectedTab.url == consentedURL else { return }
+                // User-script policy is fixed before a document load. Reload
+                // so this already-open page receives the newly authorized policy.
+                selectedTab.reload()
+                self.presentWebExtensionActionPage(
+                    popup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    isPrivateBrowsing: isPrivateBrowsing
+                )
+            } catch {
+                self?.presentWebExtensionActionsAlert(
+                    title: "Site access could not be changed",
+                    message: error.localizedDescription
+                )
+            }
+        }
+    }
+
+    private func presentWebExtensionActionPage(
         _ popup: FloorpWebExtensionActionPopup,
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -802,60 +802,79 @@ final class BrowserCoordinator: BaseCoordinator,
               selectedTab.isPrivate == isPrivateBrowsing else { return }
         let consentedURL = selectedTab.url
         Task { [weak self, weak selectedTab, packageManager] in
-            do {
-                let context = try await packageManager.authorizePermissionMutationWithPackageSnapshot(
-                    for: popup.package.extensionID,
-                    expectedGeneration: popup.package.generation
-                )
-                guard let self,
-                      let selectedTab,
-                      !Task.isCancelled,
-                      self.tabManager.selectedTab === selectedTab,
-                      selectedTab.isPrivate == isPrivateBrowsing,
-                      selectedTab.url == consentedURL else { return }
-                guard !isPrivateBrowsing || context.package.grants.privateBrowsingEnabled else {
-                    self.presentWebExtensionActionsUnavailable()
-                    return
-                }
-                let currentPopup = FloorpWebExtensionActionPopup(
-                    package: context.package,
-                    actionState: popup.actionState,
-                    title: popup.title
-                )
-                let hostAccess = isPrivateBrowsing
-                    ? context.package.grants.privateHostAccess
-                    : context.package.grants.normalHostAccess
-                if let accessPlan = Self.webExtensionActionSiteAccessPlan(
-                    currentURL: consentedURL,
-                    requestedHosts: context.package.grants.requestedHosts,
-                    hostAccess: hostAccess,
+            guard let self, let selectedTab else { return }
+            await self.prepareWebExtensionActionPopup(
+                popup,
+                consentedURL: consentedURL,
+                resolver: resolver,
+                messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
+                isPrivateBrowsing: isPrivateBrowsing
+            )
+        }
+    }
+
+    private func prepareWebExtensionActionPopup(
+        _ popup: FloorpWebExtensionActionPopup,
+        consentedURL: URL?,
+        resolver: FloorpWebExtensionPageResourceResolver,
+        messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
+        isPrivateBrowsing: Bool
+    ) async {
+        do {
+            let context = try await packageManager.authorizePermissionMutationWithPackageSnapshot(
+                for: popup.package.extensionID,
+                expectedGeneration: popup.package.generation
+            )
+            guard !Task.isCancelled,
+                  tabManager.selectedTab === selectedTab,
+                  selectedTab.isPrivate == isPrivateBrowsing,
+                  selectedTab.url == consentedURL else { return }
+            guard !isPrivateBrowsing || context.package.grants.privateBrowsingEnabled else {
+                presentWebExtensionActionsUnavailable()
+                return
+            }
+            let currentPopup = FloorpWebExtensionActionPopup(
+                package: context.package,
+                actionState: popup.actionState,
+                title: popup.title
+            )
+            let hostAccess = isPrivateBrowsing
+                ? context.package.grants.privateHostAccess
+                : context.package.grants.normalHostAccess
+            if let accessPlan = Self.webExtensionActionSiteAccessPlan(
+                currentURL: consentedURL,
+                requestedHosts: context.package.grants.requestedHosts,
+                hostAccess: hostAccess,
+                isPrivateBrowsing: isPrivateBrowsing
+            ) {
+                presentWebExtensionActionSiteAccess(
+                    accessPlan,
+                    authorization: context.authorization,
+                    consentedURL: consentedURL,
+                    popup: currentPopup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    packageManager: packageManager,
+                    selectedTab: selectedTab,
                     isPrivateBrowsing: isPrivateBrowsing
-                ) {
-                    self.presentWebExtensionActionSiteAccess(
-                        accessPlan,
-                        authorization: context.authorization,
-                        consentedURL: consentedURL,
-                        popup: currentPopup,
-                        resolver: resolver,
-                        messageRuntime: messageRuntime,
-                        packageManager: packageManager,
-                        selectedTab: selectedTab,
-                        isPrivateBrowsing: isPrivateBrowsing
-                    )
-                } else {
-                    self.presentWebExtensionActionPage(
-                        currentPopup,
-                        resolver: resolver,
-                        messageRuntime: messageRuntime,
-                        isPrivateBrowsing: isPrivateBrowsing
-                    )
-                }
-            } catch {
-                self?.presentWebExtensionActionsAlert(
-                    title: "Extension action could not open",
-                    message: error.localizedDescription
+                )
+            } else {
+                presentWebExtensionActionPage(
+                    currentPopup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    isPrivateBrowsing: isPrivateBrowsing
                 )
             }
+        } catch {
+            presentWebExtensionActionsAlert(
+                title: "Extension action could not open",
+                message: error.localizedDescription
+            )
         }
     }
 
@@ -942,45 +961,68 @@ final class BrowserCoordinator: BaseCoordinator,
               selectedTab.isPrivate == isPrivateBrowsing,
               selectedTab.url == consentedURL else { return }
         Task { [weak self, weak selectedTab, packageManager] in
-            do {
-                let previousGrants = popup.package.grants
-                let replacement = FloorpWebExtensionPermissionSnapshot(
-                    apiPermissions: previousGrants.apiPermissions,
-                    requestedHosts: previousGrants.requestedHosts,
-                    normalHostAccess: isPrivateBrowsing ? previousGrants.normalHostAccess : access,
-                    privateHostAccess: isPrivateBrowsing ? access : previousGrants.privateHostAccess,
-                    privateBrowsingEnabled: previousGrants.privateBrowsingEnabled
-                )
-                try await packageManager.updateGrants(
-                    replacement,
-                    authorization: authorization
-                ) { [weak self, weak selectedTab] in
-                    guard let self, let selectedTab else { return false }
-                    return self.tabManager.selectedTab === selectedTab &&
-                        selectedTab.isPrivate == isPrivateBrowsing &&
-                        selectedTab.url == consentedURL
-                }
-                guard let self,
-                      let selectedTab,
-                      !Task.isCancelled,
-                      self.tabManager.selectedTab === selectedTab,
-                      selectedTab.isPrivate == isPrivateBrowsing,
-                      selectedTab.url == consentedURL else { return }
-                // User-script policy is fixed before a document load. Reload
-                // so this already-open page receives the newly authorized policy.
-                selectedTab.reload()
-                self.presentWebExtensionActionPage(
-                    popup,
-                    resolver: resolver,
-                    messageRuntime: messageRuntime,
-                    isPrivateBrowsing: isPrivateBrowsing
-                )
-            } catch {
-                self?.presentWebExtensionActionsAlert(
-                    title: "Site access could not be changed",
-                    message: error.localizedDescription
-                )
+            guard let self, let selectedTab else { return }
+            await self.commitWebExtensionActionSiteAccess(
+                access,
+                authorization: authorization,
+                consentedURL: consentedURL,
+                popup: popup,
+                resolver: resolver,
+                messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
+                isPrivateBrowsing: isPrivateBrowsing
+            )
+        }
+    }
+
+    private func commitWebExtensionActionSiteAccess(
+        _ access: FloorpWebExtensionHostAccess,
+        authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
+        consentedURL: URL?,
+        popup: FloorpWebExtensionActionPopup,
+        resolver: FloorpWebExtensionPageResourceResolver,
+        messageRuntime: FloorpWebExtensionMessageRuntime,
+        packageManager: FloorpWebExtensionLivePackageManager,
+        selectedTab: Tab,
+        isPrivateBrowsing: Bool
+    ) async {
+        do {
+            let previousGrants = popup.package.grants
+            let replacement = FloorpWebExtensionPermissionSnapshot(
+                apiPermissions: previousGrants.apiPermissions,
+                requestedHosts: previousGrants.requestedHosts,
+                normalHostAccess: isPrivateBrowsing ? previousGrants.normalHostAccess : access,
+                privateHostAccess: isPrivateBrowsing ? access : previousGrants.privateHostAccess,
+                privateBrowsingEnabled: previousGrants.privateBrowsingEnabled
+            )
+            try await packageManager.updateGrants(
+                replacement,
+                authorization: authorization
+            ) { [weak self, weak selectedTab] in
+                guard let self, let selectedTab else { return false }
+                return self.tabManager.selectedTab === selectedTab &&
+                    selectedTab.isPrivate == isPrivateBrowsing &&
+                    selectedTab.url == consentedURL
             }
+            guard !Task.isCancelled,
+                  tabManager.selectedTab === selectedTab,
+                  selectedTab.isPrivate == isPrivateBrowsing,
+                  selectedTab.url == consentedURL else { return }
+            // User-script policy is fixed before a document load. Reload
+            // so this already-open page receives the newly authorized policy.
+            selectedTab.reload()
+            presentWebExtensionActionPage(
+                popup,
+                resolver: resolver,
+                messageRuntime: messageRuntime,
+                isPrivateBrowsing: isPrivateBrowsing
+            )
+        } catch {
+            presentWebExtensionActionsAlert(
+                title: "Site access could not be changed",
+                message: error.localizedDescription
+            )
         }
     }
 

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
@@ -415,6 +415,105 @@ final class FloorpWebExtensionLazyBackgroundHost {
     }
 }
 
+@MainActor
+final class FloorpWebExtensionPageMessageReceiver {
+    let identity: FloorpWebExtensionPageBridgeIdentity
+    let controllerIdentifier: ObjectIdentifier
+    private(set) weak var webView: WKWebView?
+    private var isInvalidated = false
+
+    init(identity: FloorpWebExtensionPageBridgeIdentity, webView: WKWebView) {
+        self.identity = identity
+        self.webView = webView
+        controllerIdentifier = ObjectIdentifier(webView.configuration.userContentController)
+    }
+
+    var isAvailable: Bool {
+        guard !isInvalidated, let url = webView?.url else { return false }
+        return identity.authorizesDocument(url, isMainFrame: true)
+    }
+
+    func invalidate() {
+        isInvalidated = true
+        webView = nil
+    }
+
+    func deliver(
+        _ message: FloorpWebExtensionMessagePayload,
+        sender: FloorpWebExtensionBackgroundRuntimeMessageSender
+    ) async throws -> FloorpWebExtensionMessagePayload? {
+        guard sender.extensionID == identity.extensionID,
+              sender.profileKey == identity.profileKey,
+              sender.packageGeneration == identity.packageGeneration,
+              isAvailable,
+              let webView else {
+            throw FloorpWebExtensionMessageError.authenticationFailed
+        }
+        let expectedWebView = webView
+        let messageJSON = try Self.jsonString(from: message.jsonData)
+        let senderJSON = try Self.senderJSON(sender, receiver: identity)
+        let serialized = try await webView.callAsyncJavaScript(
+            """
+            const deliver = globalThis.__floorpWebExtensionDeliverPageRuntimeMessage;
+            if (typeof deliver !== "function") throw new Error("Extension page bridge unavailable");
+            return await deliver(JSON.parse(messageJSON), JSON.parse(senderJSON));
+            """,
+            arguments: ["messageJSON": messageJSON, "senderJSON": senderJSON],
+            in: nil,
+            contentWorld: .page
+        ) as? String
+        guard !isInvalidated,
+              self.webView === expectedWebView,
+              isAvailable else {
+            throw FloorpWebExtensionMessageError.backgroundReplaced
+        }
+        guard let serialized,
+              let envelopeData = serialized.data(using: .utf8),
+              let envelope = try JSONSerialization.jsonObject(with: envelopeData) as? [String: Any],
+              let hasResponse = envelope["hasResponse"] as? Bool else {
+            throw FloorpWebExtensionMessageError.handlerFailed
+        }
+        guard hasResponse else { return nil }
+        let value = envelope["value"] ?? NSNull()
+        guard JSONSerialization.isValidJSONObject(["value": value]) else {
+            throw FloorpWebExtensionMessageError.handlerFailed
+        }
+        let data = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed])
+        return try FloorpWebExtensionMessagePayload(jsonData: data)
+    }
+
+    private static func jsonString(from data: Data) throws -> String {
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw FloorpWebExtensionMessageError.malformedEnvelope
+        }
+        return value
+    }
+
+    private static func senderJSON(
+        _ sender: FloorpWebExtensionBackgroundRuntimeMessageSender,
+        receiver: FloorpWebExtensionPageBridgeIdentity
+    ) throws -> String {
+        var components = URLComponents()
+        components.scheme = FloorpWebExtensionPageNavigationPolicy.resourceScheme
+        components.host = receiver.originHost
+        components.path = "/"
+        guard let receiverURL = components.url else {
+            throw FloorpWebExtensionMessageError.malformedEnvelope
+        }
+        let object: [String: Any] = [
+            "id": sender.extensionID.rawValue,
+            "isPrivate": sender.isPrivate,
+            "url": receiverURL.absoluteString
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        guard data.count <= FloorpWebExtensionMessagePayload.maximumByteCount,
+              let serialized = String(data: data, encoding: .utf8) else {
+            throw FloorpWebExtensionMessageError.payloadTooLarge
+        }
+        return serialized
+    }
+}
+
 /// Owns authenticated, per-extension WebKit bridges for one browser profile.
 /// Package/profile composition must reinstall a bridge with the new trusted tab
 /// context before every navigation.
@@ -439,6 +538,7 @@ final class FloorpWebExtensionMessageRuntime {
     private final class ControllerEntry {
         weak var controller: WKUserContentController?
         var sessions = [BridgeSessionKey: FloorpWebExtensionMessageBridgeSession]()
+        var pageIdentities = [FloorpWebExtensionID: FloorpWebExtensionPageBridgeIdentity]()
 
         init(controller: WKUserContentController) {
             self.controller = controller
@@ -456,6 +556,19 @@ final class FloorpWebExtensionMessageRuntime {
         let kind: BridgeSessionKind
     }
 
+    private struct PageReceiverKey: Hashable {
+        let controllerIdentifier: ObjectIdentifier
+        let extensionID: FloorpWebExtensionID
+    }
+
+    private final class WeakPageReceiver {
+        weak var value: FloorpWebExtensionPageMessageReceiver?
+
+        init(_ value: FloorpWebExtensionPageMessageReceiver) {
+            self.value = value
+        }
+    }
+
     let backgroundHost: FloorpWebExtensionLazyBackgroundHost
     let profileKey: FloorpWebExtensionCoordinatorProfileKey?
     private let nativeAPIDispatcher: (any FloorpWebExtensionNativeAPIDispatching)?
@@ -463,8 +576,9 @@ final class FloorpWebExtensionMessageRuntime {
         @escaping @MainActor @Sendable () async -> Void
     ) -> Void
     private var controllers = [ObjectIdentifier: ControllerEntry]()
+    private var pageReceivers = [PageReceiverKey: WeakPageReceiver]()
     private var activePageGenerations = [FloorpWebExtensionID: String]()
-    private var activeBackgroundGenerations = [FloorpWebExtensionID: String]()
+    private var activeBackgroundBridges = [FloorpWebExtensionID: FloorpWebExtensionBackgroundBridgeIdentity]()
 
     init(
         backgroundHost: FloorpWebExtensionLazyBackgroundHost,
@@ -519,10 +633,10 @@ final class FloorpWebExtensionMessageRuntime {
         let expectedPackageGeneration = nativeHost?.activePackageGeneration(for: extensionID)
         let session = FloorpWebExtensionMessageBridgeSession(
             extensionID: extensionID,
-            backgroundHost: backgroundHost,
             nativeAPIDispatcher: nativeAPIDispatcher,
             bootstrap: nativeHost?.javaScriptBootstrap(for: extensionID),
             contentWorld: .world(name: Self.isolatedContentWorldName(for: extensionID)),
+            supportsSameSurfacePageNavigation: false,
             owner: "floorp.webextension.bridge.tab.\(extensionID.rawValue)",
             authorizeDocument: { url, isMainFrame in
                 authorizeDocument(url, isMainFrame, tab)
@@ -538,6 +652,12 @@ final class FloorpWebExtensionMessageRuntime {
                     }
                 }
                 return authorizeFrameScript(scriptID, revisionToken, url, isMainFrame, tab)
+            },
+            dispatchRuntimeMessage: { [weak self] message, sender in
+                guard let self else {
+                    throw FloorpWebExtensionMessageError.backgroundUnavailable
+                }
+                return try await self.dispatchRuntimeMessage(message, sender: sender)
             },
             scheduleRequest: scheduleBridgeRequest,
             makeSender: { url, isMainFrame in
@@ -605,10 +725,14 @@ final class FloorpWebExtensionMessageRuntime {
         controllers[identifier] = entry
         let key = BridgeSessionKey(extensionID: page.extensionID, kind: .page)
         entry.sessions.removeValue(forKey: key)?.detach()
+        invalidatePageReceiver(
+            for: page.extensionID,
+            controllerIdentifier: identifier
+        )
+        entry.pageIdentities[page.extensionID] = page
 
         let session = FloorpWebExtensionMessageBridgeSession(
             extensionID: page.extensionID,
-            backgroundHost: backgroundHost,
             nativeAPIDispatcher: nativeAPIDispatcher,
             bootstrap: nativeHost?.javaScriptBootstrap(for: page.extensionID),
             // Popup/options resources run in WebKit's page world.  Their
@@ -619,10 +743,17 @@ final class FloorpWebExtensionMessageRuntime {
             // package JavaScript can reach its APIs, while web content cannot
             // reuse the bridge after a navigation.
             contentWorld: .page,
+            supportsSameSurfacePageNavigation: true,
             owner: "floorp.webextension.bridge.page.\(page.extensionID.rawValue).\(page.originHost)",
             authorizeDocument: { [weak self] url, isMainFrame in
                 self?.activePageGenerations[page.extensionID] == page.packageGeneration &&
                     page.authorizesDocument(url, isMainFrame: isMainFrame)
+            },
+            dispatchRuntimeMessage: { [weak self] message, sender in
+                guard let self else {
+                    throw FloorpWebExtensionMessageError.backgroundUnavailable
+                }
+                return try await self.dispatchRuntimeMessage(message, sender: sender)
             },
             scheduleRequest: scheduleBridgeRequest,
             makeSender: { url, _ in
@@ -657,11 +788,11 @@ final class FloorpWebExtensionMessageRuntime {
             return false
         }
 
-        if let activeGeneration = activeBackgroundGenerations[background.extensionID],
-           activeGeneration != background.packageGeneration {
+        if let activeBackground = activeBackgroundBridges[background.extensionID],
+           activeBackground != background {
             invalidateBackgroundBridges(for: background.extensionID)
         }
-        activeBackgroundGenerations[background.extensionID] = background.packageGeneration
+        activeBackgroundBridges[background.extensionID] = background
 
         removeReleasedControllers()
         let identifier = ObjectIdentifier(controller)
@@ -672,14 +803,20 @@ final class FloorpWebExtensionMessageRuntime {
 
         let session = FloorpWebExtensionMessageBridgeSession(
             extensionID: background.extensionID,
-            backgroundHost: backgroundHost,
             nativeAPIDispatcher: nativeAPIDispatcher,
             bootstrap: nativeHost?.javaScriptBootstrap(for: background.extensionID),
             contentWorld: .page,
+            supportsSameSurfacePageNavigation: false,
             owner: "floorp.webextension.bridge.background.\(background.extensionID.rawValue).\(background.originHost)",
             authorizeDocument: { [weak self] url, isMainFrame in
-                self?.activeBackgroundGenerations[background.extensionID] == background.packageGeneration &&
+                self?.activeBackgroundBridges[background.extensionID] == background &&
                     background.authorizesDocument(url, isMainFrame: isMainFrame)
+            },
+            dispatchRuntimeMessage: { [weak self] message, sender in
+                guard let self else {
+                    throw FloorpWebExtensionMessageError.backgroundUnavailable
+                }
+                return try await self.dispatchRuntimeMessage(message, sender: sender)
             },
             scheduleRequest: scheduleBridgeRequest,
             makeSender: { _, _ in
@@ -714,13 +851,18 @@ final class FloorpWebExtensionMessageRuntime {
         for extensionID: FloorpWebExtensionID,
         retainingGeneration: String? = nil
     ) {
-        for entry in controllers.values {
+        for (controllerIdentifier, entry) in controllers {
             let pageKeys = entry.sessions.keys.filter {
                 $0.extensionID == extensionID && $0.kind == .page
             }
             for key in pageKeys {
                 entry.sessions.removeValue(forKey: key)?.detach()
             }
+            entry.pageIdentities.removeValue(forKey: extensionID)
+            invalidatePageReceiver(
+                for: extensionID,
+                controllerIdentifier: controllerIdentifier
+            )
         }
         if activePageGenerations[extensionID] != retainingGeneration {
             activePageGenerations.removeValue(forKey: extensionID)
@@ -743,8 +885,8 @@ final class FloorpWebExtensionMessageRuntime {
                 entry.sessions.removeValue(forKey: key)?.detach()
             }
         }
-        if activeBackgroundGenerations[extensionID] != retainingGeneration {
-            activeBackgroundGenerations.removeValue(forKey: extensionID)
+        if activeBackgroundBridges[extensionID]?.packageGeneration != retainingGeneration {
+            activeBackgroundBridges.removeValue(forKey: extensionID)
         }
         removeReleasedControllers()
     }
@@ -753,7 +895,7 @@ final class FloorpWebExtensionMessageRuntime {
         _ background: FloorpWebExtensionBackgroundBridgeIdentity
     ) -> Bool {
         profileKey == background.profileKey &&
-            activeBackgroundGenerations[background.extensionID] == background.packageGeneration
+            activeBackgroundBridges[background.extensionID] == background
     }
 
     func dispatchAlarmEvent(_ event: FloorpWebExtensionAlarmEvent) async throws {
@@ -764,14 +906,19 @@ final class FloorpWebExtensionMessageRuntime {
     }
 
     func removeExtension(_ extensionID: FloorpWebExtensionID) {
-        for entry in controllers.values {
+        for (controllerIdentifier, entry) in controllers {
             let keys = entry.sessions.keys.filter { $0.extensionID == extensionID }
             keys.forEach { key in
                 entry.sessions.removeValue(forKey: key)?.detach()
             }
+            entry.pageIdentities.removeValue(forKey: extensionID)
+            invalidatePageReceiver(
+                for: extensionID,
+                controllerIdentifier: controllerIdentifier
+            )
         }
         activePageGenerations.removeValue(forKey: extensionID)
-        activeBackgroundGenerations.removeValue(forKey: extensionID)
+        activeBackgroundBridges.removeValue(forKey: extensionID)
         backgroundHost.unregister(extensionID: extensionID)
         removeReleasedControllers()
     }
@@ -780,9 +927,11 @@ final class FloorpWebExtensionMessageRuntime {
         for entry in controllers.values {
             entry.sessions.values.forEach { $0.detach() }
         }
+        pageReceivers.values.forEach { $0.value?.invalidate() }
         controllers.removeAll()
+        pageReceivers.removeAll()
         activePageGenerations.removeAll()
-        activeBackgroundGenerations.removeAll()
+        activeBackgroundBridges.removeAll()
         backgroundHost.tearDown()
     }
 
@@ -792,14 +941,128 @@ final class FloorpWebExtensionMessageRuntime {
     /// will install a new authenticated bridge on the next event.
     func releaseBackgroundResources() {
         backgroundHost.releaseActiveHandlers()
-        let extensionIDs = Set(activeBackgroundGenerations.keys)
+        let extensionIDs = Set(activeBackgroundBridges.keys)
         for extensionID in extensionIDs {
             invalidateBackgroundBridges(for: extensionID)
         }
     }
 
     private func removeReleasedControllers() {
+        pageReceivers = pageReceivers.filter { key, weakReceiver in
+            guard let receiver = weakReceiver.value,
+                  let entry = controllers[key.controllerIdentifier],
+                  entry.controller != nil,
+                  entry.pageIdentities[key.extensionID] == receiver.identity else {
+                weakReceiver.value?.invalidate()
+                return false
+            }
+            return true
+        }
         controllers = controllers.filter { _, entry in entry.controller != nil }
+    }
+
+    func registerPageMessageReceiver(
+        _ page: FloorpWebExtensionPageBridgeIdentity,
+        webView: WKWebView
+    ) -> FloorpWebExtensionPageMessageReceiver? {
+        removeReleasedControllers()
+        guard profileKey == page.profileKey,
+              activePageGenerations[page.extensionID] == page.packageGeneration else {
+            return nil
+        }
+        let controllerIdentifier = ObjectIdentifier(webView.configuration.userContentController)
+        guard controllers[controllerIdentifier]?.pageIdentities[page.extensionID] == page else {
+            return nil
+        }
+        let key = PageReceiverKey(
+            controllerIdentifier: controllerIdentifier,
+            extensionID: page.extensionID
+        )
+        if let receiver = pageReceivers[key]?.value,
+           receiver.identity == page,
+           receiver.webView === webView {
+            return receiver
+        }
+        pageReceivers.removeValue(forKey: key)?.value?.invalidate()
+        let receiver = FloorpWebExtensionPageMessageReceiver(
+            identity: page,
+            webView: webView
+        )
+        pageReceivers[key] = WeakPageReceiver(receiver)
+        return receiver
+    }
+
+    func dispatchRuntimeMessage(
+        _ message: FloorpWebExtensionMessagePayload,
+        sender: any FloorpWebExtensionMessageSender
+    ) async throws -> FloorpWebExtensionMessagePayload? {
+        guard let backgroundSender = sender as? FloorpWebExtensionBackgroundRuntimeMessageSender else {
+            return try await backgroundHost.dispatch(message, sender: sender)
+        }
+        guard isActive(backgroundSender) else {
+            throw FloorpWebExtensionMessageError.authenticationFailed
+        }
+
+        removeReleasedControllers()
+        let receivers = pageReceivers.values.compactMap(\.value).filter {
+            $0.identity.profileKey == backgroundSender.profileKey &&
+                $0.identity.extensionID == backgroundSender.extensionID &&
+                $0.identity.packageGeneration == backgroundSender.packageGeneration &&
+                $0.isAvailable
+        }
+        var firstResponse: FloorpWebExtensionMessagePayload?
+        for receiver in receivers {
+            guard isActive(backgroundSender) else {
+                throw FloorpWebExtensionMessageError.backgroundReplaced
+            }
+            do {
+                let response = try await receiver.deliver(message, sender: backgroundSender)
+                if firstResponse == nil, let response, isRegistered(receiver) {
+                    firstResponse = response
+                }
+            } catch {
+                if !isActive(backgroundSender) {
+                    throw FloorpWebExtensionMessageError.backgroundReplaced
+                }
+            }
+        }
+        guard isActive(backgroundSender) else {
+            throw FloorpWebExtensionMessageError.backgroundReplaced
+        }
+        return firstResponse
+    }
+
+    private func invalidatePageReceiver(
+        for extensionID: FloorpWebExtensionID,
+        controllerIdentifier: ObjectIdentifier
+    ) {
+        let key = PageReceiverKey(
+            controllerIdentifier: controllerIdentifier,
+            extensionID: extensionID
+        )
+        pageReceivers.removeValue(forKey: key)?.value?.invalidate()
+    }
+
+    private func isActive(
+        _ sender: FloorpWebExtensionBackgroundRuntimeMessageSender
+    ) -> Bool {
+        guard profileKey == sender.profileKey,
+              let background = activeBackgroundBridges[sender.extensionID] else {
+            return false
+        }
+        return background.profileKey == sender.profileKey &&
+            background.packageGeneration == sender.packageGeneration &&
+            background.originHost == sender.originHost
+    }
+
+    private func isRegistered(_ receiver: FloorpWebExtensionPageMessageReceiver) -> Bool {
+        let key = PageReceiverKey(
+            controllerIdentifier: receiver.controllerIdentifier,
+            extensionID: receiver.identity.extensionID
+        )
+        return pageReceivers[key]?.value === receiver &&
+            controllers[key.controllerIdentifier]?.pageIdentities[key.extensionID] == receiver.identity &&
+            receiver.isAvailable
     }
 }
 
@@ -809,12 +1072,15 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
     private static let version = 1
 
     private let extensionID: FloorpWebExtensionID
-    private let backgroundHost: FloorpWebExtensionLazyBackgroundHost
     private let nativeAPIDispatcher: (any FloorpWebExtensionNativeAPIDispatching)?
     private let bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?
     private let contentPolicyOwner: String
     private let authorizeDocument: @MainActor (URL, Bool) -> Bool
     private let authorizeFrameScript: (@MainActor (String, String, URL, Bool) -> Bool)?
+    private let dispatchRuntimeMessage: @MainActor (
+        FloorpWebExtensionMessagePayload,
+        any FloorpWebExtensionMessageSender
+    ) async throws -> FloorpWebExtensionMessagePayload?
     private let scheduleRequest: @MainActor (
         @escaping @MainActor @Sendable () async -> Void
     ) -> Void
@@ -822,35 +1088,41 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
     private let nonce: String
     private let handlerName: String
     private let contentWorld: WKContentWorld
+    private let supportsSameSurfacePageNavigation: Bool
     private weak var controller: WKUserContentController?
     private var attachmentGeneration: UInt64 = 0
 
     init(
         extensionID: FloorpWebExtensionID,
-        backgroundHost: FloorpWebExtensionLazyBackgroundHost,
         nativeAPIDispatcher: (any FloorpWebExtensionNativeAPIDispatching)?,
         bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?,
         contentWorld: WKContentWorld,
+        supportsSameSurfacePageNavigation: Bool,
         owner: String,
         authorizeDocument: @escaping @MainActor (URL, Bool) -> Bool,
         authorizeFrameScript: (@MainActor (String, String, URL, Bool) -> Bool)? = nil,
+        dispatchRuntimeMessage: @escaping @MainActor (
+            FloorpWebExtensionMessagePayload,
+            any FloorpWebExtensionMessageSender
+        ) async throws -> FloorpWebExtensionMessagePayload?,
         scheduleRequest: @escaping @MainActor (
             @escaping @MainActor @Sendable () async -> Void
         ) -> Void,
         makeSender: @escaping @MainActor (URL, Bool) -> any FloorpWebExtensionMessageSender
     ) {
         self.extensionID = extensionID
-        self.backgroundHost = backgroundHost
         self.nativeAPIDispatcher = nativeAPIDispatcher
         self.bootstrap = bootstrap
         contentPolicyOwner = owner
         self.authorizeDocument = authorizeDocument
         self.authorizeFrameScript = authorizeFrameScript
+        self.dispatchRuntimeMessage = dispatchRuntimeMessage
         self.scheduleRequest = scheduleRequest
         self.makeSender = makeSender
         nonce = Self.makeNonce()
         handlerName = "floorpRuntime_\(nonce.prefix(24))"
         self.contentWorld = contentWorld
+        self.supportsSameSurfacePageNavigation = supportsSameSurfacePageNavigation
     }
 
     func attach(to controller: WKUserContentController) {
@@ -863,7 +1135,8 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
                 extensionID: extensionID,
                 nonce: nonce,
                 handlerName: handlerName,
-                bootstrap: bootstrap
+                bootstrap: bootstrap,
+                supportsSameSurfacePageNavigation: supportsSameSurfacePageNavigation
             ),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: false,
@@ -971,7 +1244,7 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             }
             let response: FloorpWebExtensionMessagePayload?
             if envelope.operation == "runtime.sendMessage" {
-                response = try await backgroundHost.dispatch(envelope.payload, sender: sender)
+                response = try await dispatchRuntimeMessage(envelope.payload, sender)
             } else if let nativeAPIDispatcher {
                 response = try await nativeAPIDispatcher.dispatch(
                     operation: envelope.operation,
@@ -1150,11 +1423,13 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
         extensionID: FloorpWebExtensionID,
         nonce: String,
         handlerName: String,
-        bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?
+        bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?,
+        supportsSameSurfacePageNavigation: Bool
     ) -> String {
         let extensionLiteral = javaScriptLiteral(extensionID.rawValue)
         let nonceLiteral = javaScriptLiteral(nonce)
         let handlerLiteral = javaScriptLiteral(handlerName)
+        let sameSurfacePageNavigationLiteral = supportsSameSurfacePageNavigation ? "true" : "false"
         let bootstrapLiteral: String
         if let bootstrap,
            let data = try? JSONEncoder().encode(bootstrap),
@@ -1341,6 +1616,16 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             }
             return serializeResponse(null);
           };
+          const deliverRuntimeMessage = async (message, sender) => {
+            for (const listener of runtimeOnMessageListeners) {
+              if (typeof listener !== "function") continue;
+              const value = await invokeMessageListener(listener, message, sender);
+              if (typeof value !== "undefined") {
+                return JSON.stringify({hasResponse: true, value});
+              }
+            }
+            return JSON.stringify({hasResponse: false});
+          };
           const deliverAlarm = async (alarm) => {
             for (const listener of alarmListeners) {
               if (typeof listener === "function") await listener(alarm);
@@ -1526,10 +1811,48 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             },
             getLimits() { return request("declarativeNetRequest.getLimits"); }
           });
+          // iOS presents popup/options resources inside one authenticated,
+          // package-owned WKWebView.  Some desktop extensions discover or
+          // create another window before opening Settings.  On that page
+          // surface only, translate a same-origin package URL into a
+          // same-WebView navigation.  Tab content and hidden backgrounds never
+          // receive this compatibility capability.
+          const supportsSameSurfacePageNavigation = \(sameSurfacePageNavigationLiteral);
+          const sameSurfacePageNavigationTarget = (value) => {
+            if (!supportsSameSurfacePageNavigation || typeof value !== "string") return null;
+            let current;
+            let target;
+            try {
+              current = new URL(globalThis.location.href);
+              target = new URL(value, current);
+            } catch (_) {
+              return null;
+            }
+            if (current.protocol !== "floorp-extension:" ||
+                target.protocol !== current.protocol ||
+                target.host !== current.host ||
+                current.username || current.password || current.port ||
+                target.username || target.password || target.port ||
+                target.search) {
+              return null;
+            }
+            return target;
+          };
+          const navigateSameSurfacePage = (value) => {
+            const target = sameSurfacePageNavigationTarget(value);
+            if (!target) return null;
+            globalThis.location.assign(target.href);
+            return Object.freeze({active: true, url: target.href});
+          };
           const tabs = Object.freeze({
             query(queryInfo = {}) { return request("tabs.query", {queryInfo}); },
             get(tabId) { return request("tabs.get", {tabId}); },
-            create(createProperties = {}) { return request("tabs.create", {createProperties}); },
+            create(createProperties = {}) {
+              const navigatedTab = navigateSameSurfacePage(createProperties?.url);
+              return navigatedTab
+                ? Promise.resolve(navigatedTab)
+                : request("tabs.create", {createProperties});
+            },
             update(tabId, updateProperties = {}) { return request("tabs.update", {tabId, updateProperties}); },
             reload(tabId, reloadProperties = {}) { return request("tabs.reload", {tabId, reloadProperties}); },
             sendMessage(tabId, message, options = {}) {
@@ -1537,6 +1860,25 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             },
             onRemoved: tabsOnRemoved.event
           });
+          const windows = supportsSameSurfacePageNavigation ? Object.freeze({
+            getAll() {
+              // There are no separately addressable extension popup windows
+              // in this page surface.  Returning an empty list makes the
+              // extension take its create path without inventing tab IDs.
+              return Promise.resolve([]);
+            },
+            create(createData = {}) {
+              const navigatedTab = navigateSameSurfacePage(createData?.url);
+              if (!navigatedTab) {
+                return Promise.reject(new Error("windows.create only supports a same-origin package page"));
+              }
+              return Promise.resolve(Object.freeze({
+                focused: true,
+                type: createData?.type || "popup",
+                tabs: Object.freeze([navigatedTab])
+              }));
+            }
+          }) : null;
           const storage = Object.freeze({
             local: storageArea("local"),
             sync: storageArea("sync", 5 * 1024 * 1024, 8 * 1024),
@@ -1684,13 +2026,19 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             configurable: false,
             writable: false
           });
+          Object.defineProperty(globalThis, "__floorpWebExtensionDeliverPageRuntimeMessage", {
+            value: deliverRuntimeMessage,
+            enumerable: false,
+            configurable: false,
+            writable: false
+          });
           Object.defineProperty(globalThis, "__floorpWebExtensionDeliverAlarm", {
             value: deliverAlarm,
             enumerable: false,
             configurable: false,
             writable: false
           });
-          for (const [name, value] of Object.entries({
+          const browserNamespaces = {
             runtime,
             permissions,
             scripting,
@@ -1701,7 +2049,9 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             action,
             browserAction: action,
             tabs
-          })) {
+          };
+          if (windows) browserNamespaces.windows = windows;
+          for (const [name, value] of Object.entries(browserNamespaces)) {
             Object.defineProperty(browserObject, name, {
               value,
               enumerable: true,
@@ -1804,7 +2154,7 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
           const chromeObject = globalThis.chrome && typeof globalThis.chrome === "object"
             ? globalThis.chrome
             : {};
-          for (const [name, value] of Object.entries({
+          const chromeNamespaces = {
             runtime: chromeRuntime,
             permissions: callbackNamespace(permissions),
             scripting: callbackNamespace(scripting),
@@ -1821,7 +2171,9 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
             browserAction: callbackNamespace(action),
             tabs: callbackNamespace(tabs),
             extension: chromeExtension
-          })) {
+          };
+          if (windows) chromeNamespaces.windows = callbackNamespace(windows);
+          for (const [name, value] of Object.entries(chromeNamespaces)) {
             if (name === "alarms") {
               Object.defineProperty(value, "onAlarm", {value: alarms.onAlarm, enumerable: true});
             }

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPageHost.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPageHost.swift
@@ -1146,6 +1146,7 @@ final class FloorpWebExtensionPageViewController: UIViewController {
 
     private let navigationControllerDelegate: FloorpWebExtensionPageNavigationDelegate
     private let entryPointURL: URL
+    private var pageMessageReceiver: FloorpWebExtensionPageMessageReceiver?
 
     init(
         surface: FloorpWebExtensionPageSurface,
@@ -1174,6 +1175,7 @@ final class FloorpWebExtensionPageViewController: UIViewController {
         ) else {
             throw FloorpWebExtensionPageHostError.invalidResourceURL
         }
+        let pageBridgeIdentity: FloorpWebExtensionPageBridgeIdentity?
         if let profileKey = messageRuntime?.profileKey {
             let identity = try FloorpWebExtensionPageBridgeIdentity(
                 profileKey: profileKey,
@@ -1181,10 +1183,13 @@ final class FloorpWebExtensionPageViewController: UIViewController {
                 originHost: originHost,
                 surface: surface
             )
-            _ = messageRuntime?.installPageBridge(
+            let installed = messageRuntime?.installPageBridge(
                 identity,
                 on: configuration.userContentController
-            )
+            ) == true
+            pageBridgeIdentity = installed ? identity : nil
+        } else {
+            pageBridgeIdentity = nil
         }
         self.surface = surface
         self.entryPointURL = entryPointURL
@@ -1194,11 +1199,27 @@ final class FloorpWebExtensionPageViewController: UIViewController {
         )
         webView = WKWebView(frame: .zero, configuration: configuration)
         super.init(nibName: nil, bundle: nil)
+        if let pageBridgeIdentity, let messageRuntime {
+            pageMessageReceiver = messageRuntime.registerPageMessageReceiver(
+                pageBridgeIdentity,
+                webView: webView
+            )
+        }
         webView.navigationDelegate = navigationControllerDelegate
         webView.uiDelegate = navigationControllerDelegate
         preferredContentSize = surface == .actionPopup
             ? CGSize(width: 360, height: 520)
             : CGSize(width: 640, height: 720)
+    }
+
+    deinit {
+        guard Thread.isMainThread else {
+            assertionFailure("Extension page was not deallocated on the main thread")
+            return
+        }
+        MainActor.assumeIsolated {
+            pageMessageReceiver?.invalidate()
+        }
     }
 
     @available(*, unavailable)

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
@@ -2060,6 +2060,23 @@ final class FloorpWebExtensionLivePackageManager: FloorpWebExtensionSettingsMana
         for extensionID: FloorpWebExtensionID,
         expectedGeneration: String
     ) async throws -> PermissionMutationAuthorization {
+        try await authorizePermissionMutationWithPackageSnapshot(
+            for: extensionID,
+            expectedGeneration: expectedGeneration
+        ).authorization
+    }
+
+    /// Captures both the one-use mutation authority and the grants shown by a
+    /// product-owned consent prompt while holding the same lifecycle gate.
+    /// Callers must build the prompt and its replacement snapshot from the
+    /// returned package, never from an earlier package listing.
+    func authorizePermissionMutationWithPackageSnapshot(
+        for extensionID: FloorpWebExtensionID,
+        expectedGeneration: String
+    ) async throws -> (
+        authorization: PermissionMutationAuthorization,
+        package: FloorpWebExtensionInstalledPackage
+    ) {
         let gate = lifecycleMutationGate(for: extensionID)
         await gate.acquire()
         defer { Task { await gate.release() } }
@@ -2072,11 +2089,12 @@ final class FloorpWebExtensionLivePackageManager: FloorpWebExtensionSettingsMana
             throw FloorpWebExtensionPackageStoreError.inactivePackageGeneration(extensionID)
         }
         try authorizeCatalogRecord(package)
-        return .init(
+        let authorization = PermissionMutationAuthorization(
             extensionID: extensionID,
             packageGeneration: expectedGeneration,
             lifecycleRevision: lifecycleRevisions[extensionID, default: 0]
         )
+        return (authorization, package)
     }
 
     func updateGrants(

--- a/firefox-ios/TestFlight/WhatToTest.en-US.txt
+++ b/firefox-ios/TestFlight/WhatToTest.en-US.txt
@@ -1,65 +1,54 @@
 Floorp for iOS — curated WebExtensions candidate
 
-This build is eligible for this test only when TestFlight shows the exact
-version and build stated in the release evidence and Extensions shows a signed,
-app-bundled catalog containing 17 fixed packages. If the catalog is missing,
-contains a different count, or its package list changes after launch, stop and
-report it as a release-integrity failure. Do not substitute the older fixture
-catalog or another TestFlight build.
+Use this candidate only when TestFlight shows the exact version/build from the
+release evidence and Settings > Extensions shows the signed, app-bundled
+catalog of 17 fixed packages. Stop and report a release-integrity failure if
+the catalog is missing, has a different count, or changes after launch. Do not
+substitute another TestFlight build.
 
-This candidate is not an extension store. It has no Chrome Web Store, Firefox
-Add-ons, arbitrary URL, ZIP, XPI, CRX, shared-sheet, or local-file installation
-path. It does not fetch JavaScript, WebAssembly, or DNR lists. Do not attempt
-to bypass those boundaries; report any visible path that appears to do so.
+This is not an extension store. There must be no Chrome Web Store installation
+path, Firefox Add-ons installation, arbitrary URL, ZIP, XPI, CRX, share-sheet,
+or local-file installation. The reviewed packages must not fetch remote
+JavaScript, WebAssembly, configuration, updates, or DNR lists. Report any
+visible path or network activity that appears to cross these boundaries.
 
-In a normal browsing profile, open Settings > Extensions and confirm the
-signed metadata (name, version, permissions, license, source, generation) for
-the 17 fixed packages. Install one representative from each family: Floorp Site
-Appearance (content script), Floorp Tracker Block Lite or Very Good AdBlock
-(static block-only DNR), and Floorp Session Timer or Easy to RSS (action,
-popup/options, storage, alarms). Grant a site only when prompted and use a
-non-sensitive Floorp QA page or another approved test page. Confirm that the
-declared local behavior works, then disable, re-enable, remove, and reinstall
-each representative. Disable must stop runtime/content rules/actions without
-silently changing the generation; remove must clear extension-owned data.
+In a normal profile, inspect signed metadata for the 17 packages. Install one
+representative from each family: Floorp Site Appearance; Floorp Tracker Block
+Lite or Very Good AdBlock; and Floorp Session Timer or Easy to RSS. Use only a
+non-sensitive Floorp QA page or another approved test page. Confirm declared
+behavior, then disable, re-enable, remove, and reinstall each representative.
+Disable must stop runtime/content rules/actions without changing generation;
+remove must clear extension-owned data.
 
-Also install Dark Reader, grant it a non-sensitive HTTP(S) test page, and use
-its popup to toggle the page appearance. Reload the page and reopen the popup
-to confirm settings remain profile-local. `storage.sync` is intentionally
-device-local in Floorp: do not expect a cloud account or cross-device sync.
-The reviewed build must not fetch remote configuration, news, or updates.
+Install Dark Reader and open a normal HTTP(S) test page in one browser window.
+Open its action popup with site access initially denied. Confirm Floorp offers
+explicit access for the current site and all requested sites. Choose the
+current site, confirm the same page reloads and becomes dark, then reopen the
+popup. It must show the real hostname, not `about:`, and must not claim the
+page is browser-protected. Toggle Off and On while the popup stays open:
+both the page and the popup status must update each time. Tap Settings and
+confirm the authenticated Dark Reader settings page opens. Reload and reopen
+the popup to confirm the choice remains profile-local.
 
-Open an extension with no declared action as well as one with a popup. The
-Extensions menu must remain usable and must not crash. For DNR behavior, use
-only a supplied Floorp QA harness: verify block-only behavior and per-site
-exclusion. A redirect, header modification, allow-all rule, dynamic/session
-rule, remotely refreshed list, or a rule change after installation is a defect.
+Known limits for this candidate: Dark Reader multi-window active-tab routing
+and its large DevTools data view are not release acceptance paths. Test the
+core popup, page appearance, and Settings flow in a single browser window.
+`storage.sync` is intentionally device-local; do not expect cloud sync.
 
-Repeat the key install, permission, enable/disable, and delete paths in a
-private profile. Private use is opt-in and profile-local: normal-profile grants,
-storage, alarms, rules, and runtime state must not appear in private browsing;
-private state must not reappear in normal browsing. If a private installation
-is not enabled for the chosen package, it must be refused safely.
+Open an extension with no action and one with a popup; the Extensions menu must
+remain usable. For DNR, use only the supplied Floorp QA harness and verify
+block-only behavior plus per-site exclusion. Redirects, header modification,
+allow-all, dynamic/session rules, remote list refresh, or post-install rule
+changes are defects.
 
-There is no silent catalog replacement in this candidate. A future immutable
-generation may be applied only after a native confirmation that identifies the
-old/new version, generation, digest, and any authority delta. If a supplied
-signed test update lacks that confirmation, fails integrity/expiry/rollback or
-revocation validation, or tries to increase authority without consent, it must
-remain inactive and the known-good generation must stay intact. Record the
-result only when a release-approved signed test artifact is supplied.
+Repeat key install, permission, enable/disable, delete, and Dark Reader paths
+in Private Browsing. Private use is opt-in and profile-local. Normal grants,
+storage, alarms, rules, and runtime state must not appear in private browsing,
+and private state must not return to normal browsing.
 
-Repeat core browser smoke tests in normal and private browsing, English and
-Japanese, with VoiceOver. Report any crash, hang, unexpected network activity,
-permission bypass, cross-profile data leak, catalog change, or TestFlight
-version/build mismatch. Do not use personal credentials or production data for
-this candidate.
-
-Known limitations: the catalog is a fixed app-bundled set, not a general
-plug-in collection. The sole maintainer's P0 policy records the verified
-license/notice/provenance basis; its exact signed catalog and candidate-bound
-approval record are verified before the normal candidate PR is merged.
-Physical-device evidence and Apple review remain required. This tester pass
-does not by itself establish the physical-device
-performance, memory, battery, accessibility, or revocation acceptance evidence
-required for broader release.
+Repeat core browser smoke tests in normal/private browsing, English/Japanese,
+and with VoiceOver. Report crashes, hangs, unexpected network activity,
+permission bypass, cross-profile leakage, catalog changes, or version/build
+mismatches. Do not use personal credentials or production data. Physical-
+device performance, memory, battery, accessibility, revocation evidence, and
+Apple review remain required for broader release.

--- a/firefox-ios/TestFlight/WhatToTest.ja-JP.txt
+++ b/firefox-ios/TestFlight/WhatToTest.ja-JP.txt
@@ -1,53 +1,45 @@
 Floorp for iOS — 固定 WebExtensions カタログ候補
 
-このテストは、TestFlight のバージョン／ビルド番号がリリース証跡と完全一致し、Extensions
-画面に署名済み・アプリ同梱の固定17本カタログが表示される候補に限ります。カタログがない、
-本数が17以外、または起動後に一覧が変化した場合は、そこで中止してリリース完全性の不具合
-として報告してください。旧 fixture カタログや別の TestFlight ビルドで代替しないでください。
+TestFlight の版／ビルドがリリース証跡と完全一致し、「設定」>「Extensions」に署名済み・
+アプリ同梱の固定17本カタログが表示される候補だけをテストしてください。カタログがない、
+本数が違う、または起動後に一覧が変わった場合は、リリース完全性の不具合として中止・報告
+してください。別の TestFlight ビルドで代替しないでください。
 
-この候補は拡張ストアではありません。Chrome ウェブストア、Firefox Add-ons、任意 URL、ZIP、
-XPI、CRX、共有シート、ローカルファイルから導入する経路はありません。JavaScript、WASM、
-DNR リストも取得しません。これらの境界を回避しようとせず、該当する導入経路が見えた場合は
-不具合として報告してください。
+これは拡張ストアではありません。Chrome ウェブストア、Firefox Add-ons、任意 URL、ZIP、
+XPI、CRX、共有シート、ローカルファイルから導入できてはなりません。レビュー済み package は
+remote JavaScript、WASM、設定、更新、DNR list を取得してはなりません。境界を越える導線や
+通信が見えた場合は報告してください。
 
-通常プロファイルで「設定」>「Extensions」を開き、17本すべてについて署名済み metadata
-（名前、版、権限、ライセンス、source、generation）を確認してください。各機能群から1本ずつ、
-Floorp Site Appearance（content script）、Floorp Tracker Block Lite または Very Good AdBlock
-（static block-only DNR）、Floorp Session Timer または Easy to RSS（action、popup/options、
-storage、alarms）を導入します。サイト権限は表示されたときだけ許可し、個人情報を含まない
-Floorp QA ページまたは承認済みのテストページを使ってください。期待されるローカル動作を
-確認した後、各代表を無効化、有効化、削除、再導入してください。無効化は runtime/content rule/
-action を停止し、generation を暗黙に変えてはなりません。削除は拡張機能所有データを消去します。
+通常プロファイルで17本の署名済み metadata を確認します。各機能群から Floorp Site
+Appearance、Floorp Tracker Block Lite または Very Good AdBlock、Floorp Session Timer
+または Easy to RSS を代表として導入してください。個人情報を含まない Floorp QA page または
+承認済み test page だけを使います。宣言された動作を確認後、無効化、有効化、削除、再導入を
+行ってください。無効化は generation を変えずに runtime/content rule/action を停止し、削除は
+拡張機能所有データを消去する必要があります。
 
-Dark Reader も導入し、個人情報を含まない HTTP(S) テストページだけを許可して、popup から表示を
-切り替えてください。ページを再読み込みし、popup を開き直して設定が profile-local に残ることを
-確認します。`storage.sync` は Floorp では意図的に端末内だけの保存領域であり、クラウドまたは
-端末間同期は期待しないでください。レビュー済み build は remote configuration、news、update を
-取得してはなりません。
+Dark Reader を導入し、1つの browser window で通常の HTTP(S) test page を開きます。サイト
+アクセスを未許可にした状態で action popup を開き、現在のサイトと要求された全サイトを明示した
+Floorp の許可 UI が出ることを確認します。「現在のサイト」を選び、同じ page が再読み込みされて
+dark 表示になることを確認して popup を開き直してください。`about:` ではなく実 hostname が表示
+され、「browser によって保護」と誤表示されないことが必要です。popup を開いたまま Off と On を
+切り替え、page と popup の状態表示が毎回一緒に変わることを確認します。Settings を押し、認証済み
+Dark Reader 設定 page が開くことも確認してください。reload と popup 再表示後も設定は
+profile-local に保持される必要があります。
 
-action 未宣言の拡張機能と popup を持つ拡張機能の両方を開いてください。Extensions メニューが
-使用可能なままで、クラッシュしないことを確認します。DNR は、提供された Floorp QA harness
-だけを使い、block-only 動作とサイト単位の除外を確認してください。redirect、header modification、
-allow-all、dynamic/session rule、リモート更新リスト、導入後のルール変更はすべて不具合です。
+既知の制限: Dark Reader の複数 window にまたがる active-tab routing と大容量 DevTools data
+view は今回の合格経路ではありません。主要な popup、page 表示、Settings は単一 window で確認
+してください。`storage.sync` は意図的に端末内だけで、cloud sync は行いません。
 
-通常プロファイルの導入、権限、有効／無効、削除の主要経路を private profile でも繰り返します。
-Private 利用は opt-in で profile-local です。通常側のサイト権限、storage、alarms、rules、runtime
-state が private 側に現れず、private 側の状態が通常側に戻らないことを確認してください。選んだ
-拡張機能の private 導入が許可されていない場合は、安全に拒否されなければなりません。
+action 未宣言の拡張機能と popup 付き拡張機能を開き、Extensions menu が使用可能なままか確認
+します。DNR は提供された Floorp QA harness だけを使い、block-only とサイト単位除外を確認します。
+redirect、header modification、allow-all、dynamic/session rule、remote list 更新、導入後の rule
+変更は不具合です。
 
-この候補にはサイレントな catalog 更新はありません。将来の immutable generation は、旧／新版、
-generation、digest、追加される権限を示す native confirmation 後だけ適用できます。承認済みの
-署名テスト artifact が提供された場合、confirmation のない更新、改ざん、期限切れ、rollback、
-失効、同意なしの権限増加はすべて inactive のまま拒否され、既知正常 generation が保持される
-ことを確認してください。それ以外の更新結果を推測して記録しないでください。
+Private Browsing でも導入、権限、有効／無効、削除、Dark Reader の主要経路を繰り返します。
+Private 利用は opt-in かつ profile-local です。通常側の権限、storage、alarms、rules、runtime
+state が private 側に現れず、private state が通常側へ戻らないことを確認してください。
 
-通常／private ブラウジング、英語／日本語、VoiceOver でブラウザの主要スモークテストも繰り返し
-ます。クラッシュ、ハング、想定外のネットワーク通信、権限回避、profile 間データ漏えい、
-catalog の変化、TestFlight の版／ビルド不一致を報告してください。個人の認証情報や本番データは
-この候補で使用しないでください。
-
-既知の制限: この catalog は固定のアプリ同梱セットであり、一般的な plug-in collection では
-ありません。sole maintainer の P0 policy は確認済み license/notice/provenance による再配布根拠を
-記録しています。exact signed catalog と candidate-bound approval record は通常の candidate PR merge
-前に検証されますが、実機証跡と Apple 審査は引き続き必要です。このテストだけでは、より広い配布に必要な実機性能、memory、battery、
-accessibility、失効演習の証跡は完了しません。
+通常／private、英語／日本語、VoiceOver で browser の主要 smoke test も行います。crash、hang、
+想定外通信、権限回避、profile 間漏えい、catalog 変化、版／ビルド不一致を報告してください。
+個人の認証情報や本番データは使わないでください。広い配布には実機性能、memory、battery、
+accessibility、失効証跡、Apple 審査が引き続き必要です。

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1565,6 +1565,103 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(subject.childCoordinators.isEmpty)
     }
 
+    // MARK: - Web extension action site access
+
+    func testWebExtensionActionSiteAccessPlanOffersExplicitScopesWhenDenied() throws {
+        let requestedHosts = Set([try FloorpWebExtensionMatchPattern("<all_urls>")])
+
+        let plan = try XCTUnwrap(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://www.example.com/article"),
+            requestedHosts: requestedHosts,
+            hostAccess: .denied,
+            isPrivateBrowsing: false
+        ))
+
+        let currentSite = try FloorpWebExtensionMatchPattern("https://www.example.com/*")
+        XCTAssertEqual(plan.currentHost, "www.example.com")
+        XCTAssertEqual(plan.access(for: .currentSite), .selectedSites([currentSite]))
+        XCTAssertEqual(plan.access(for: .allRequestedSites), .allRequestedSites)
+        XCTAssertNil(plan.access(for: .cancel))
+        XCTAssertTrue(plan.requestsEveryWebsite)
+        XCTAssertFalse(plan.isPrivateBrowsing)
+    }
+
+    func testWebExtensionActionSiteAccessPlanDoesNotPromptAfterAccessWasGranted() throws {
+        let requestedHosts = Set([try FloorpWebExtensionMatchPattern("<all_urls>")])
+
+        XCTAssertNil(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://www.example.com/"),
+            requestedHosts: requestedHosts,
+            hostAccess: .allRequestedSites,
+            isPrivateBrowsing: false
+        ))
+        XCTAssertNil(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://www.example.com/"),
+            requestedHosts: requestedHosts,
+            hostAccess: .selectedSites([
+                try FloorpWebExtensionMatchPattern("https://www.example.com/*")
+            ]),
+            isPrivateBrowsing: false
+        ))
+    }
+
+    func testWebExtensionActionSiteAccessPlanAddsCurrentSiteWithoutDroppingExistingSites() throws {
+        let requestedHosts = Set([try FloorpWebExtensionMatchPattern("<all_urls>")])
+        let existingSite = try FloorpWebExtensionMatchPattern("https://existing.example/*")
+        let currentSite = try FloorpWebExtensionMatchPattern("https://current.example/*")
+
+        let plan = try XCTUnwrap(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://current.example/page"),
+            requestedHosts: requestedHosts,
+            hostAccess: .selectedSites([existingSite]),
+            isPrivateBrowsing: false
+        ))
+
+        XCTAssertEqual(
+            plan.access(for: .currentSite),
+            .selectedSites([existingSite, currentSite])
+        )
+        XCTAssertEqual(plan.access(for: .allRequestedSites), .allRequestedSites)
+    }
+
+    func testWebExtensionActionSiteAccessPlanDoesNotPromptForProtectedOrUnrequestedPage() throws {
+        let requestedHosts = Set([
+            try FloorpWebExtensionMatchPattern("https://allowed.example/*")
+        ])
+
+        XCTAssertNil(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "about:blank"),
+            requestedHosts: requestedHosts,
+            hostAccess: .denied,
+            isPrivateBrowsing: false
+        ))
+        XCTAssertNil(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://not-allowed.example/"),
+            requestedHosts: requestedHosts,
+            hostAccess: .denied,
+            isPrivateBrowsing: false
+        ))
+    }
+
+    func testWebExtensionActionSiteAccessPlanKeepsPrivateAndPathLimitedScopeExplicit() throws {
+        let requestedHosts = Set([
+            try FloorpWebExtensionMatchPattern("https://example.com/private/*")
+        ])
+
+        let plan = try XCTUnwrap(BrowserCoordinator.webExtensionActionSiteAccessPlan(
+            currentURL: URL(string: "https://example.com/private/page"),
+            requestedHosts: requestedHosts,
+            hostAccess: .denied,
+            isPrivateBrowsing: true
+        ))
+
+        XCTAssertNil(plan.currentSite)
+        XCTAssertNil(plan.currentHost)
+        XCTAssertNil(plan.access(for: .currentSite))
+        XCTAssertEqual(plan.access(for: .allRequestedSites), .allRequestedSites)
+        XCTAssertTrue(plan.isPrivateBrowsing)
+    }
+
     // MARK: - Route handling
 
     // MARK: canHandle(route:)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -20,6 +20,8 @@ import QuickAnswersKit
 final class BrowserCoordinatorTests: XCTestCase,
                                      FeatureFlaggable,
                                      StoreTestUtility {
+    // XCTest initializes these fixtures in setUp and releases them in tearDown.
+    // swiftlint:disable implicitly_unwrapped_optional
     private var mockRouter: MockRouter!
     private var profile: MockProfile!
     private var overlayModeManager: MockOverlayModeManager!
@@ -32,6 +34,7 @@ final class BrowserCoordinatorTests: XCTestCase,
     private var mockStore: MockStoreForMiddleware<AppState>!
     private var homepageTabStateStore: HomepageTabStateStore!
     private var mockWorldCupStore: MockWorldCupStore!
+    // swiftlint:enable implicitly_unwrapped_optional
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
     override func setUp() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionMessageRuntimeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionMessageRuntimeTests.swift
@@ -507,6 +507,7 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
               callbackError,
               leakedLastError: chrome.runtime.lastError !== null,
               contentGetURLRejected,
+              windowsType: typeof chrome.windows,
               runtimeId: chrome.runtime.id,
               dynamicLimit: browser.declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES
             };
@@ -519,6 +520,7 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertEqual(result?["callbackError"] as? String, "unsupported_code_execution")
         XCTAssertEqual(result?["leakedLastError"] as? Bool, false)
         XCTAssertEqual(result?["contentGetURLRejected"] as? Bool, true)
+        XCTAssertEqual(result?["windowsType"] as? String, "undefined")
         XCTAssertEqual(result?["runtimeId"] as? String, extensionID.rawValue)
         XCTAssertEqual(result?["dynamicLimit"] as? Int, 5_000)
         XCTAssertEqual(
@@ -786,6 +788,424 @@ final class FloorpWebExtensionMessageRuntimeTests: XCTestCase {
         XCTAssertTrue(pageTransportHost.hasPrefix("page-"))
         XCTAssertTrue(URL(string: backgroundTransportURL)?.host?.hasPrefix("background-") == true)
         XCTAssertNotEqual(URL(string: backgroundTransportURL)?.host, pageTransportHost)
+    }
+
+    func testBackgroundRuntimeMessageBroadcastsOnceToOpenPageAndPreservesPageToBackground() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "background-to-page-profile",
+            isPrivateBrowsing: false
+        )
+        let host = FloorpWebExtensionLazyBackgroundHost()
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: host,
+            profileKey: profileKey
+        )
+        let resources = [
+            "background.js": Data("""
+            let backgroundDeliveryCount = 0;
+            browser.runtime.onMessage.addListener(async (message, sender) => {
+              backgroundDeliveryCount += 1;
+              if (message.type !== "popup-command") return false;
+              const pageReply = await browser.runtime.sendMessage({
+                type: "background-change",
+                value: message.value
+              });
+              return {
+                backgroundDeliveryCount,
+                pageReply,
+                senderURL: sender.url
+              };
+            });
+            """.utf8),
+            "ui/popup/index.html": Data("<html><body>Runtime broadcast popup</body></html>".utf8)
+        ]
+        let installedPackage = try makeBackgroundInstalledPackage(
+            generation: "background-to-page-generation",
+            resources: resources
+        )
+        let resolver = FloorpWebExtensionPageResourceResolver { request in
+            guard let data = resources[request.path] else {
+                throw FloorpWebExtensionPackageStoreError.resourceUnavailable(request.path)
+            }
+            return data
+        }
+        try runtime.registerPackageBackground(
+            package: installedPackage,
+            packageProfileKey: .init(
+                profileIdentifier: profileKey.profileIdentifier,
+                isPrivateBrowsing: profileKey.isPrivateBrowsing
+            ),
+            resolver: resolver
+        )
+        let page = try FloorpWebExtensionPageViewController(
+            surface: .actionPopup,
+            package: .init(installedPackage: installedPackage),
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: resolver,
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        page.loadViewIfNeeded()
+        try await waitForLoad(page.webView)
+
+        let result = try await page.webView.callAsyncJavaScript(
+            """
+            const received = [];
+            browser.runtime.onMessage.addListener((message, sender) => {
+              received.push({
+                message,
+                senderId: sender.id,
+                senderURL: sender.url,
+                senderPrivate: sender.isPrivate,
+                hasTab: Object.prototype.hasOwnProperty.call(sender, "tab")
+              });
+              return {acknowledged: message.type};
+            });
+            const commandReply = await browser.runtime.sendMessage({
+              type: "popup-command",
+              value: 17
+            });
+            return {received, commandReply};
+            """,
+            contentWorld: .page
+        ) as? [String: Any]
+        let received = result?["received"] as? [[String: Any]]
+        let delivery = received?.first
+        let deliveredMessage = delivery?["message"] as? [String: Any]
+        let commandReply = result?["commandReply"] as? [String: Any]
+        let pageReply = commandReply?["pageReply"] as? [String: Any]
+        let pageHost = try XCTUnwrap(page.webView.url?.host)
+
+        XCTAssertEqual(received?.count, 1)
+        XCTAssertEqual(deliveredMessage?["type"] as? String, "background-change")
+        XCTAssertEqual(deliveredMessage?["value"] as? Int, 17)
+        XCTAssertEqual(delivery?["senderId"] as? String, extensionID.rawValue)
+        XCTAssertEqual(delivery?["senderURL"] as? String, "floorp-extension://\(pageHost)/")
+        XCTAssertEqual(delivery?["senderPrivate"] as? Bool, false)
+        XCTAssertEqual(delivery?["hasTab"] as? Bool, false)
+        XCTAssertEqual(pageReply?["acknowledged"] as? String, "background-change")
+        XCTAssertEqual(commandReply?["backgroundDeliveryCount"] as? Int, 1)
+        XCTAssertTrue((commandReply?["senderURL"] as? String)?.hasSuffix("/ui/popup/index.html") == true)
+    }
+
+    func testBackgroundRuntimeMessageWithoutAPageResponseResolvesAsNoPayload() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "background-no-page-response-profile",
+            isPrivateBrowsing: false
+        )
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: .init(),
+            profileKey: profileKey
+        )
+        let package = try FloorpWebExtensionPagePackageGeneration(
+            extensionID: extensionID,
+            generation: "background-no-page-response-generation",
+            resourcePaths: ["ui/popup/index.html"]
+        )
+        let page = try FloorpWebExtensionPageViewController(
+            surface: .actionPopup,
+            package: package,
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: .init { _ in Data("<html><body>No listener</body></html>".utf8) },
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        page.loadViewIfNeeded()
+        try await waitForLoad(page.webView)
+
+        let background = try FloorpWebExtensionBackgroundBridgeIdentity(
+            profileKey: profileKey,
+            package: package,
+            originHost: "background-\(UUID().uuidString.lowercased())",
+            entryPath: "__floorp_background_no_response.html"
+        )
+        let backgroundConfiguration = WKWebViewConfiguration()
+        XCTAssertTrue(runtime.installBackgroundBridge(
+            background,
+            on: backgroundConfiguration.userContentController
+        ))
+        let sender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: profileKey,
+            packageGeneration: package.generation,
+            originHost: background.originHost
+        )
+        let payload = try FloorpWebExtensionMessagePayload(
+            jsonData: Data(#"{"type":"fire-and-forget"}"#.utf8)
+        )
+
+        let response = try await runtime.dispatchRuntimeMessage(payload, sender: sender)
+
+        XCTAssertNil(response)
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testBackgroundToPageDeliveryIsIsolatedByProfileGenerationAndRuntimeLifetime() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "broadcast-isolation-profile",
+            isPrivateBrowsing: false
+        )
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: .init(),
+            profileKey: profileKey
+        )
+        let firstPackage = try FloorpWebExtensionPagePackageGeneration(
+            extensionID: extensionID,
+            generation: "broadcast-generation-one",
+            resourcePaths: ["ui/popup/index.html"]
+        )
+        let resolver = FloorpWebExtensionPageResourceResolver { _ in
+            Data("<html><body>Broadcast isolation</body></html>".utf8)
+        }
+        let firstPage = try FloorpWebExtensionPageViewController(
+            surface: .actionPopup,
+            package: firstPackage,
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: resolver,
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        firstPage.loadViewIfNeeded()
+        try await waitForLoad(firstPage.webView)
+        _ = try await firstPage.webView.callAsyncJavaScript(
+            """
+            globalThis.deliveryCount = 0;
+            browser.runtime.onMessage.addListener(() => {
+              globalThis.deliveryCount += 1;
+              return {page: "first"};
+            });
+            """,
+            contentWorld: .page
+        )
+        let firstPageHost = try XCTUnwrap(firstPage.webView.url?.host)
+        let firstPageIdentity = try FloorpWebExtensionPageBridgeIdentity(
+            profileKey: profileKey,
+            package: firstPackage,
+            originHost: firstPageHost,
+            surface: .actionPopup
+        )
+        let duplicateReceiver = runtime.registerPageMessageReceiver(
+            firstPageIdentity,
+            webView: firstPage.webView
+        )
+        XCTAssertTrue(
+            duplicateReceiver === runtime.registerPageMessageReceiver(
+                firstPageIdentity,
+                webView: firstPage.webView
+            )
+        )
+        let firstBackground = try FloorpWebExtensionBackgroundBridgeIdentity(
+            profileKey: profileKey,
+            package: firstPackage,
+            originHost: "background-\(UUID().uuidString.lowercased())",
+            entryPath: "__floorp_background_first.html"
+        )
+        let firstBackgroundConfiguration = WKWebViewConfiguration()
+        XCTAssertTrue(runtime.installBackgroundBridge(
+            firstBackground,
+            on: firstBackgroundConfiguration.userContentController
+        ))
+        let payload = try FloorpWebExtensionMessagePayload(
+            jsonData: Data(#"{"type":"generation-change"}"#.utf8)
+        )
+        let firstSender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: profileKey,
+            packageGeneration: firstPackage.generation,
+            originHost: firstBackground.originHost
+        )
+
+        let directReply: FloorpWebExtensionMessagePayload?
+        do {
+            directReply = try await XCTUnwrap(duplicateReceiver).deliver(
+                payload,
+                sender: firstSender
+            )
+        } catch {
+            XCTFail("Direct page delivery failed: \(error)")
+            return
+        }
+        XCTAssertEqual(
+            try directReply?.decode([String: String].self),
+            ["page": "first"]
+        )
+        _ = try await firstPage.webView.callAsyncJavaScript(
+            "globalThis.deliveryCount = 0",
+            contentWorld: .page
+        )
+        let firstReply = try await runtime.dispatchRuntimeMessage(payload, sender: firstSender)
+        XCTAssertEqual(
+            try firstReply?.decode([String: String].self),
+            ["page": "first"]
+        )
+        let firstDeliveryCount = try await firstPage.webView.callAsyncJavaScript(
+            "return globalThis.deliveryCount",
+            contentWorld: .page
+        ) as? Int
+        XCTAssertEqual(firstDeliveryCount, 1)
+
+        let foreignSender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: .init(profileIdentifier: "foreign-profile", isPrivateBrowsing: false),
+            packageGeneration: firstPackage.generation,
+            originHost: firstBackground.originHost
+        )
+        do {
+            _ = try await runtime.dispatchRuntimeMessage(payload, sender: foreignSender)
+            XCTFail("Expected a foreign profile sender to be rejected")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionMessageError, .authenticationFailed)
+        }
+
+        let secondPackage = try FloorpWebExtensionPagePackageGeneration(
+            extensionID: extensionID,
+            generation: "broadcast-generation-two",
+            resourcePaths: ["ui/popup/index.html"]
+        )
+        let secondPage = try FloorpWebExtensionPageViewController(
+            surface: .options,
+            package: secondPackage,
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: resolver,
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        secondPage.loadViewIfNeeded()
+        try await waitForLoad(secondPage.webView)
+        _ = try await secondPage.webView.callAsyncJavaScript(
+            """
+            globalThis.deliveryCount = 0;
+            browser.runtime.onMessage.addListener(() => {
+              globalThis.deliveryCount += 1;
+              return {page: "second"};
+            });
+            """,
+            contentWorld: .page
+        )
+        let secondBackground = try FloorpWebExtensionBackgroundBridgeIdentity(
+            profileKey: profileKey,
+            package: secondPackage,
+            originHost: "background-\(UUID().uuidString.lowercased())",
+            entryPath: "__floorp_background_second.html"
+        )
+        let secondBackgroundConfiguration = WKWebViewConfiguration()
+        XCTAssertTrue(runtime.installBackgroundBridge(
+            secondBackground,
+            on: secondBackgroundConfiguration.userContentController
+        ))
+        let secondSender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: profileKey,
+            packageGeneration: secondPackage.generation,
+            originHost: secondBackground.originHost
+        )
+
+        let secondReply = try await runtime.dispatchRuntimeMessage(payload, sender: secondSender)
+        XCTAssertEqual(
+            try secondReply?.decode([String: String].self),
+            ["page": "second"]
+        )
+        let replacedPageDeliveryCount = try await firstPage.webView.callAsyncJavaScript(
+            "return globalThis.deliveryCount",
+            contentWorld: .page
+        ) as? Int
+        let secondPageDeliveryCount = try await secondPage.webView.callAsyncJavaScript(
+            "return globalThis.deliveryCount",
+            contentWorld: .page
+        ) as? Int
+        XCTAssertEqual(replacedPageDeliveryCount, 1)
+        XCTAssertEqual(secondPageDeliveryCount, 1)
+        do {
+            _ = try await runtime.dispatchRuntimeMessage(payload, sender: firstSender)
+            XCTFail("Expected the replaced generation sender to be rejected")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionMessageError, .authenticationFailed)
+        }
+
+        runtime.tearDown()
+        do {
+            _ = try await runtime.dispatchRuntimeMessage(payload, sender: secondSender)
+            XCTFail("Expected delivery after runtime teardown to be rejected")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionMessageError, .authenticationFailed)
+        }
+        let deliveryCountAfterTearDown = try await secondPage.webView.callAsyncJavaScript(
+            "return globalThis.deliveryCount",
+            contentWorld: .page
+        ) as? Int
+        XCTAssertEqual(deliveryCountAfterTearDown, 1)
+    }
+
+    func testReleasedExtensionPageStopsReceivingBackgroundMessages() async throws {
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "released-page-profile",
+            isPrivateBrowsing: false
+        )
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: .init(),
+            profileKey: profileKey
+        )
+        let package = try FloorpWebExtensionPagePackageGeneration(
+            extensionID: extensionID,
+            generation: "released-page-generation",
+            resourcePaths: ["ui/popup/index.html"]
+        )
+        let resolver = FloorpWebExtensionPageResourceResolver { _ in
+            Data("<html><body>Released page</body></html>".utf8)
+        }
+        var page: FloorpWebExtensionPageViewController? = try .init(
+            surface: .actionPopup,
+            package: package,
+            entryPoint: .init("ui/popup/index.html"),
+            resolver: resolver,
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+        page?.loadViewIfNeeded()
+        let orphanedWebView = try XCTUnwrap(page?.webView)
+        try await waitForLoad(orphanedWebView)
+        _ = try await orphanedWebView.callAsyncJavaScript(
+            """
+            globalThis.deliveryCount = 0;
+            browser.runtime.onMessage.addListener(() => {
+              globalThis.deliveryCount += 1;
+            });
+            """,
+            contentWorld: .page
+        )
+        weak var releasedPage = page
+        page = nil
+        XCTAssertNil(releasedPage)
+
+        let background = try FloorpWebExtensionBackgroundBridgeIdentity(
+            profileKey: profileKey,
+            package: package,
+            originHost: "background-\(UUID().uuidString.lowercased())",
+            entryPath: "__floorp_background_released.html"
+        )
+        let backgroundConfiguration = WKWebViewConfiguration()
+        XCTAssertTrue(runtime.installBackgroundBridge(
+            background,
+            on: backgroundConfiguration.userContentController
+        ))
+        let sender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: profileKey,
+            packageGeneration: package.generation,
+            originHost: background.originHost
+        )
+        let payload = try FloorpWebExtensionMessagePayload(
+            jsonData: Data(#"{"type":"after-page-release"}"#.utf8)
+        )
+
+        let response = try await runtime.dispatchRuntimeMessage(payload, sender: sender)
+
+        XCTAssertNil(response)
+        let orphanedDeliveryCount = try await orphanedWebView.callAsyncJavaScript(
+            "return globalThis.deliveryCount",
+            contentWorld: .page
+        ) as? Int
+        XCTAssertEqual(orphanedDeliveryCount, 0)
     }
 
     func testRuntimeTearDownInvalidatesBackgroundRegistrations() async throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPageHostTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPageHostTests.swift
@@ -314,6 +314,120 @@ final class FloorpWebExtensionPageHostTests: XCTestCase {
         XCTFail("The extension page ES module did not execute.")
     }
 
+    func testPageBridgeMapsDarkReaderWindowAndTabCreationToSafeSameSurfaceNavigation() async throws {
+        let package = try FloorpWebExtensionPagePackageGeneration(
+            extensionID: extensionID,
+            generation: "same-origin-navigation-generation",
+            resourcePaths: ["popup/index.html", "options/index.html", "devtools/index.html"]
+        )
+        let resources = [
+            "popup/index.html": Data("<!doctype html><body>Popup</body>".utf8),
+            "options/index.html": Data("<!doctype html><body>Options</body>".utf8),
+            "devtools/index.html": Data("<!doctype html><body>DevTools</body>".utf8)
+        ]
+        let profileKey = FloorpWebExtensionCoordinatorProfileKey(
+            profileIdentifier: "same-surface-navigation-profile",
+            isPrivateBrowsing: false
+        )
+        let runtime = FloorpWebExtensionMessageRuntime(
+            backgroundHost: .init(),
+            profileKey: profileKey
+        )
+        let controller = try FloorpWebExtensionPageViewController(
+            surface: .actionPopup,
+            package: package,
+            entryPoint: .init("popup/index.html"),
+            resolver: .init { request in resources[request.path] ?? Data() },
+            messageRuntime: runtime,
+            openExternal: { _ in }
+        )
+
+        controller.loadViewIfNeeded()
+        try await waitForLoad(controller.webView)
+        let initialHost = try XCTUnwrap(controller.webView.url?.host)
+        let discovery = try await controller.webView.callAsyncJavaScript(
+            """
+            const windowCount = await new Promise((resolve, reject) => {
+              chrome.windows.getAll({populate: true, windowTypes: ["popup"]}, (items) => {
+                if (chrome.runtime.lastError) reject(new Error(chrome.runtime.lastError.message));
+                else resolve(items.length);
+              });
+            });
+            const target = chrome.runtime.getURL("/options/index.html");
+            chrome.tabs.create({url: target});
+            window.close();
+            return {windowCount, target, windowsType: typeof chrome.windows};
+            """,
+            contentWorld: .page
+        ) as? [String: Any]
+        XCTAssertEqual(discovery?["windowCount"] as? Int, 0)
+        XCTAssertEqual(discovery?["windowsType"] as? String, "object")
+        XCTAssertEqual(
+            discovery?["target"] as? String,
+            "floorp-extension://\(initialHost)/options/index.html"
+        )
+
+        for _ in 0..<250 {
+            if !controller.webView.isLoading,
+               controller.webView.url?.path == "/options/index.html" {
+                XCTAssertEqual(controller.webView.url?.host, initialHost)
+                let body = try await controller.webView.callAsyncJavaScript(
+                    "return document.body.textContent",
+                    contentWorld: .page
+                ) as? String
+                XCTAssertEqual(body, "Options")
+                break
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertEqual(controller.webView.url?.path, "/options/index.html")
+
+        let rejected = try await controller.webView.callAsyncJavaScript(
+            """
+            const candidates = [
+              "https://example.com/",
+              `floorp-extension://different-origin/options/index.html`,
+              `${chrome.runtime.getURL("/devtools/index.html")}?remote=1`
+            ];
+            const results = [];
+            for (const url of candidates) {
+              try {
+                await chrome.windows.create({type: "popup", url});
+                results.push("resolved");
+              } catch (_) {
+                results.push("rejected");
+              }
+            }
+            return {results, href: globalThis.location.href};
+            """,
+            contentWorld: .page
+        ) as? [String: Any]
+        XCTAssertEqual(rejected?["results"] as? [String], ["rejected", "rejected", "rejected"])
+        XCTAssertEqual(
+            rejected?["href"] as? String,
+            "floorp-extension://\(initialHost)/options/index.html"
+        )
+
+        _ = try await controller.webView.callAsyncJavaScript(
+            """
+            const target = chrome.runtime.getURL("/devtools/index.html");
+            chrome.windows.create({type: "popup", url: target, width: 800, height: 600});
+            window.close();
+            return target;
+            """,
+            contentWorld: .page
+        )
+        for _ in 0..<250 {
+            if !controller.webView.isLoading,
+               controller.webView.url?.path == "/devtools/index.html" {
+                break
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertEqual(controller.webView.url?.host, initialHost)
+        XCTAssertEqual(controller.webView.url?.path, "/devtools/index.html")
+    }
+
     func testActionPopupFactoryUsesDefaultAndDisabledStatesWithoutOpeningAPage() throws {
         let package = try makeInstalledPackage(resourcePaths: ["popup/index.html"])
         let popup = try FloorpWebExtensionActionResource("popup/index.html")


### PR DESCRIPTION
## :scroll: Tickets

- Jira: N/A — user-reported Dark Reader follow-up regression
- GitHub issue: N/A

## :bulb: Description

Fixes three remaining Dark Reader failures on iOS:

- ordinary HTTP(S) pages were still presented to the popup as `about:` when fresh site access had not been granted;
- On/Off changed the page but the open popup kept its stale status;
- Settings did not respond because Dark Reader expects desktop `windows` and `tabs.create` behavior.

The action menu now presents product-owned site-access consent for the exact selected tab, preserves existing selected-site grants, applies one-use generation-bound authorization, reloads the already-open page, and then opens the popup. Normal and Private Browsing grants remain separate.

Authenticated background runtime messages now broadcast to open extension pages of the same profile, extension, generation, and background origin. Existing page-to-background response semantics remain unchanged, while no-response listeners no longer mask later page responses.

For popup/options pages only, same-origin package `tabs.create` / `windows.create` calls are mapped to navigation in the existing authenticated WebView. External, cross-origin, credentialed, port-bearing, queried, and non-inventoried package URLs continue to fail closed.

Known compatibility limits outside this hotfix:

- multi-window `tabs.query({lastFocusedWindow: true})` semantics are not yet modeled;
- Dark Reader DevTools data exceeds the current 48 KiB message limit;
- the unchanged signed catalog expires on 2026-09-11T16:08:02Z and needs an independent re-sign before long-running external cohorts rely on fresh installation or first grant.

Validation:

- 37 MessageRuntime/PageHost XCTest cases passed, 0 failures.
- 7 site-access and lifecycle-authorization XCTest cases passed, 0 failures.
- 18 catalog build/functional/documentation/provenance tests passed.
- Signed catalog release verification passed for all 17 unchanged packages.
- `swiftc -frontend -parse`, `git diff --check`, and `npm run build` passed.
- iPhone 17 / iOS 26.5 Simulator build and launch passed. `example.com` rendered dark and the popup showed `example.com` with `Extension is enabled`.

## :movie_camera: Demos

| Before | After |
| - | - |
| Popup shows `about:` or stale Off status | Popup identifies `example.com` and receives live background changes |
| Freshly denied site access leaves an existing page unmodified | Explicit site consent updates the grant and reloads the selected page |
| Settings does nothing | Settings navigates to the same authenticated package surface |

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our PR naming guidelines
- [x] I ensured unit tests pass and wrote tests for new code
- [x] If working on UI, I checked accessibility (the new consent uses a standard UIAlertController)
- [x] If adding telemetry, I read the data stewardship requirements (N/A: no telemetry)
- [ ] If adding or modifying strings, I read the guidelines and will request a string review (the current WebExtension settings surface remains English-only)
- [x] If needed, I updated documentation and added comments to complex code
