### PR TITLE
Improve extension permissions and Dark Reader integration

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -636,6 +636,27 @@ final class BrowserCoordinator: BaseCoordinator,
         let iconData: Data?
     }
 
+    @MainActor
+    private final class FloorpWebExtensionPromptDismissalWaiter {
+        private var isDismissed = false
+        private var continuations = [CheckedContinuation<Void, Never>]()
+
+        func wait() async {
+            guard !isDismissed else { return }
+            await withCheckedContinuation { continuation in
+                continuations.append(continuation)
+            }
+        }
+
+        func signal() {
+            guard !isDismissed else { return }
+            isDismissed = true
+            let pending = continuations
+            continuations.removeAll()
+            pending.forEach { $0.resume() }
+        }
+    }
+
     enum FloorpWebExtensionActionSiteAccessChoice: Equatable {
         case currentSite
         case allRequestedSites
@@ -701,6 +722,29 @@ final class BrowserCoordinator: BaseCoordinator,
             },
             isPrivateBrowsing: isPrivateBrowsing
         )
+    }
+
+    /// Revalidates the scope represented by the user's choice without tying
+    /// consent to a raw URL string. Redirects, query changes, and same-site
+    /// history updates remain valid; a navigation outside the selected or
+    /// manifest-requested scope does not.
+    static func webExtensionActionConsentRemainsValid(
+        currentURL: URL?,
+        requestedHosts: Set<FloorpWebExtensionMatchPattern>,
+        access: FloorpWebExtensionHostAccess
+    ) -> Bool {
+        guard let currentURL,
+              requestedHosts.contains(where: { $0.matches(currentURL) }) else {
+            return false
+        }
+        switch access {
+        case .denied:
+            return false
+        case .selectedSites(let sites):
+            return sites.contains(where: { $0.matches(currentURL) })
+        case .allRequestedSites:
+            return true
+        }
     }
 
     private static func currentSitePattern(
@@ -788,18 +832,24 @@ final class BrowserCoordinator: BaseCoordinator,
             choices: choices,
             accessibilityIdentifier: "Floorp.WebExtensions.ActionPicker"
         )
-        presentWebExtensionPrompt(prompt) { [weak self] identifier in
-            guard let popup = popups.first(where: { $0.package.extensionID.rawValue == identifier }) else {
-                return
+        var selectedPopup: FloorpWebExtensionActionPopup?
+        presentWebExtensionPrompt(
+            prompt,
+            onDismiss: { [weak self] in
+                guard let popup = selectedPopup else { return }
+                self?.presentWebExtensionActionPopup(
+                    popup,
+                    resolver: resolver,
+                    messageRuntime: messageRuntime,
+                    packageManager: packageManager,
+                    selectedTab: selectedTab,
+                    isPrivateBrowsing: isPrivateBrowsing
+                )
             }
-            self?.presentWebExtensionActionPopup(
-                popup,
-                resolver: resolver,
-                messageRuntime: messageRuntime,
-                packageManager: packageManager,
-                selectedTab: selectedTab,
-                isPrivateBrowsing: isPrivateBrowsing
-            )
+        ) { identifier in
+            selectedPopup = popups.first {
+                $0.package.extensionID.rawValue == identifier
+            }
         }
     }
 
@@ -813,12 +863,10 @@ final class BrowserCoordinator: BaseCoordinator,
     ) {
         guard tabManager.selectedTab === selectedTab,
               selectedTab.isPrivate == isPrivateBrowsing else { return }
-        let consentedURL = selectedTab.url
         Task { [weak self, weak selectedTab, packageManager] in
             guard let self, let selectedTab else { return }
             await self.prepareWebExtensionActionPopup(
                 popup,
-                consentedURL: consentedURL,
                 resolver: resolver,
                 messageRuntime: messageRuntime,
                 packageManager: packageManager,
@@ -830,7 +878,6 @@ final class BrowserCoordinator: BaseCoordinator,
 
     private func prepareWebExtensionActionPopup(
         _ popup: FloorpWebExtensionActionPopup,
-        consentedURL: URL?,
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,
         packageManager: FloorpWebExtensionLivePackageManager,
@@ -844,8 +891,7 @@ final class BrowserCoordinator: BaseCoordinator,
             )
             guard !Task.isCancelled,
                   tabManager.selectedTab === selectedTab,
-                  selectedTab.isPrivate == isPrivateBrowsing,
-                  selectedTab.url == consentedURL else { return }
+                  selectedTab.isPrivate == isPrivateBrowsing else { return }
             guard !isPrivateBrowsing || context.package.grants.privateBrowsingEnabled else {
                 presentWebExtensionActionsUnavailable()
                 return
@@ -859,8 +905,9 @@ final class BrowserCoordinator: BaseCoordinator,
             let hostAccess = isPrivateBrowsing
                 ? context.package.grants.privateHostAccess
                 : context.package.grants.normalHostAccess
+            let currentURL = selectedTab.url
             if let accessPlan = Self.webExtensionActionSiteAccessPlan(
-                currentURL: consentedURL,
+                currentURL: currentURL,
                 requestedHosts: context.package.grants.requestedHosts,
                 hostAccess: hostAccess,
                 isPrivateBrowsing: isPrivateBrowsing
@@ -868,7 +915,6 @@ final class BrowserCoordinator: BaseCoordinator,
                 presentWebExtensionActionSiteAccess(
                     accessPlan,
                     authorization: context.authorization,
-                    consentedURL: consentedURL,
                     popup: currentPopup,
                     resolver: resolver,
                     messageRuntime: messageRuntime,
@@ -895,7 +941,6 @@ final class BrowserCoordinator: BaseCoordinator,
     private func presentWebExtensionActionSiteAccess(
         _ plan: FloorpWebExtensionActionSiteAccessPlan,
         authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
-        consentedURL: URL?,
         popup: FloorpWebExtensionActionPopup,
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,
@@ -951,18 +996,22 @@ final class BrowserCoordinator: BaseCoordinator,
             choices: choices,
             accessibilityIdentifier: "Floorp.WebExtensions.ActionSiteAccessConsent"
         )
-        presentWebExtensionPrompt(prompt) { [weak self] identifier in
+        let dismissalWaiter = FloorpWebExtensionPromptDismissalWaiter()
+        presentWebExtensionPrompt(
+            prompt,
+            onDismiss: { dismissalWaiter.signal() }
+        ) { [weak self] identifier in
             guard let access = accesses[identifier] else { return }
             self?.applyWebExtensionActionSiteAccess(
                 access,
                 authorization: authorization,
-                consentedURL: consentedURL,
                 popup: popup,
                 resolver: resolver,
                 messageRuntime: messageRuntime,
                 packageManager: packageManager,
                 selectedTab: selectedTab,
-                isPrivateBrowsing: isPrivateBrowsing
+                isPrivateBrowsing: isPrivateBrowsing,
+                dismissalWaiter: dismissalWaiter
             )
         }
     }
@@ -970,29 +1019,28 @@ final class BrowserCoordinator: BaseCoordinator,
     private func applyWebExtensionActionSiteAccess(
         _ access: FloorpWebExtensionHostAccess,
         authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
-        consentedURL: URL?,
         popup: FloorpWebExtensionActionPopup,
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,
         packageManager: FloorpWebExtensionLivePackageManager,
         selectedTab: Tab,
-        isPrivateBrowsing: Bool
+        isPrivateBrowsing: Bool,
+        dismissalWaiter: FloorpWebExtensionPromptDismissalWaiter
     ) {
         guard tabManager.selectedTab === selectedTab,
-              selectedTab.isPrivate == isPrivateBrowsing,
-              selectedTab.url == consentedURL else { return }
+              selectedTab.isPrivate == isPrivateBrowsing else { return }
         Task { [weak self, weak selectedTab, packageManager] in
             guard let self, let selectedTab else { return }
             await self.commitWebExtensionActionSiteAccess(
                 access,
                 authorization: authorization,
-                consentedURL: consentedURL,
                 popup: popup,
                 resolver: resolver,
                 messageRuntime: messageRuntime,
                 packageManager: packageManager,
                 selectedTab: selectedTab,
-                isPrivateBrowsing: isPrivateBrowsing
+                isPrivateBrowsing: isPrivateBrowsing,
+                dismissalWaiter: dismissalWaiter
             )
         }
     }
@@ -1000,13 +1048,13 @@ final class BrowserCoordinator: BaseCoordinator,
     private func commitWebExtensionActionSiteAccess(
         _ access: FloorpWebExtensionHostAccess,
         authorization: FloorpWebExtensionLivePackageManager.PermissionMutationAuthorization,
-        consentedURL: URL?,
         popup: FloorpWebExtensionActionPopup,
         resolver: FloorpWebExtensionPageResourceResolver,
         messageRuntime: FloorpWebExtensionMessageRuntime,
         packageManager: FloorpWebExtensionLivePackageManager,
         selectedTab: Tab,
-        isPrivateBrowsing: Bool
+        isPrivateBrowsing: Bool,
+        dismissalWaiter: FloorpWebExtensionPromptDismissalWaiter
     ) async {
         do {
             let previousGrants = popup.package.grants
@@ -1017,29 +1065,51 @@ final class BrowserCoordinator: BaseCoordinator,
                 privateHostAccess: isPrivateBrowsing ? access : previousGrants.privateHostAccess,
                 privateBrowsingEnabled: previousGrants.privateBrowsingEnabled
             )
-            try await packageManager.updateGrants(
+            let updatedPackage = try await packageManager.updateGrants(
                 replacement,
                 authorization: authorization
             ) { [weak self, weak selectedTab] in
                 guard let self, let selectedTab else { return false }
+                // The payload is the immutable scope the user just approved.
+                // A page can redirect or briefly report an intermediate URL
+                // while the native sheet is dismissing; that must not erase
+                // explicit consent. Keep the mutation bound to the same tab
+                // and profile here, then re-check the live URL below before
+                // reloading or opening extension UI on that page.
                 return self.tabManager.selectedTab === selectedTab &&
-                    selectedTab.isPrivate == isPrivateBrowsing &&
-                    selectedTab.url == consentedURL
+                    selectedTab.isPrivate == isPrivateBrowsing
             }
+            let effectiveAccess = isPrivateBrowsing
+                ? updatedPackage.grants.privateHostAccess
+                : updatedPackage.grants.normalHostAccess
+            guard effectiveAccess == access else {
+                throw FloorpWebExtensionPackageStoreError.corruptedRegistry
+            }
+            await dismissalWaiter.wait()
             guard !Task.isCancelled,
                   tabManager.selectedTab === selectedTab,
                   selectedTab.isPrivate == isPrivateBrowsing,
-                  selectedTab.url == consentedURL else { return }
+                  Self.webExtensionActionConsentRemainsValid(
+                    currentURL: selectedTab.url,
+                    requestedHosts: updatedPackage.grants.requestedHosts,
+                    access: access
+                  ) else { return }
             // User-script policy is fixed before a document load. Reload
             // so this already-open page receives the newly authorized policy.
             selectedTab.reload()
             presentWebExtensionActionPage(
-                popup,
+                .init(
+                    package: updatedPackage,
+                    actionState: popup.actionState,
+                    title: popup.title,
+                    iconData: popup.iconData
+                ),
                 resolver: resolver,
                 messageRuntime: messageRuntime,
                 isPrivateBrowsing: isPrivateBrowsing
             )
         } catch {
+            await dismissalWaiter.wait()
             presentWebExtensionActionsAlert(
                 title: FloorpStrings.WebExtensions.siteAccessChangeErrorTitle,
                 message: error.localizedDescription
@@ -1082,13 +1152,15 @@ final class BrowserCoordinator: BaseCoordinator,
 
     private func presentWebExtensionPrompt(
         _ presentation: FloorpWebExtensionPromptPresentation,
+        onDismiss: @escaping FloorpWebExtensionPromptViewController.DismissHandler = {},
         onChoice: @escaping FloorpWebExtensionPromptViewController.ChoiceHandler
     ) {
         let controller = FloorpWebExtensionPromptViewController(
             presentation: presentation,
             windowUUID: windowUUID,
             themeManager: themeManager,
-            onChoice: onChoice
+            onChoice: onChoice,
+            onDismiss: onDismiss
         )
         controller.sheetPresentationController?.detents = [.medium(), .large()]
         controller.sheetPresentationController?.prefersGrabberVisible = true

--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -593,6 +593,7 @@ final class BrowserCoordinator: BaseCoordinator,
         let resolver = store.makePageResourceResolver()
         Task { [weak self, store, packageManager, apiHost, messageRuntime, selectedTab] in
             let packages = await store.installedPackages()
+            let catalogItems = await packageManager.catalogItems()
             var popups = [FloorpWebExtensionActionPopup]()
             for package in packages where package.isEnabled {
                 if isPrivateBrowsing && !package.grants.privateBrowsingEnabled {
@@ -601,7 +602,8 @@ final class BrowserCoordinator: BaseCoordinator,
                 let persistedState = await apiHost.actions.state(for: package.extensionID)
                 if let popup = Self.actionPopup(
                     for: package,
-                    persistedState: persistedState
+                    persistedState: persistedState,
+                    iconData: catalogItems.first(where: { $0.id == package.extensionID })?.iconData
                 ) {
                     popups.append(popup)
                 }
@@ -631,6 +633,7 @@ final class BrowserCoordinator: BaseCoordinator,
         let package: FloorpWebExtensionInstalledPackage
         let actionState: FloorpWebExtensionActionState
         let title: String
+        let iconData: Data?
     }
 
     enum FloorpWebExtensionActionSiteAccessChoice: Equatable {
@@ -713,7 +716,8 @@ final class BrowserCoordinator: BaseCoordinator,
 
     private static func actionPopup(
         for package: FloorpWebExtensionInstalledPackage,
-        persistedState: FloorpWebExtensionActionState
+        persistedState: FloorpWebExtensionActionState,
+        iconData: Data?
     ) -> FloorpWebExtensionActionPopup? {
         var actionState = persistedState
         let manifestAction = package.preflight.manifest.action
@@ -728,14 +732,15 @@ final class BrowserCoordinator: BaseCoordinator,
         return .init(
             package: package,
             actionState: actionState,
-            title: actionState.title ?? package.name
+            title: actionState.title ?? package.name,
+            iconData: iconData
         )
     }
 
     private func presentWebExtensionActionsUnavailable() {
         presentWebExtensionActionsAlert(
-            title: "Extensions unavailable",
-            message: "Extension actions are not ready for this browsing profile."
+            title: FloorpStrings.WebExtensions.loadErrorTitle,
+            message: FloorpStrings.WebExtensions.actionsUnavailableMessage
         )
     }
 
@@ -749,8 +754,8 @@ final class BrowserCoordinator: BaseCoordinator,
     ) {
         guard !popups.isEmpty else {
             presentWebExtensionActionsAlert(
-                title: "Extensions",
-                message: "No extension actions are available for this tab."
+                title: FloorpStrings.WebExtensions.actions,
+                message: FloorpStrings.WebExtensions.noActionsAvailableMessage
             )
             return
         }
@@ -765,29 +770,37 @@ final class BrowserCoordinator: BaseCoordinator,
             )
             return
         }
-        let alert = UIAlertController(
-            title: "Extensions",
-            message: "Choose an extension action.",
-            preferredStyle: .actionSheet
-        )
-        for popup in popups {
-            alert.addAction(UIAlertAction(title: popup.title, style: .default) { [weak self] _ in
-                self?.presentWebExtensionActionPopup(
-                    popup,
-                    resolver: resolver,
-                    messageRuntime: messageRuntime,
-                    packageManager: packageManager,
-                    selectedTab: selectedTab,
-                    isPrivateBrowsing: isPrivateBrowsing
+        let choices = popups.map { popup in
+            FloorpWebExtensionPromptPresentation.Choice(
+                identifier: popup.package.extensionID.rawValue,
+                title: popup.title,
+                detail: FloorpStrings.WebExtensions.version(popup.package.version),
+                icon: .extensionIcon(
+                    id: popup.package.extensionID,
+                    data: popup.iconData
                 )
-            })
+            )
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = browserViewController.view
-            popover.sourceRect = browserViewController.view.bounds
+        let prompt = FloorpWebExtensionPromptPresentation(
+            title: FloorpStrings.WebExtensions.actions,
+            message: FloorpStrings.WebExtensions.chooseActionMessage,
+            heroIcon: .system("puzzlepiece.extension.fill"),
+            choices: choices,
+            accessibilityIdentifier: "Floorp.WebExtensions.ActionPicker"
+        )
+        presentWebExtensionPrompt(prompt) { [weak self] identifier in
+            guard let popup = popups.first(where: { $0.package.extensionID.rawValue == identifier }) else {
+                return
+            }
+            self?.presentWebExtensionActionPopup(
+                popup,
+                resolver: resolver,
+                messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
+                isPrivateBrowsing: isPrivateBrowsing
+            )
         }
-        present(alert)
     }
 
     private func presentWebExtensionActionPopup(
@@ -840,7 +853,8 @@ final class BrowserCoordinator: BaseCoordinator,
             let currentPopup = FloorpWebExtensionActionPopup(
                 package: context.package,
                 actionState: popup.actionState,
-                title: popup.title
+                title: popup.title,
+                iconData: popup.iconData
             )
             let hostAccess = isPrivateBrowsing
                 ? context.package.grants.privateHostAccess
@@ -872,7 +886,7 @@ final class BrowserCoordinator: BaseCoordinator,
             }
         } catch {
             presentWebExtensionActionsAlert(
-                title: "Extension action could not open",
+                title: FloorpStrings.WebExtensions.actionOpenErrorTitle,
                 message: error.localizedDescription
             )
         }
@@ -889,61 +903,68 @@ final class BrowserCoordinator: BaseCoordinator,
         selectedTab: Tab,
         isPrivateBrowsing: Bool
     ) {
-        var message = [
-            "This extension cannot read or change the current page until you allow site access.",
-            "The page will reload after access is allowed."
-        ].joined(separator: " ")
+        var messageParts = [
+            FloorpStrings.WebExtensions.actionSiteAccessMessage,
+            FloorpStrings.WebExtensions.actionSiteAccessReloadMessage
+        ]
         if plan.requestsEveryWebsite {
-            message += " All requested sites include every HTTP and HTTPS website."
+            messageParts.append(FloorpStrings.WebExtensions.actionAllWebsitesMessage)
         } else if plan.requestedSiteCount > 1 {
-            message += " This extension requested access to \(plan.requestedSiteCount) site patterns."
+            messageParts.append(
+                FloorpStrings.WebExtensions.actionRequestedSiteCount(plan.requestedSiteCount)
+            )
         }
         if plan.isPrivateBrowsing {
-            message += " This choice applies only in Private Browsing."
+            messageParts.append(FloorpStrings.WebExtensions.actionPrivateScopeMessage)
         }
-        let alert = UIAlertController(
-            title: "Allow site access for \(popup.title)?",
-            message: message,
-            preferredStyle: .actionSheet
-        )
-        alert.view.accessibilityIdentifier = "Floorp.WebExtensions.ActionSiteAccessConsent"
+        var choices = [FloorpWebExtensionPromptPresentation.Choice]()
+        var accesses = [String: FloorpWebExtensionHostAccess]()
         if let currentHost = plan.currentHost,
            let access = plan.access(for: .currentSite) {
-            alert.addAction(UIAlertAction(title: "Allow on \(currentHost)", style: .default) { [weak self] _ in
-                self?.applyWebExtensionActionSiteAccess(
-                    access,
-                    authorization: authorization,
-                    consentedURL: consentedURL,
-                    popup: popup,
-                    resolver: resolver,
-                    messageRuntime: messageRuntime,
-                    packageManager: packageManager,
-                    selectedTab: selectedTab,
-                    isPrivateBrowsing: isPrivateBrowsing
-                )
-            })
+            let identifier = "currentSite"
+            accesses[identifier] = access
+            choices.append(.init(
+                identifier: identifier,
+                title: FloorpStrings.WebExtensions.allowOnSite(currentHost),
+                detail: FloorpStrings.WebExtensions.onlyThisWebsite,
+                icon: .system("globe")
+            ))
         }
         if let access = plan.access(for: .allRequestedSites) {
-            alert.addAction(UIAlertAction(title: "Allow on All Requested Sites", style: .default) { [weak self] _ in
-                self?.applyWebExtensionActionSiteAccess(
-                    access,
-                    authorization: authorization,
-                    consentedURL: consentedURL,
-                    popup: popup,
-                    resolver: resolver,
-                    messageRuntime: messageRuntime,
-                    packageManager: packageManager,
-                    selectedTab: selectedTab,
-                    isPrivateBrowsing: isPrivateBrowsing
-                )
-            })
+            let identifier = "allRequestedSites"
+            accesses[identifier] = access
+            choices.append(.init(
+                identifier: identifier,
+                title: FloorpStrings.WebExtensions.allowOnAllRequestedSites,
+                detail: FloorpStrings.WebExtensions.allRequestedSites(plan.requestedSiteCount),
+                icon: .system("globe.americas.fill"),
+                role: .preferred
+            ))
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = browserViewController.view
-            popover.sourceRect = browserViewController.view.bounds
+        let prompt = FloorpWebExtensionPromptPresentation(
+            title: FloorpStrings.WebExtensions.actionSiteAccessTitle(name: popup.title),
+            message: messageParts.joined(separator: " "),
+            heroIcon: .extensionIcon(
+                id: popup.package.extensionID,
+                data: popup.iconData
+            ),
+            choices: choices,
+            accessibilityIdentifier: "Floorp.WebExtensions.ActionSiteAccessConsent"
+        )
+        presentWebExtensionPrompt(prompt) { [weak self] identifier in
+            guard let access = accesses[identifier] else { return }
+            self?.applyWebExtensionActionSiteAccess(
+                access,
+                authorization: authorization,
+                consentedURL: consentedURL,
+                popup: popup,
+                resolver: resolver,
+                messageRuntime: messageRuntime,
+                packageManager: packageManager,
+                selectedTab: selectedTab,
+                isPrivateBrowsing: isPrivateBrowsing
+            )
         }
-        present(alert)
     }
 
     private func applyWebExtensionActionSiteAccess(
@@ -1020,7 +1041,7 @@ final class BrowserCoordinator: BaseCoordinator,
             )
         } catch {
             presentWebExtensionActionsAlert(
-                title: "Site access could not be changed",
+                title: FloorpStrings.WebExtensions.siteAccessChangeErrorTitle,
                 message: error.localizedDescription
             )
         }
@@ -1053,15 +1074,30 @@ final class BrowserCoordinator: BaseCoordinator,
             present(navigationController)
         } catch {
             presentWebExtensionActionsAlert(
-                title: "Extension action could not open",
+                title: FloorpStrings.WebExtensions.actionOpenErrorTitle,
                 message: error.localizedDescription
             )
         }
     }
 
+    private func presentWebExtensionPrompt(
+        _ presentation: FloorpWebExtensionPromptPresentation,
+        onChoice: @escaping FloorpWebExtensionPromptViewController.ChoiceHandler
+    ) {
+        let controller = FloorpWebExtensionPromptViewController(
+            presentation: presentation,
+            windowUUID: windowUUID,
+            themeManager: themeManager,
+            onChoice: onChoice
+        )
+        controller.sheetPresentationController?.detents = [.medium(), .large()]
+        controller.sheetPresentationController?.prefersGrabberVisible = true
+        present(controller)
+    }
+
     private func presentWebExtensionActionsAlert(title: String, message: String) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.done, style: .default))
         present(alert)
     }
 

--- a/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
+++ b/firefox-ios/Client/Frontend/Browser/BrowserViewController/Views/BrowserViewController.swift
@@ -4553,9 +4553,6 @@ extension BrowserViewController: LegacyTabDelegate {
         let printHelper = PrintHelper(tab: tab)
         tab.addContentScriptToPage(printHelper, name: PrintHelper.name())
 
-        let nightModeHelper = NightModeHelper()
-        tab.addContentScriptToCustomWorld(nightModeHelper, name: NightModeHelper.name())
-
         // XXX: Bug 1390200 - Disable NSUserActivity/CoreSpotlight temporarily
         // let spotlightHelper = SpotlightHelper(tab: tab)
         // tab.addHelper(spotlightHelper, name: SpotlightHelper.name())

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -26,6 +26,7 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
         static let avatarCircle = StandardImageIdentifiers.Large.avatarCircle
         static let share = StandardImageIdentifiers.Large.shareApple
         static let reportBrokenSite = StandardImageIdentifiers.Large.report
+        static let extensionActions = StandardImageIdentifiers.Large.lightning
     }
 
     private var isReportBrokenSiteOn: Bool {
@@ -227,12 +228,12 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
     private func getWebExtensionsSection(with uuid: WindowUUID, tabInfo: MainMenuTabInfo) -> MenuSection {
         MenuSection(options: [
             MenuElement(
-                title: "Extensions",
-                iconName: Icons.settings,
+                title: FloorpStrings.WebExtensions.actions,
+                iconName: Icons.extensionActions,
                 isEnabled: true,
                 isActive: false,
-                a11yLabel: "Extensions",
-                a11yHint: "Open extension actions",
+                a11yLabel: FloorpStrings.WebExtensions.actions,
+                a11yHint: FloorpStrings.WebExtensions.actionsAccessibilityHint,
                 a11yId: "Floorp.WebExtensions.Browser.Actions",
                 action: {
                     store.dispatch(

--- a/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
+++ b/firefox-ios/Client/Frontend/Browser/MainMenu/MainMenuConfigurationUtility.swift
@@ -295,7 +295,6 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                 options.append(configureReaderViewItem(with: uuid, tabInfo: tabInfo))
             }
             options.append(contentsOf: [
-                configureWebsiteDarkModeItem(with: uuid, and: tabInfo),
                 configureShortcutsItem(with: uuid, and: tabInfo),
                 MenuElement(
                     title: .MainMenu.Submenus.Save.SaveAsPDF,
@@ -643,38 +642,6 @@ struct MainMenuConfigurationUtility: Equatable, FeatureFlaggable {
                         windowUUID: uuid,
                         actionType: MainMenuActionType.tapZoom,
                         telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage)
-                    )
-                )
-            }
-        )
-    }
-
-    private func configureWebsiteDarkModeItem(
-        with uuid: WindowUUID,
-        and tabInfo: MainMenuTabInfo
-    ) -> MenuElement {
-        typealias A11y = String.MainMenu.Submenus.Tools.AccessibilityLabels
-        typealias Tools = String.MainMenu.Submenus.Tools
-
-        let nightModeIsOn = NightModeHelper.isActivated()
-
-        return MenuElement(
-            title: .MainMenu.Submenus.Tools.WebsiteDarkMode,
-            iconName: "",
-            isEnabled: true,
-            isActive: nightModeIsOn,
-            a11yLabel: .MainMenu.ToolsSection.AccessibilityLabels.WebsiteDarkMode,
-            a11yHint: nightModeIsOn ? Tools.WebsiteDarkModeOn : Tools.WebsiteDarkModeOff,
-            a11yId: AccessibilityIdentifiers.MainMenu.nightMode,
-            isOptional: true,
-            infoTitle: nightModeIsOn ? Tools.WebsiteDarkModeOn : Tools.WebsiteDarkModeOff,
-            action: {
-                store.dispatch(
-                    MainMenuAction(
-                        windowUUID: uuid,
-                        actionType: MainMenuActionType.tapToggleNightMode,
-                        telemetryInfo: TelemetryInfo(isHomepage: tabInfo.isHomepage,
-                                                     isActionOn: nightModeIsOn)
                     )
                 )
             }

--- a/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
+++ b/firefox-ios/Client/Frontend/Settings/AppearanceSettings/AppearanceSettingsView.swift
@@ -56,9 +56,6 @@ struct AppearanceSettingsView: View {
                     cornerRadius: UX.cornerRadius
                 )
 
-                // Section for toggling website appearance (e.g., dark mode).
-                WebsiteAppearanceSection(theme: currentTheme, onChange: setWebsiteDarkMode, cornerRadius: UX.cornerRadius)
-
                 PageZoomSection(theme: currentTheme, cornerRadius: UX.cornerRadius) {
                     delegate?.pressedPageZoom()
                 }
@@ -100,28 +97,6 @@ struct AppearanceSettingsView: View {
         }
     }
 
-    private struct WebsiteAppearanceSection: View {
-        let theme: Theme?
-        let onChange: (Bool) -> Void
-        let cornerRadius: CGFloat
-
-        var body: some View {
-            GenericSectionView(
-                theme: theme,
-                title: String.WebsiteAppearanceSectionHeader,
-                description: String.WebsiteDarkModeDescription,
-                identifier: AccessibilityIdentifiers.Settings.Appearance.websiteAppearanceSectionTitle
-            ) {
-                DarkModeToggleView(
-                    theme: theme,
-                    isEnabled: NightModeHelper.isActivated(),
-                    onChange: onChange
-                )
-                .modifier(SectionStyle(theme: theme, cornerRadius: cornerRadius))
-            }
-        }
-    }
-
     private struct PageZoomSection: View {
         let theme: Theme?
         let cornerRadius: CGFloat
@@ -152,17 +127,6 @@ struct AppearanceSettingsView: View {
         themeManager.setSystemTheme(isOn: isAutomatic)
         if !isAutomatic {
             themeManager.setManualTheme(to: selectedOption == .light ? .light : .dark)
-        }
-    }
-
-    /// Toggles the website dark mode.
-    /// - Parameter isOn: A Boolean indicating whether dark mode is enabled for websites.
-    private func setWebsiteDarkMode(_ isOn: Bool) {
-        NightModeHelper.toggle()
-        if NightModeHelper.isActivated() {
-            // TODO(FXIOS-11584): Add telemetry here
-        } else {
-            // TODO(FXIOS-11584): Add telemetry here
         }
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/NightModeHelper.swift
@@ -18,29 +18,26 @@ class NightModeHelper: TabContentScript {
     }
 
     func scriptMessageHandlerNames() -> [String]? {
-        return ["NightMode"]
-    }
-
-    static func jsCallbackBuilder(_ enabled: Bool) -> String {
-        return "window.__firefox__.NightMode.setEnabled(\(enabled))"
+        return []
     }
 
     func userContentController(
         _ userContentController: WKUserContentController,
         didReceiveScriptMessage message: WKScriptMessage
     ) {
-        guard let webView = message.frameInfo.webView else { return }
-        webView.evaluateJavascriptInCustomContentWorld(
-            NightModeHelper.jsCallbackBuilder(NightModeHelper.isActivated()),
-            in: .world(name: NightModeHelper.name())
-        )
+        // Retained as a no-op for source compatibility. Floorp uses the
+        // curated Dark Reader extension for website darkening.
+    }
+
+    static func jsCallbackBuilder(_ enabled: Bool) -> String {
+        return "window.__firefox__.NightMode.setEnabled(\(enabled))"
     }
 
     @MainActor
     static func toggle(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard
     ) {
-        setNightMode(userDefaults, enabled: !NightModeHelper.isActivated())
+        setNightMode(userDefaults, enabled: false)
     }
 
     @MainActor
@@ -48,18 +45,20 @@ class NightModeHelper: TabContentScript {
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard,
         enabled: Bool
     ) {
-        userDefaults.set(enabled, forKey: NightModeKeys.Status)
+        _ = enabled
+        userDefaults.set(false, forKey: NightModeKeys.Status)
         let windowManager: WindowManager = AppContainer.shared.resolve()
         for tabManager in windowManager.allWindowTabManagers() {
             for tab in tabManager.tabs {
-                tab.nightMode = enabled
-                tab.webView?.scrollView.indicatorStyle = enabled ? .white : .default
+                tab.nightMode = false
+                tab.webView?.scrollView.indicatorStyle = .default
             }
         }
     }
 
     static func isActivated(_ userDefaults: UserDefaultsInterface = UserDefaults.standard) -> Bool {
-        return userDefaults.bool(forKey: NightModeKeys.Status)
+        _ = userDefaults
+        return false
     }
 
     // MARK: - Temporary functions
@@ -71,13 +70,13 @@ class NightModeHelper: TabContentScript {
     static func turnOff(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard
     ) {
-        guard isActivated() else { return }
         setNightMode(userDefaults, enabled: false)
     }
 
     static func cleanNightModeDefaults(
         _ userDefaults: UserDefaultsInterface = UserDefaults.standard
     ) {
+        userDefaults.removeObject(forKey: NightModeKeys.Status)
         userDefaults.removeObject(forKey: NightModeKeys.DarkThemeEnabled)
     }
 }

--- a/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
+++ b/firefox-ios/Client/Frontend/TabContentsScripts/UserScriptManager.swift
@@ -18,11 +18,6 @@ class UserScriptManager {
         source: "window.__firefox__.NoImageMode.setEnabled(true)",
         injectionTime: .atDocumentStart,
         forMainFrameOnly: true)
-    private let nightModeUserScript = WKUserScript(
-        source: NightModeHelper.jsCallbackBuilder(true),
-        injectionTime: .atDocumentEnd,
-        forMainFrameOnly: true,
-        in: .world(name: NightModeHelper.name()))
     private let printHelperUserScript = WKUserScript.createInPageContentWorld(
         source: "window.print = function () { window.webkit.messageHandlers.printHandler.postMessage({}) }",
         injectionTime: .atDocumentEnd,
@@ -60,18 +55,6 @@ class UserScriptManager {
                 forMainFrameOnly: mainFrameOnly
             )
             scripts[name] = userScript
-        }
-
-        // NightMode scripts
-        let nightModeName = "NightMode\(name)"
-        if let source = UserScriptManager.getScriptSource(nightModeName) {
-            let wrappedSource = "(function() { const APP_ID_TOKEN = '\(UserScriptManager.appIdToken)'; \(source) })()"
-            let userScript = WKUserScript(
-                source: wrappedSource,
-                injectionTime: injectionTime,
-                forMainFrameOnly: mainFrameOnly,
-                in: .world(name: NightModeHelper.name()))
-            scripts[nightModeName] = userScript
         }
 
         // Autofill scripts
@@ -126,11 +109,6 @@ class UserScriptManager {
                 browserScripts.append(autofillScript)
             }
 
-            let nightModeName = "NightMode\(name)"
-            if let nightModeScript = compiledUserScripts[nightModeName] {
-                browserScripts.append(nightModeScript)
-            }
-
             let webcompatName = "Webcompat\(name)"
             if let webcompatUserScript = compiledUserScripts[webcompatName] {
                 browserScripts.append(webcompatUserScript)
@@ -138,11 +116,6 @@ class UserScriptManager {
         }
         // Inject the Print Helper. This needs to be in the `page` content world in order to hook `window.print()`.
         browserScripts.append(printHelperUserScript)
-        // If Night Mode is enabled, inject a small user script to ensure
-        // that it gets enabled immediately when the DOM loads.
-        if nightMode {
-            browserScripts.append(nightModeUserScript)
-        }
         // If No Image Mode is enabled, inject a small user script to ensure
         // that it gets enabled immediately when the DOM loads.
         if noImageMode {

--- a/firefox-ios/Client/TabManagement/Tab.swift
+++ b/firefox-ios/Client/TabManagement/Tab.swift
@@ -381,23 +381,24 @@ class Tab: NSObject,
 
             UserScriptManager.shared.injectUserScriptsIntoWebView(
                 webView,
-                nightMode: nightMode,
+                nightMode: effectiveBuiltInNightMode,
                 noImageMode: noImageMode
             )
         }
     }
 
+    private var effectiveBuiltInNightMode: Bool {
+        false
+    }
+
     var nightMode: Bool {
         didSet {
             guard nightMode != oldValue else { return }
-            webView?.isOpaque = !nightMode
-            webView?.evaluateJavascriptInCustomContentWorld(
-                NightModeHelper.jsCallbackBuilder(nightMode),
-                in: .world(name: NightModeHelper.name())
-            )
+            let effectiveNightMode = effectiveBuiltInNightMode
+            webView?.isOpaque = !effectiveNightMode
             UserScriptManager.shared.injectUserScriptsIntoWebView(
                 webView,
-                nightMode: nightMode,
+                nightMode: effectiveNightMode,
                 noImageMode: noImageMode
             )
         }
@@ -572,7 +573,7 @@ class Tab: NSObject,
 
         UserScriptManager.shared.injectUserScriptsIntoWebView(
             webView,
-            nightMode: nightMode,
+            nightMode: effectiveBuiltInNightMode,
             noImageMode: noImageMode
         )
         FloorpWebExtensionRuntime.runtime(
@@ -1078,8 +1079,8 @@ class Tab: NSObject,
         /// Note: Background colors are only visible when `isOpaque` is false — setting them while it's true has no effect.
         webView?.backgroundColor =  theme.colors.layer1
         webView?.scrollView.backgroundColor = theme.colors.layer1
-        webView?.isOpaque = !nightMode
-        webView?.underPageBackgroundColor = nightMode ? .black : nil
+        webView?.isOpaque = !effectiveBuiltInNightMode
+        webView?.underPageBackgroundColor = effectiveBuiltInNightMode ? .black : nil
     }
 
     // MARK: - Static Helpers

--- a/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
+++ b/firefox-ios/Client/TabManagement/TabManagerImplementation.swift
@@ -708,7 +708,7 @@ final class TabManagerImplementation: NSObject,
         // Setting those here since `configureTab` applies those on the legacy path. Inlined here because the
         // deeplink-optimization path intentionally bypasses `addTab` / `configureTab`.
         tab.navigationDelegate = navigationDelegate
-        tab.nightMode = NightModeHelper.isActivated()
+        tab.nightMode = false
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
         return tab
     }
@@ -1273,7 +1273,7 @@ final class TabManagerImplementation: NSObject,
             }
         }
 
-        tab.nightMode = NightModeHelper.isActivated()
+        tab.nightMode = false
         tab.noImageMode = NoImageModeHelper.isActivated(profile.prefs)
 
         if flushToDisk {

--- a/firefox-ios/Floorp/Floorp.xcstrings
+++ b/firefox-ios/Floorp/Floorp.xcstrings
@@ -1429,6 +1429,204 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "キャンセル" } }
       }
     },
+    "Floorp.WebExtensions.Done.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Done" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "完了" } }
+      }
+    },
+    "Floorp.WebExtensions.Allow.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "許可" } }
+      }
+    },
+    "Floorp.WebExtensions.Actions.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extension Actions" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能のアクション" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionsAccessibilityHint.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Open actions provided by installed extensions" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "インストール済みの拡張機能が提供するアクションを開きます" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionsUnavailableMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extension actions are not ready for this browsing profile." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このブラウジングプロファイルでは拡張機能のアクションを利用できません。" } }
+      }
+    },
+    "Floorp.WebExtensions.NoActionsAvailableMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No extension actions are available for this page." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このページで利用できる拡張機能のアクションはありません。" } }
+      }
+    },
+    "Floorp.WebExtensions.ChooseActionMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Choose an extension to open for this page." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このページで開く拡張機能を選択してください。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionSiteAccessTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow site access for %1$@?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@にサイトへのアクセスを許可しますか？" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionSiteAccessMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This extension needs your permission before it can read or change the current page." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在のページを読み取ったり変更したりするには、あなたの許可が必要です。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionSiteAccessReloadMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The page reloads after access is allowed." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アクセスを許可するとページが再読み込みされます。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionAllWebsitesMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The requested access includes every HTTP and HTTPS website." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "要求されたアクセスには、すべてのHTTPおよびHTTPSウェブサイトが含まれます。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionRequestedSiteCount.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The extension requested %1$d site patterns." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能は%1$d件のサイトパターンへのアクセスを要求しています。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionPrivateScopeMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This choice applies only in Private Browsing." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この選択はプライベートブラウジングにのみ適用されます。" } }
+      }
+    },
+    "Floorp.WebExtensions.AllowOnSite.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow on %1$@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@で許可" } }
+      }
+    },
+    "Floorp.WebExtensions.AllowOnAllRequestedSites.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow on all requested sites" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "要求されたすべてのサイトで許可" } }
+      }
+    },
+    "Floorp.WebExtensions.OnlyThisWebsite.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Only this website" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "このウェブサイトのみ" } }
+      }
+    },
+    "Floorp.WebExtensions.SiteAccessForTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site access for %1$@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@のサイトアクセス" } }
+      }
+    },
+    "Floorp.WebExtensions.PrivateSiteAccessForTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Private site access for %1$@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@のプライベートサイトアクセス" } }
+      }
+    },
+    "Floorp.WebExtensions.SiteAccessPromptMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Choose where this extension may read or change page data." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能がページデータを読み取りまたは変更できる範囲を選択してください。" } }
+      }
+    },
+    "Floorp.WebExtensions.PrivateSiteAccessPromptMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Choose where the separate Private Browsing copy may read or change page data." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートブラウジング用の個別コピーがページデータを読み取りまたは変更できる範囲を選択してください。" } }
+      }
+    },
+    "Floorp.WebExtensions.NoSites.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No sites" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "許可しない" } }
+      }
+    },
+    "Floorp.WebExtensions.NoSitesDetail.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The extension cannot read or change website content." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能はウェブサイトの内容を読み取りまたは変更できません。" } }
+      }
+    },
+    "Floorp.WebExtensions.AllRequestedSitesChoice.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "All requested sites" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "要求されたすべてのサイト" } }
+      }
+    },
+    "Floorp.WebExtensions.OnlySite.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Only %1$@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@のみ" } }
+      }
+    },
+    "Floorp.WebExtensions.OnlySiteDetail.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Replace the current selection with this site only." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在の選択をこのサイトのみに置き換えます。" } }
+      }
+    },
+    "Floorp.WebExtensions.AddSite.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Add a site…" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイトを追加…" } }
+      }
+    },
+    "Floorp.WebExtensions.AddSiteMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enter a hostname or HTTPS URL. Only that site will be added." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ホスト名またはHTTPS URLを入力してください。そのサイトのみが追加されます。" } }
+      }
+    },
+    "Floorp.WebExtensions.RemoveSite.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove %1$@" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@を削除" } }
+      }
+    },
+    "Floorp.WebExtensions.CurrentSelection.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Current selection" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在の選択" } }
+      }
+    },
+    "Floorp.WebExtensions.PrivateBrowsingConsentTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow %1$@ in Private Browsing?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートブラウジングで%1$@を許可しますか？" } }
+      }
+    },
+    "Floorp.WebExtensions.PrivateBrowsingConsentMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Floorp creates a separate private copy. Site access starts off, and its private data is removed when the private session ends." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Floorpはプライベート用の個別コピーを作成します。サイトアクセスはオフで開始され、プライベートセッションの終了時にデータが削除されます。" } }
+      }
+    },
+    "Floorp.WebExtensions.ActionOpenErrorTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extension action could not open" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能のアクションを開けませんでした" } }
+      }
+    },
+    "Floorp.WebExtensions.SiteAccessChangeErrorTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site access could not be changed" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイトアクセスを変更できませんでした" } }
+      }
+    },
     "Floorp.WebExtensions.AccessSection.v1" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Access" } },

--- a/firefox-ios/Floorp/FloorpStrings.swift
+++ b/firefox-ios/Floorp/FloorpStrings.swift
@@ -1054,6 +1054,86 @@ enum FloorpStrings {
             value: "Cancel",
             comment: "Action that cancels an extension operation"
         )
+        static let done = string(
+            "Floorp.WebExtensions.Done.v1",
+            value: "Done",
+            comment: "Action that dismisses extension information"
+        )
+        static let allow = string(
+            "Floorp.WebExtensions.Allow.v1",
+            value: "Allow",
+            comment: "Action that grants an extension capability"
+        )
+        static let actions = string(
+            "Floorp.WebExtensions.Actions.v1",
+            value: "Extension Actions",
+            comment: "Browser menu action and heading for extension page actions"
+        )
+        static let actionsAccessibilityHint = string(
+            "Floorp.WebExtensions.ActionsAccessibilityHint.v1",
+            value: "Open actions provided by installed extensions",
+            comment: "Accessibility hint for the browser extension-actions menu item"
+        )
+        static let actionsUnavailableMessage = string(
+            "Floorp.WebExtensions.ActionsUnavailableMessage.v1",
+            value: "Extension actions are not ready for this browsing profile.",
+            comment: "Error shown when extension page actions are unavailable for the active profile"
+        )
+        static let noActionsAvailableMessage = string(
+            "Floorp.WebExtensions.NoActionsAvailableMessage.v1",
+            value: "No extension actions are available for this page.",
+            comment: "Message shown when no installed extension provides an action for the current page"
+        )
+        static let chooseActionMessage = string(
+            "Floorp.WebExtensions.ChooseActionMessage.v1",
+            value: "Choose an extension to open for this page.",
+            comment: "Guidance shown above the extension page-action picker"
+        )
+        private static let actionSiteAccessTitleFormat = string(
+            "Floorp.WebExtensions.ActionSiteAccessTitle.v1",
+            value: "Allow site access for %1$@?",
+            comment: "Title of page-action site-access consent; argument is the extension name"
+        )
+        static let actionSiteAccessMessage = string(
+            "Floorp.WebExtensions.ActionSiteAccessMessage.v1",
+            value: "This extension needs your permission before it can read or change the current page.",
+            comment: "Explanation shown by page-action site-access consent"
+        )
+        static let actionSiteAccessReloadMessage = string(
+            "Floorp.WebExtensions.ActionSiteAccessReloadMessage.v1",
+            value: "The page reloads after access is allowed.",
+            comment: "Page reload disclosure shown by page-action site-access consent"
+        )
+        static let actionAllWebsitesMessage = string(
+            "Floorp.WebExtensions.ActionAllWebsitesMessage.v1",
+            value: "The requested access includes every HTTP and HTTPS website.",
+            comment: "Disclosure when an extension requested every website"
+        )
+        private static let actionRequestedSiteCountFormat = string(
+            "Floorp.WebExtensions.ActionRequestedSiteCount.v1",
+            value: "The extension requested %1$d site patterns.",
+            comment: "Disclosure for the number of requested extension site patterns"
+        )
+        static let actionPrivateScopeMessage = string(
+            "Floorp.WebExtensions.ActionPrivateScopeMessage.v1",
+            value: "This choice applies only in Private Browsing.",
+            comment: "Disclosure that a page-action site-access choice is private-profile only"
+        )
+        private static let allowOnSiteFormat = string(
+            "Floorp.WebExtensions.AllowOnSite.v1",
+            value: "Allow on %1$@",
+            comment: "Action that grants extension access to one host; argument is the hostname"
+        )
+        static let allowOnAllRequestedSites = string(
+            "Floorp.WebExtensions.AllowOnAllRequestedSites.v1",
+            value: "Allow on all requested sites",
+            comment: "Action that grants access to every site declared by an extension"
+        )
+        static let onlyThisWebsite = string(
+            "Floorp.WebExtensions.OnlyThisWebsite.v1",
+            value: "Only this website",
+            comment: "Detail for a current-site-only extension access choice"
+        )
         static let accessSection = string(
             "Floorp.WebExtensions.AccessSection.v1",
             value: "Access",
@@ -1184,6 +1264,71 @@ enum FloorpStrings {
             value: "Site Access",
             comment: "Action and heading for standard-profile extension site access"
         )
+        private static let siteAccessForTitleFormat = string(
+            "Floorp.WebExtensions.SiteAccessForTitle.v1",
+            value: "Site access for %1$@",
+            comment: "Title of standard site-access choices; argument is the extension name"
+        )
+        private static let privateSiteAccessForTitleFormat = string(
+            "Floorp.WebExtensions.PrivateSiteAccessForTitle.v1",
+            value: "Private site access for %1$@",
+            comment: "Title of private site-access choices; argument is the extension name"
+        )
+        static let siteAccessPromptMessage = string(
+            "Floorp.WebExtensions.SiteAccessPromptMessage.v1",
+            value: "Choose where this extension may read or change page data.",
+            comment: "Guidance shown above standard site-access choices"
+        )
+        static let privateSiteAccessPromptMessage = string(
+            "Floorp.WebExtensions.PrivateSiteAccessPromptMessage.v1",
+            value: "Choose where the separate Private Browsing copy may read or change page data.",
+            comment: "Guidance shown above private site-access choices"
+        )
+        static let noSites = string(
+            "Floorp.WebExtensions.NoSites.v1",
+            value: "No sites",
+            comment: "Choice that denies an extension access to every site"
+        )
+        static let noSitesDetail = string(
+            "Floorp.WebExtensions.NoSitesDetail.v1",
+            value: "The extension cannot read or change website content.",
+            comment: "Explanation of the no-sites extension access choice"
+        )
+        static let allRequestedSitesChoice = string(
+            "Floorp.WebExtensions.AllRequestedSitesChoice.v1",
+            value: "All requested sites",
+            comment: "Choice that grants every site declared by an extension"
+        )
+        private static let onlySiteFormat = string(
+            "Floorp.WebExtensions.OnlySite.v1",
+            value: "Only %1$@",
+            comment: "Choice that grants one declared site pattern; argument is the site pattern"
+        )
+        static let onlySiteDetail = string(
+            "Floorp.WebExtensions.OnlySiteDetail.v1",
+            value: "Replace the current selection with this site only.",
+            comment: "Explanation of a single-site extension access choice"
+        )
+        static let addSite = string(
+            "Floorp.WebExtensions.AddSite.v1",
+            value: "Add a site…",
+            comment: "Action that adds a site to selected extension access"
+        )
+        static let addSiteMessage = string(
+            "Floorp.WebExtensions.AddSiteMessage.v1",
+            value: "Enter a hostname or HTTPS URL. Only that site will be added.",
+            comment: "Guidance for entering an extension site-access hostname"
+        )
+        private static let removeSiteFormat = string(
+            "Floorp.WebExtensions.RemoveSite.v1",
+            value: "Remove %1$@",
+            comment: "Action that removes one selected extension site; argument is the site pattern"
+        )
+        static let currentSelection = string(
+            "Floorp.WebExtensions.CurrentSelection.v1",
+            value: "Current selection",
+            comment: "Status identifying the active extension site-access choice"
+        )
         static let allRequestedWebsites = string(
             "Floorp.WebExtensions.AllRequestedWebsites.v1",
             value: "HTTP(S) · All requested websites",
@@ -1218,6 +1363,27 @@ enum FloorpStrings {
             "Floorp.WebExtensions.PrivateBrowsing.v1",
             value: "Private Browsing",
             comment: "Action and heading for extension Private Browsing access"
+        )
+        private static let privateBrowsingConsentTitleFormat = string(
+            "Floorp.WebExtensions.PrivateBrowsingConsentTitle.v1",
+            value: "Allow %1$@ in Private Browsing?",
+            comment: "Title of extension Private Browsing consent; argument is the extension name"
+        )
+        static let privateBrowsingConsentMessage = string(
+            "Floorp.WebExtensions.PrivateBrowsingConsentMessage.v1",
+            value: "Floorp creates a separate private copy. Site access starts off, "
+                + "and its private data is removed when the private session ends.",
+            comment: "Explanation shown before allowing an extension in Private Browsing"
+        )
+        static let actionOpenErrorTitle = string(
+            "Floorp.WebExtensions.ActionOpenErrorTitle.v1",
+            value: "Extension action could not open",
+            comment: "Error title when an extension page action cannot open"
+        )
+        static let siteAccessChangeErrorTitle = string(
+            "Floorp.WebExtensions.SiteAccessChangeErrorTitle.v1",
+            value: "Site access could not be changed",
+            comment: "Error title when an extension site-access change fails"
         )
         static let networkProtection = string(
             "Floorp.WebExtensions.NetworkProtection.v1",
@@ -1351,6 +1517,37 @@ enum FloorpStrings {
 
         static func installTitle(name: String) -> String {
             localizedStringWithFormat(installTitleFormat, name)
+        }
+
+        static func actionSiteAccessTitle(name: String) -> String {
+            localizedStringWithFormat(actionSiteAccessTitleFormat, name)
+        }
+
+        static func actionRequestedSiteCount(_ count: Int) -> String {
+            localizedStringWithFormat(actionRequestedSiteCountFormat, count)
+        }
+
+        static func allowOnSite(_ host: String) -> String {
+            localizedStringWithFormat(allowOnSiteFormat, host)
+        }
+
+        static func siteAccessForTitle(name: String, isPrivateBrowsing: Bool) -> String {
+            localizedStringWithFormat(
+                isPrivateBrowsing ? privateSiteAccessForTitleFormat : siteAccessForTitleFormat,
+                name
+            )
+        }
+
+        static func onlySite(_ site: String) -> String {
+            localizedStringWithFormat(onlySiteFormat, site)
+        }
+
+        static func removeSite(_ site: String) -> String {
+            localizedStringWithFormat(removeSiteFormat, site)
+        }
+
+        static func privateBrowsingConsentTitle(name: String) -> String {
+            localizedStringWithFormat(privateBrowsingConsentTitleFormat, name)
         }
 
         static func publisher(_ publisher: String) -> String {

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
@@ -60,6 +60,25 @@ struct FloorpWebExtensionPermissionRequest: Sendable {
     let origins: Set<FloorpWebExtensionMatchPattern>
 }
 
+struct FloorpWebExtensionNetworkFetchResponse: Sendable {
+    let url: URL
+    let statusCode: Int
+    let headers: [String: String]
+    let body: Data
+}
+
+private final class FloorpWebExtensionNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
 /// Profile-owned native implementation of the Stage 2 API subset.
 ///
 /// The message bridge authenticates the extension and document before this
@@ -81,8 +100,13 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     typealias LiveScriptingTargetResolver = @MainActor @Sendable (
         Int
     ) throws -> FloorpWebExtensionLiveScriptingTarget
+    typealias NetworkFetchTransport = @Sendable (URL) async throws -> FloorpWebExtensionNetworkFetchResponse
 
     private static let maximumJavaScriptManifestBootstrapByteCount = 64 * 1_024
+    private static let maximumNetworkFetchBodyByteCount = 2 * 1_024 * 1_024
+    private static let networkFetchChunkByteCount = 24 * 1_024
+    private static let maximumPendingNetworkFetches = 8
+    private static let networkFetchLifetime: TimeInterval = 30
 
     private struct ActiveExtension {
         let authorityRevision: UUID
@@ -100,6 +124,14 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         /// broader dynamic/session contract, but a signed catalog package
         /// cannot create a new DNR policy at runtime.
         let allowsMutableDNR: Bool
+    }
+
+    private struct PendingNetworkFetch {
+        let extensionID: FloorpWebExtensionID
+        let authorityRevision: UUID
+        let body: Data
+        var offset: Int
+        let expiration: Date
     }
 
     /// Immutable package data made available before document-start JavaScript
@@ -253,6 +285,34 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
 
     private struct RuntimeGetURLRequest: Decodable {
         let path: String
+    }
+
+    private struct RuntimeFetchRequest: Decodable {
+        private enum CodingKeys: String, CodingKey, CaseIterable {
+            case url
+            case method
+        }
+
+        let url: String
+        let method: String
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(in: decoder, allowing: Set(CodingKeys.allCases.map(\.rawValue)))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            url = try container.decode(String.self, forKey: .url)
+            method = try container.decode(String.self, forKey: .method)
+        }
+    }
+
+    private struct RuntimeFetchReadRequest: Decodable {
+        private enum CodingKeys: String, CodingKey, CaseIterable { case fetchId }
+        let fetchId: String
+
+        init(from decoder: Decoder) throws {
+            try rejectUnknownKeys(in: decoder, allowing: Set(CodingKeys.allCases.map(\.rawValue)))
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            fetchId = try container.decode(String.self, forKey: .fetchId)
+        }
     }
 
     private struct PermissionDetailsRequest: Decodable {
@@ -529,6 +589,18 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     private struct IntegerResponse: Encodable { let value: Int }
     private struct StringResponse: Encodable { let value: String }
     private struct StringsResponse: Encodable { let values: [String] }
+    private struct RuntimeFetchResponse: Encodable {
+        let status: Int
+        let statusText: String
+        let headers: [String: String]
+        let bodyBase64: String
+        let fetchId: String?
+        let done: Bool
+    }
+    private struct RuntimeFetchChunkResponse: Encodable {
+        let bodyBase64: String
+        let done: Bool
+    }
     private struct PermissionDetailsResponse: Encodable {
         let permissions: [String]
         let origins: [String]
@@ -639,7 +711,9 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     private let permissionRequestAuthorizer: PermissionRequestAuthorizer?
     private let permissionMutationHandler: PermissionMutationHandler?
     private let liveScriptingTargetResolver: LiveScriptingTargetResolver?
+    private let networkFetchTransport: NetworkFetchTransport
     private var activeExtensions = [FloorpWebExtensionID: ActiveExtension]()
+    private var pendingNetworkFetches = [String: PendingNetworkFetch]()
     private enum RegistryBinding {
         case unmanaged
         case installed
@@ -662,7 +736,8 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         permissionRequestAuthorizer: PermissionRequestAuthorizer? = nil,
         permissionMutationHandler: PermissionMutationHandler? = nil,
         liveScriptingTargetResolver: LiveScriptingTargetResolver? = nil,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        networkFetchTransport: NetworkFetchTransport? = nil
     ) throws {
         profileKey = .init(
             profileIdentifier: profileIdentifier,
@@ -708,6 +783,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         self.permissionMutationHandler = permissionMutationHandler
         self.liveScriptingTargetResolver = liveScriptingTargetResolver
         self.now = now
+        self.networkFetchTransport = networkFetchTransport ?? Self.fetchWithoutRedirects
     }
 
     convenience init(
@@ -763,6 +839,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         resourcePaths: Set<String> = [],
         allowsMutableDNR: Bool = true
     ) async {
+        pendingNetworkFetches = pendingNetworkFetches.filter { $0.value.extensionID != extensionID }
         activeExtensions[extensionID] = .init(
             authorityRevision: UUID(),
             permissions: grants.apiPermissions,
@@ -834,6 +911,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     /// uninstall.
     func suspend(_ extensionID: FloorpWebExtensionID) async {
         activeExtensions.removeValue(forKey: extensionID)
+        pendingNetworkFetches = pendingNetworkFetches.filter { $0.value.extensionID != extensionID }
         cssInsertions.removeValue(forKey: extensionID)
         alarmEvents.unregister(extensionID: extensionID)
         await permissionBroker.grant(
@@ -871,6 +949,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     func suspend() async {
         let identifiers = Array(activeExtensions.keys)
         activeExtensions.removeAll()
+        pendingNetworkFetches.removeAll()
         cssInsertions.removeAll()
         alarmEvents.tearDown()
         for extensionID in identifiers {
@@ -911,6 +990,10 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
             }
             try await runtimeReloader(sender.extensionID)
             return try response(EmptyResponse())
+        case "runtime.fetch":
+            return try await runtimeFetch(payload, active: active, sender: sender)
+        case "runtime.fetch.read":
+            return try runtimeFetchRead(payload, active: active, sender: sender)
         case "permissions.getAll":
             return try await permissionDetails(for: sender.extensionID)
         case "permissions.contains":
@@ -1156,6 +1239,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     fileprivate func invalidateRegistryBinding() {
         registryBinding = .invalidated
         activeExtensions.removeAll()
+        pendingNetworkFetches.removeAll()
     }
 
     private var hasCurrentRegistryBinding: Bool {
@@ -1216,6 +1300,171 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
             throw FloorpWebExtensionMessageError.malformedEnvelope
         }
         return try response(StringResponse(value: url.absoluteString))
+    }
+
+    private func runtimeFetch(
+        _ payload: FloorpWebExtensionMessagePayload,
+        active: ActiveExtension,
+        sender: any FloorpWebExtensionMessageSender
+    ) async throws -> FloorpWebExtensionMessagePayload {
+        guard sender is FloorpWebExtensionBackgroundRuntimeMessageSender else {
+            throw FloorpWebExtensionMessageError.unsupportedOperation
+        }
+        let request = try decode(RuntimeFetchRequest.self, from: payload)
+        guard request.method.uppercased() == "GET",
+              (1...4_096).contains(request.url.utf8.count),
+              let url = URL(string: request.url),
+              ["http", "https"].contains(url.scheme?.lowercased()),
+              url.host != nil,
+              url.user == nil,
+              url.password == nil else {
+            throw FloorpWebExtensionMessageError.malformedEnvelope
+        }
+        guard await permissionBroker.allowsHostAccess(
+            for: sender.extensionID,
+            url: url,
+            isPrivate: sender.isPrivate
+        ) else {
+            throw FloorpWebExtensionMessageError.permissionDenied
+        }
+
+        let fetched = try await networkFetchTransport(url)
+        try requireCurrentSender(sender, expectedActive: active)
+        guard fetched.statusCode >= 100,
+              fetched.statusCode <= 599,
+              ["http", "https"].contains(fetched.url.scheme?.lowercased()),
+              fetched.url.host != nil,
+              fetched.url.user == nil,
+              fetched.url.password == nil,
+              await permissionBroker.allowsHostAccess(
+                  for: sender.extensionID,
+                  url: fetched.url,
+                  isPrivate: sender.isPrivate
+              ) else {
+            throw FloorpWebExtensionMessageError.permissionDenied
+        }
+        guard !(300..<400).contains(fetched.statusCode) else {
+            throw FloorpWebExtensionMessageError.handlerFailed
+        }
+        guard fetched.body.count <= Self.maximumNetworkFetchBodyByteCount else {
+            throw FloorpWebExtensionMessageError.payloadTooLarge
+        }
+
+        removeExpiredNetworkFetches()
+        let chunkEnd = min(Self.networkFetchChunkByteCount, fetched.body.count)
+        let firstChunk = fetched.body.subdata(in: 0..<chunkEnd)
+        let isComplete = chunkEnd == fetched.body.count
+        var fetchID: String?
+        if !isComplete {
+            guard pendingNetworkFetches.count < Self.maximumPendingNetworkFetches else {
+                throw FloorpWebExtensionMessageError.tooManyPendingMessages
+            }
+            let identifier = UUID().uuidString.lowercased()
+            pendingNetworkFetches[identifier] = PendingNetworkFetch(
+                extensionID: sender.extensionID,
+                authorityRevision: active.authorityRevision,
+                body: fetched.body,
+                offset: chunkEnd,
+                expiration: now().addingTimeInterval(Self.networkFetchLifetime)
+            )
+            fetchID = identifier
+        }
+        return try response(RuntimeFetchResponse(
+            status: fetched.statusCode,
+            statusText: HTTPURLResponse.localizedString(forStatusCode: fetched.statusCode),
+            headers: Self.sanitizedNetworkHeaders(fetched.headers),
+            bodyBase64: firstChunk.base64EncodedString(),
+            fetchId: fetchID,
+            done: isComplete
+        ))
+    }
+
+    private func runtimeFetchRead(
+        _ payload: FloorpWebExtensionMessagePayload,
+        active: ActiveExtension,
+        sender: any FloorpWebExtensionMessageSender
+    ) throws -> FloorpWebExtensionMessagePayload {
+        guard sender is FloorpWebExtensionBackgroundRuntimeMessageSender else {
+            throw FloorpWebExtensionMessageError.unsupportedOperation
+        }
+        let request = try decode(RuntimeFetchReadRequest.self, from: payload)
+        guard (1...64).contains(request.fetchId.utf8.count) else {
+            throw FloorpWebExtensionMessageError.malformedEnvelope
+        }
+        removeExpiredNetworkFetches()
+        guard var pending = pendingNetworkFetches[request.fetchId],
+              pending.extensionID == sender.extensionID,
+              pending.authorityRevision == active.authorityRevision else {
+            throw FloorpWebExtensionMessageError.unauthorizedDocument
+        }
+        let chunkEnd = min(pending.offset + Self.networkFetchChunkByteCount, pending.body.count)
+        let chunk = pending.body.subdata(in: pending.offset..<chunkEnd)
+        pending.offset = chunkEnd
+        let isComplete = chunkEnd == pending.body.count
+        if isComplete {
+            pendingNetworkFetches.removeValue(forKey: request.fetchId)
+        } else {
+            pendingNetworkFetches[request.fetchId] = pending
+        }
+        return try response(RuntimeFetchChunkResponse(
+            bodyBase64: chunk.base64EncodedString(),
+            done: isComplete
+        ))
+    }
+
+    private func removeExpiredNetworkFetches() {
+        let currentDate = now()
+        pendingNetworkFetches = pendingNetworkFetches.filter { $0.value.expiration > currentDate }
+    }
+
+    nonisolated private static func sanitizedNetworkHeaders(_ headers: [String: String]) -> [String: String] {
+        var sanitized = [String: String]()
+        var byteCount = 0
+        for (name, value) in headers.sorted(by: { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }) {
+            let lowercaseName = name.lowercased()
+            guard lowercaseName != "set-cookie",
+                  lowercaseName != "set-cookie2",
+                  sanitized.count < 64,
+                  (1...256).contains(name.utf8.count),
+                  value.utf8.count <= 4_096 else {
+                continue
+            }
+            let nextByteCount = byteCount + name.utf8.count + value.utf8.count
+            guard nextByteCount <= 16 * 1_024 else { break }
+            sanitized[name] = value
+            byteCount = nextByteCount
+        }
+        return sanitized
+    }
+
+    nonisolated private static func fetchWithoutRedirects(
+        _ url: URL
+    ) async throws -> FloorpWebExtensionNetworkFetchResponse {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        configuration.urlCache = nil
+        let redirectDelegate = FloorpWebExtensionNoRedirectDelegate()
+        let session = URLSession(configuration: configuration, delegate: redirectDelegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 20
+        request.setValue("text/css,*/*;q=0.1", forHTTPHeaderField: "Accept")
+        let (body, response) = try await session.data(for: request)
+        guard let response = response as? HTTPURLResponse,
+              let responseURL = response.url else {
+            throw FloorpWebExtensionMessageError.handlerFailed
+        }
+        var headers = [String: String]()
+        for (name, value) in response.allHeaderFields {
+            headers[String(describing: name)] = String(describing: value)
+        }
+        return FloorpWebExtensionNetworkFetchResponse(
+            url: responseURL,
+            statusCode: response.statusCode,
+            headers: headers,
+            body: body
+        )
     }
 
     private func permissionDetails(

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionAPIHost.swift
@@ -67,7 +67,42 @@ struct FloorpWebExtensionNetworkFetchResponse: Sendable {
     let body: Data
 }
 
-private final class FloorpWebExtensionNoRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+private final class FloorpWebExtensionNetworkFetchDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let maximumBodyByteCount: Int
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<FloorpWebExtensionNetworkFetchResponse, Error>?
+    private var response: HTTPURLResponse?
+    private var body = Data()
+    private var task: URLSessionDataTask?
+    private var didFinish = false
+
+    init(maximumBodyByteCount: Int) {
+        self.maximumBodyByteCount = maximumBodyByteCount
+    }
+
+    func fetch(
+        _ request: URLRequest,
+        using session: URLSession
+    ) async throws -> FloorpWebExtensionNetworkFetchResponse {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                guard !didFinish else {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.continuation = continuation
+                let task = session.dataTask(with: request)
+                self.task = task
+                lock.unlock()
+                task.resume()
+            }
+        } onCancel: {
+            self.finish(.failure(CancellationError()), cancellingTask: true)
+        }
+    }
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
@@ -76,6 +111,100 @@ private final class FloorpWebExtensionNoRedirectDelegate: NSObject, URLSessionTa
         completionHandler: @escaping (URLRequest?) -> Void
     ) {
         completionHandler(nil)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let response = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            finish(.failure(FloorpWebExtensionMessageError.handlerFailed))
+            return
+        }
+        guard response.expectedContentLength < 0 ||
+                response.expectedContentLength <= Int64(maximumBodyByteCount) else {
+            completionHandler(.cancel)
+            finish(.failure(FloorpWebExtensionMessageError.payloadTooLarge))
+            return
+        }
+        lock.lock()
+        if !didFinish {
+            self.response = response
+        }
+        lock.unlock()
+        completionHandler(.allow)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        var exceedsLimit = false
+        lock.lock()
+        if !didFinish {
+            if data.count > maximumBodyByteCount - body.count {
+                exceedsLimit = true
+            } else {
+                body.append(data)
+            }
+        }
+        lock.unlock()
+        guard exceedsLimit else { return }
+        finish(.failure(FloorpWebExtensionMessageError.payloadTooLarge))
+        dataTask.cancel()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error {
+            finish(.failure(error))
+            return
+        }
+        lock.lock()
+        let response = response
+        let body = body
+        lock.unlock()
+        guard let response,
+              let responseURL = response.url else {
+            finish(.failure(FloorpWebExtensionMessageError.handlerFailed))
+            return
+        }
+        var headers = [String: String]()
+        for (name, value) in response.allHeaderFields {
+            headers[String(describing: name)] = String(describing: value)
+        }
+        finish(.success(FloorpWebExtensionNetworkFetchResponse(
+            url: responseURL,
+            statusCode: response.statusCode,
+            headers: headers,
+            body: body
+        )))
+    }
+
+    private func finish(
+        _ result: Result<FloorpWebExtensionNetworkFetchResponse, Error>,
+        cancellingTask: Bool = false
+    ) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        didFinish = true
+        let continuation = continuation
+        self.continuation = nil
+        let task = cancellingTask ? task : nil
+        self.task = nil
+        lock.unlock()
+        task?.cancel()
+        continuation?.resume(with: result)
     }
 }
 
@@ -103,7 +232,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
     typealias NetworkFetchTransport = @Sendable (URL) async throws -> FloorpWebExtensionNetworkFetchResponse
 
     private static let maximumJavaScriptManifestBootstrapByteCount = 64 * 1_024
-    private static let maximumNetworkFetchBodyByteCount = 2 * 1_024 * 1_024
+    nonisolated private static let maximumNetworkFetchBodyByteCount = 2 * 1_024 * 1_024
     private static let networkFetchChunkByteCount = 24 * 1_024
     private static let maximumPendingNetworkFetches = 8
     private static let networkFetchLifetime: TimeInterval = 30
@@ -1371,7 +1500,7 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         }
         return try response(RuntimeFetchResponse(
             status: fetched.statusCode,
-            statusText: HTTPURLResponse.localizedString(forStatusCode: fetched.statusCode),
+            statusText: "",
             headers: Self.sanitizedNetworkHeaders(fetched.headers),
             bodyBase64: firstChunk.base64EncodedString(),
             fetchId: fetchID,
@@ -1443,28 +1572,16 @@ final class FloorpWebExtensionAPIHost: FloorpWebExtensionNativeAPIDispatching {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpCookieStorage = nil
         configuration.urlCache = nil
-        let redirectDelegate = FloorpWebExtensionNoRedirectDelegate()
-        let session = URLSession(configuration: configuration, delegate: redirectDelegate, delegateQueue: nil)
+        let delegate = FloorpWebExtensionNetworkFetchDelegate(
+            maximumBodyByteCount: maximumNetworkFetchBodyByteCount
+        )
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
         defer { session.finishTasksAndInvalidate() }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.timeoutInterval = 20
         request.setValue("text/css,*/*;q=0.1", forHTTPHeaderField: "Accept")
-        let (body, response) = try await session.data(for: request)
-        guard let response = response as? HTTPURLResponse,
-              let responseURL = response.url else {
-            throw FloorpWebExtensionMessageError.handlerFailed
-        }
-        var headers = [String: String]()
-        for (name, value) in response.allHeaderFields {
-            headers[String(describing: name)] = String(describing: value)
-        }
-        return FloorpWebExtensionNetworkFetchResponse(
-            url: responseURL,
-            statusCode: response.statusCode,
-            headers: headers,
-            body: body
-        )
+        return try await delegate.fetch(request, using: session)
     }
 
     private func permissionDetails(

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
@@ -1606,7 +1606,10 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
                 result = await request("runtime.fetch.read", {fetchId: metadata.fetchId});
                 chunks.push(decodeBase64(result.bodyBase64));
               }
-              return new Response(new Blob(chunks), {
+              const responseBody = metadata.status === 204 || metadata.status === 205
+                ? null
+                : new Blob(chunks);
+              return new Response(responseBody, {
                 status: metadata.status,
                 statusText: metadata.statusText || "",
                 headers: metadata.headers || {}

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionMessageRuntime.swift
@@ -807,6 +807,7 @@ final class FloorpWebExtensionMessageRuntime {
             bootstrap: nativeHost?.javaScriptBootstrap(for: background.extensionID),
             contentWorld: .page,
             supportsSameSurfacePageNavigation: false,
+            supportsNativeNetworkRequests: true,
             owner: "floorp.webextension.bridge.background.\(background.extensionID.rawValue).\(background.originHost)",
             authorizeDocument: { [weak self] url, isMainFrame in
                 self?.activeBackgroundBridges[background.extensionID] == background &&
@@ -1089,6 +1090,7 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
     private let handlerName: String
     private let contentWorld: WKContentWorld
     private let supportsSameSurfacePageNavigation: Bool
+    private let supportsNativeNetworkRequests: Bool
     private weak var controller: WKUserContentController?
     private var attachmentGeneration: UInt64 = 0
 
@@ -1098,6 +1100,7 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
         bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?,
         contentWorld: WKContentWorld,
         supportsSameSurfacePageNavigation: Bool,
+        supportsNativeNetworkRequests: Bool = false,
         owner: String,
         authorizeDocument: @escaping @MainActor (URL, Bool) -> Bool,
         authorizeFrameScript: (@MainActor (String, String, URL, Bool) -> Bool)? = nil,
@@ -1123,6 +1126,7 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
         handlerName = "floorpRuntime_\(nonce.prefix(24))"
         self.contentWorld = contentWorld
         self.supportsSameSurfacePageNavigation = supportsSameSurfacePageNavigation
+        self.supportsNativeNetworkRequests = supportsNativeNetworkRequests
     }
 
     func attach(to controller: WKUserContentController) {
@@ -1136,7 +1140,8 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
                 nonce: nonce,
                 handlerName: handlerName,
                 bootstrap: bootstrap,
-                supportsSameSurfacePageNavigation: supportsSameSurfacePageNavigation
+                supportsSameSurfacePageNavigation: supportsSameSurfacePageNavigation,
+                supportsNativeNetworkRequests: supportsNativeNetworkRequests
             ),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: false,
@@ -1424,12 +1429,14 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
         nonce: String,
         handlerName: String,
         bootstrap: FloorpWebExtensionAPIHost.JavaScriptBootstrap?,
-        supportsSameSurfacePageNavigation: Bool
+        supportsSameSurfacePageNavigation: Bool,
+        supportsNativeNetworkRequests: Bool
     ) -> String {
         let extensionLiteral = javaScriptLiteral(extensionID.rawValue)
         let nonceLiteral = javaScriptLiteral(nonce)
         let handlerLiteral = javaScriptLiteral(handlerName)
         let sameSurfacePageNavigationLiteral = supportsSameSurfacePageNavigation ? "true" : "false"
+        let nativeNetworkRequestsLiteral = supportsNativeNetworkRequests ? "true" : "false"
         let bootstrapLiteral: String
         if let bootstrap,
            let data = try? JSONEncoder().encode(bootstrap),
@@ -1564,6 +1571,48 @@ private final class FloorpWebExtensionMessageBridgeSession: NSObject, WKScriptMe
               if (tracksStartupActivity) backgroundStartupActivity.nativeRequestFinished();
             });
           };
+          if (\(nativeNetworkRequestsLiteral) &&
+              typeof globalThis.fetch === "function" &&
+              typeof globalThis.Response === "function" &&
+              typeof globalThis.Blob === "function") {
+            const originalFetch = globalThis.fetch.bind(globalThis);
+            const decodeBase64 = (value) => {
+              const binary = atob(value || "");
+              const bytes = new Uint8Array(binary.length);
+              for (let index = 0; index < binary.length; index += 1) {
+                bytes[index] = binary.charCodeAt(index);
+              }
+              return bytes;
+            };
+            globalThis.fetch = async (input, init = {}) => {
+              const inputIsRequest = typeof globalThis.Request === "function" && input instanceof Request;
+              const method = String(init?.method || (inputIsRequest ? input.method : "GET")).toUpperCase();
+              const rawURL = inputIsRequest ? input.url : String(input);
+              let url;
+              try {
+                url = new URL(rawURL, location.href);
+              } catch (_) {
+                return originalFetch(input, init);
+              }
+              if ((url.protocol !== "http:" && url.protocol !== "https:") ||
+                  method !== "GET" || init?.body != null) {
+                return originalFetch(input, init);
+              }
+              const chunks = [];
+              let result = await request("runtime.fetch", {url: url.href, method});
+              const metadata = result;
+              chunks.push(decodeBase64(result.bodyBase64));
+              while (!result.done) {
+                result = await request("runtime.fetch.read", {fetchId: metadata.fetchId});
+                chunks.push(decodeBase64(result.bodyBase64));
+              }
+              return new Response(new Blob(chunks), {
+                status: metadata.status,
+                statusText: metadata.statusText || "",
+                headers: metadata.headers || {}
+              });
+            };
+          }
           Object.defineProperty(globalThis, \(javaScriptLiteral(FloorpWebExtensionMessageRuntime.frameAuthorizationFunctionName)), {
             value: async (scriptId, revisionToken) => {
               if (typeof scriptId !== "string" || scriptId.length < 1 || scriptId.length > 128 ||

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPermissions.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPermissions.swift
@@ -161,6 +161,22 @@ actor FloorpWebExtensionPermissionBroker {
         return activeTabGrants[extensionID]?.allows(tab, now: now()) ?? false
     }
 
+    /// Checks durable host authority for a background-owned network request.
+    /// Active-tab grants are intentionally excluded because a hidden
+    /// background document is not bound to one live tab generation.
+    func allowsHostAccess(
+        for extensionID: FloorpWebExtensionID,
+        url: URL,
+        isPrivate: Bool
+    ) -> Bool {
+        let snapshot = snapshot(for: extensionID)
+        if isPrivate && !snapshot.privateBrowsingEnabled {
+            return false
+        }
+        let access = isPrivate ? snapshot.privateHostAccess : snapshot.normalHostAccess
+        return access.allows(url, requested: snapshot.requestedHosts)
+    }
+
     func invalidate(tab: FloorpWebExtensionTabContext) {
         activeTabGrants = activeTabGrants.filter { _, grant in
             !(grant.tabID == tab.tabID && grant.documentGeneration == tab.documentGeneration)

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
@@ -462,6 +462,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
     private var choiceButtons = [ChoiceButton]()
     private var didFinish = false
     private var didReportDismissal = false
+    private var pendingChoiceIdentifier: String?
     private var heroUsesTemplateRendering = true
 
     var displayedChoiceTitles: [String] { choiceButtons.map(\.choice.title) }
@@ -501,6 +502,10 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        if let pendingChoiceIdentifier {
+            self.pendingChoiceIdentifier = nil
+            onChoice(pendingChoiceIdentifier)
+        }
         guard !didReportDismissal else { return }
         didReportDismissal = true
         onDismiss()
@@ -613,10 +618,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
         guard !didFinish else { return }
         didFinish = true
         setControlsEnabled(false)
-        // A permission mutation is a product event, not a presentation
-        // completion. Deliver it before asking UIKit to dismiss so a missing
-        // or interrupted dismissal completion cannot silently drop consent.
-        onChoice(identifier)
+        pendingChoiceIdentifier = identifier
         dismiss(animated: true)
     }
 

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
@@ -302,6 +302,321 @@ final class FloorpWebExtensionCardCell: UITableViewCell, ThemeApplicable {
     }
 }
 
+struct FloorpWebExtensionPromptPresentation: Hashable, Sendable {
+    struct Choice: Hashable, Sendable {
+        enum Icon: Hashable, Sendable {
+            case system(String)
+            case extensionIcon(id: FloorpWebExtensionID, data: Data?)
+        }
+
+        enum Role: Hashable, Sendable {
+            case standard
+            case preferred
+            case destructive
+        }
+
+        let identifier: String
+        let title: String
+        let detail: String
+        let icon: Icon
+        let role: Role
+        let isSelected: Bool
+
+        init(
+            identifier: String,
+            title: String,
+            detail: String,
+            icon: Icon,
+            role: Role = .standard,
+            isSelected: Bool = false
+        ) {
+            self.identifier = identifier
+            self.title = title
+            self.detail = detail
+            self.icon = icon
+            self.role = role
+            self.isSelected = isSelected
+        }
+    }
+
+    let title: String
+    let message: String
+    let heroIcon: Choice.Icon
+    let choices: [Choice]
+    let cancelTitle: String
+    let accessibilityIdentifier: String
+
+    init(
+        title: String,
+        message: String,
+        heroIcon: Choice.Icon,
+        choices: [Choice],
+        cancelTitle: String = FloorpStrings.WebExtensions.cancel,
+        accessibilityIdentifier: String
+    ) {
+        self.title = title
+        self.message = message
+        self.heroIcon = heroIcon
+        self.choices = choices
+        self.cancelTitle = cancelTitle
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+}
+
+@MainActor
+final class FloorpWebExtensionPromptViewController: UIViewController,
+                                                      Themeable,
+                                                      InjectedThemeUUIDIdentifiable {
+    typealias ChoiceHandler = @MainActor (String) -> Void
+    typealias CancelHandler = @MainActor () -> Void
+
+    private final class ChoiceButton: UIButton {
+        let choice: FloorpWebExtensionPromptPresentation.Choice
+        private let image: UIImage?
+
+        init(choice: FloorpWebExtensionPromptPresentation.Choice) {
+            self.choice = choice
+            switch choice.icon {
+            case .system(let name):
+                image = UIImage(systemName: name)?.withRenderingMode(.alwaysTemplate)
+            case .extensionIcon(let id, let data):
+                image = FloorpWebExtensionIconRegistry.descriptor(for: id, iconData: data).image()
+            }
+            super.init(frame: .zero)
+            translatesAutoresizingMaskIntoConstraints = false
+            contentHorizontalAlignment = .leading
+            accessibilityIdentifier = choice.identifier
+            accessibilityLabel = choice.title
+            accessibilityHint = choice.detail
+            accessibilityValue = choice.isSelected ? FloorpStrings.WebExtensions.currentSelection : nil
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        func applyTheme(theme: Theme) {
+            var configuration = UIButton.Configuration.plain()
+            configuration.title = choice.title
+            configuration.subtitle = choice.isSelected
+                ? [choice.detail, FloorpStrings.WebExtensions.currentSelection]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " · ")
+                : choice.detail
+            configuration.image = choice.isSelected
+                ? UIImage(systemName: "checkmark.circle.fill")
+                : image
+            configuration.imagePlacement = .leading
+            configuration.imagePadding = 14
+            configuration.titleAlignment = .leading
+            configuration.contentInsets = NSDirectionalEdgeInsets(
+                top: 12,
+                leading: 14,
+                bottom: 12,
+                trailing: 14
+            )
+            configuration.background.backgroundColor = theme.colors.layer2
+            configuration.background.strokeColor = choice.isSelected
+                ? theme.colors.iconAccent
+                : theme.colors.borderPrimary
+            configuration.background.strokeWidth = choice.isSelected ? 2 : 1
+            configuration.background.cornerRadius = 14
+            configuration.baseForegroundColor = switch choice.role {
+            case .standard: theme.colors.textPrimary
+            case .preferred: theme.colors.textAccent
+            case .destructive: theme.colors.textCritical
+            }
+            configuration.titleTextAttributesTransformer = .init { incoming in
+                var outgoing = incoming
+                outgoing.font = .preferredFont(forTextStyle: .headline)
+                return outgoing
+            }
+            configuration.subtitleTextAttributesTransformer = .init { incoming in
+                var outgoing = incoming
+                outgoing.font = .preferredFont(forTextStyle: .subheadline)
+                outgoing.foregroundColor = theme.colors.textSecondary
+                return outgoing
+            }
+            self.configuration = configuration
+        }
+    }
+
+    let windowUUID: WindowUUID
+    var currentWindowUUID: WindowUUID? { windowUUID }
+    var themeManager: ThemeManager
+    var themeListenerCancellable: Any?
+
+    let presentation: FloorpWebExtensionPromptPresentation
+    private let notificationCenter: NotificationProtocol
+    private let onChoice: ChoiceHandler
+    private let onCancel: CancelHandler
+    private let scrollView: UIScrollView = .build()
+    private let contentStack: UIStackView = .build()
+    private let heroCard: UIView = .build()
+    private let heroIconView: UIImageView = .build()
+    private let titleLabel: UILabel = .build()
+    private let messageLabel: UILabel = .build()
+    private let cancelButton: UIButton = .build()
+    private var choiceButtons = [ChoiceButton]()
+    private var didFinish = false
+    private var heroUsesTemplateRendering = true
+
+    var displayedChoiceTitles: [String] { choiceButtons.map(\.choice.title) }
+    var displayedHeroIcon: UIImage? { heroIconView.image }
+
+    init(
+        presentation: FloorpWebExtensionPromptPresentation,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager = AppContainer.shared.resolve(),
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
+        onChoice: @escaping ChoiceHandler,
+        onCancel: @escaping CancelHandler = {}
+    ) {
+        self.presentation = presentation
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.onChoice = onChoice
+        self.onCancel = onCancel
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .pageSheet
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.accessibilityIdentifier = presentation.accessibilityIdentifier
+        setupView()
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
+    }
+
+    func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        view.backgroundColor = theme.colors.layer1
+        scrollView.backgroundColor = theme.colors.layer1
+        heroCard.backgroundColor = theme.colors.layer2
+        heroCard.layer.borderColor = theme.colors.borderPrimary.cgColor
+        heroIconView.tintColor = heroUsesTemplateRendering ? theme.colors.iconAccent : nil
+        titleLabel.textColor = theme.colors.textPrimary
+        messageLabel.textColor = theme.colors.textSecondary
+        choiceButtons.forEach { $0.applyTheme(theme: theme) }
+
+        var cancelConfiguration = UIButton.Configuration.gray()
+        cancelConfiguration.title = presentation.cancelTitle
+        cancelConfiguration.baseForegroundColor = theme.colors.textPrimary
+        cancelConfiguration.cornerStyle = .large
+        cancelButton.configuration = cancelConfiguration
+    }
+
+    private func setupView() {
+        contentStack.axis = .vertical
+        contentStack.spacing = 12
+        contentStack.alignment = .fill
+        heroCard.layer.cornerRadius = 18
+        heroCard.layer.borderWidth = 1
+
+        configureHero()
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+        view.addSubview(cancelButton)
+        contentStack.addArrangedSubview(heroCard)
+        presentation.choices.forEach(addChoice)
+
+        cancelButton.accessibilityIdentifier = "\(presentation.accessibilityIdentifier).Cancel"
+        cancelButton.addAction(UIAction { [weak self] _ in self?.finishWithCancel() }, for: .touchUpInside)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: cancelButton.topAnchor, constant: -12),
+            contentStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor, constant: 20),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor, constant: -20),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            cancelButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            cancelButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            cancelButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        ])
+    }
+
+    private func configureHero() {
+        let heroStack: UIStackView = .build()
+        heroStack.axis = .vertical
+        heroStack.alignment = .center
+        heroStack.spacing = 10
+        heroCard.addSubview(heroStack)
+
+        switch presentation.heroIcon {
+        case .system(let name):
+            heroIconView.image = UIImage(systemName: name)?.withRenderingMode(.alwaysTemplate)
+            heroUsesTemplateRendering = true
+        case .extensionIcon(let id, let data):
+            let descriptor = FloorpWebExtensionIconRegistry.descriptor(for: id, iconData: data)
+            heroIconView.image = descriptor.image()
+            heroUsesTemplateRendering = descriptor.usesTemplateRendering()
+        }
+        heroIconView.contentMode = .scaleAspectFit
+        heroIconView.isAccessibilityElement = false
+        titleLabel.text = presentation.title
+        titleLabel.font = .preferredFont(forTextStyle: .title2)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        titleLabel.textAlignment = .center
+        messageLabel.text = presentation.message
+        messageLabel.font = .preferredFont(forTextStyle: .body)
+        messageLabel.adjustsFontForContentSizeCategory = true
+        messageLabel.numberOfLines = 0
+        messageLabel.textAlignment = .center
+
+        heroStack.addArrangedSubview(heroIconView)
+        heroStack.addArrangedSubview(titleLabel)
+        heroStack.addArrangedSubview(messageLabel)
+        NSLayoutConstraint.activate([
+            heroStack.topAnchor.constraint(equalTo: heroCard.topAnchor, constant: 20),
+            heroStack.leadingAnchor.constraint(equalTo: heroCard.leadingAnchor, constant: 18),
+            heroStack.trailingAnchor.constraint(equalTo: heroCard.trailingAnchor, constant: -18),
+            heroStack.bottomAnchor.constraint(equalTo: heroCard.bottomAnchor, constant: -20),
+            heroIconView.widthAnchor.constraint(equalToConstant: 58),
+            heroIconView.heightAnchor.constraint(equalTo: heroIconView.widthAnchor)
+        ])
+    }
+
+    private func addChoice(_ choice: FloorpWebExtensionPromptPresentation.Choice) {
+        let button = ChoiceButton(choice: choice)
+        button.addAction(UIAction { [weak self] _ in
+            self?.finishWithChoice(choice.identifier)
+        }, for: .touchUpInside)
+        choiceButtons.append(button)
+        contentStack.addArrangedSubview(button)
+        button.heightAnchor.constraint(greaterThanOrEqualToConstant: 68).isActive = true
+    }
+
+    private func finishWithChoice(_ identifier: String) {
+        guard !didFinish else { return }
+        didFinish = true
+        setControlsEnabled(false)
+        dismiss(animated: true) { [onChoice] in onChoice(identifier) }
+    }
+
+    private func finishWithCancel() {
+        guard !didFinish else { return }
+        didFinish = true
+        setControlsEnabled(false)
+        dismiss(animated: true) { [onCancel] in onCancel() }
+    }
+
+    private func setControlsEnabled(_ isEnabled: Bool) {
+        choiceButtons.forEach { $0.isEnabled = isEnabled }
+        cancelButton.isEnabled = isEnabled
+    }
+}
+
 struct FloorpWebExtensionInstallPresentation: Sendable {
     enum Mode: Sendable, Equatable {
         case install

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionPresentation.swift
@@ -369,6 +369,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
                                                       InjectedThemeUUIDIdentifiable {
     typealias ChoiceHandler = @MainActor (String) -> Void
     typealias CancelHandler = @MainActor () -> Void
+    typealias DismissHandler = @MainActor () -> Void
 
     private final class ChoiceButton: UIButton {
         let choice: FloorpWebExtensionPromptPresentation.Choice
@@ -450,6 +451,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
     private let notificationCenter: NotificationProtocol
     private let onChoice: ChoiceHandler
     private let onCancel: CancelHandler
+    private let onDismiss: DismissHandler
     private let scrollView: UIScrollView = .build()
     private let contentStack: UIStackView = .build()
     private let heroCard: UIView = .build()
@@ -459,6 +461,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
     private let cancelButton: UIButton = .build()
     private var choiceButtons = [ChoiceButton]()
     private var didFinish = false
+    private var didReportDismissal = false
     private var heroUsesTemplateRendering = true
 
     var displayedChoiceTitles: [String] { choiceButtons.map(\.choice.title) }
@@ -470,7 +473,8 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         notificationCenter: NotificationProtocol = NotificationCenter.default,
         onChoice: @escaping ChoiceHandler,
-        onCancel: @escaping CancelHandler = {}
+        onCancel: @escaping CancelHandler = {},
+        onDismiss: @escaping DismissHandler = {}
     ) {
         self.presentation = presentation
         self.windowUUID = windowUUID
@@ -478,6 +482,7 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
         self.notificationCenter = notificationCenter
         self.onChoice = onChoice
         self.onCancel = onCancel
+        self.onDismiss = onDismiss
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .pageSheet
     }
@@ -492,6 +497,13 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
         setupView()
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         applyTheme()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        guard !didReportDismissal else { return }
+        didReportDismissal = true
+        onDismiss()
     }
 
     func applyTheme() {
@@ -601,14 +613,19 @@ final class FloorpWebExtensionPromptViewController: UIViewController,
         guard !didFinish else { return }
         didFinish = true
         setControlsEnabled(false)
-        dismiss(animated: true) { [onChoice] in onChoice(identifier) }
+        // A permission mutation is a product event, not a presentation
+        // completion. Deliver it before asking UIKit to dismiss so a missing
+        // or interrupted dismissal completion cannot silently drop consent.
+        onChoice(identifier)
+        dismiss(animated: true)
     }
 
     private func finishWithCancel() {
         guard !didFinish else { return }
         didFinish = true
         setControlsEnabled(false)
-        dismiss(animated: true) { [onCancel] in onCancel() }
+        onCancel()
+        dismiss(animated: true)
     }
 
     private func setControlsEnabled(_ isEnabled: Bool) {

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
@@ -1211,6 +1211,7 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
 
     private func presentExtensionPrompt(
         _ presentation: FloorpWebExtensionPromptPresentation,
+        onDismiss: @escaping FloorpWebExtensionPromptViewController.DismissHandler = {},
         onChoice: @escaping FloorpWebExtensionPromptViewController.ChoiceHandler
     ) {
         let controller = FloorpWebExtensionPromptViewController(
@@ -1218,7 +1219,8 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
             windowUUID: windowUUID,
             themeManager: themeManager,
             notificationCenter: notificationCenter,
-            onChoice: onChoice
+            onChoice: onChoice,
+            onDismiss: onDismiss
         )
         controller.sheetPresentationController?.detents = [.medium(), .large()]
         controller.sheetPresentationController?.prefersGrabberVisible = true
@@ -1327,7 +1329,17 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
                 ? "Floorp.WebExtensions.PrivateSiteAccess"
                 : "Floorp.WebExtensions.SiteAccess"
         )
-        presentExtensionPrompt(prompt) { identifier in choiceActions[identifier]?() }
+        var deferredChoiceAction: (() -> Void)?
+        presentExtensionPrompt(
+            prompt,
+            onDismiss: { deferredChoiceAction?() }
+        ) { identifier in
+            if identifier == "addSite" {
+                deferredChoiceAction = choiceActions[identifier]
+            } else {
+                choiceActions[identifier]?()
+            }
+        }
     }
 
     private func confirmPrivateBrowsingChange(
@@ -2441,11 +2453,12 @@ final class FloorpWebExtensionLivePackageManager: FloorpWebExtensionSettingsMana
         return (authorization, package)
     }
 
+    @discardableResult
     func updateGrants(
         _ grants: FloorpWebExtensionPermissionSnapshot,
         authorization: PermissionMutationAuthorization,
         validateSender: @MainActor () -> Bool = { true }
-    ) async throws {
+    ) async throws -> FloorpWebExtensionInstalledPackage {
         let extensionID = authorization.extensionID
         let gate = lifecycleMutationGate(for: extensionID)
         await gate.acquire()
@@ -2500,17 +2513,19 @@ final class FloorpWebExtensionLivePackageManager: FloorpWebExtensionSettingsMana
             }
             throw error
         }
-        if let package = await store.installedPackage(for: extensionID), package.isEnabled {
-            do {
-                try await reconcile(extensionID, package, .suspend)
-            } catch {
-                try? await store.recordActivationFailure(
-                    for: extensionID,
-                    expectedGeneration: package.generation
-                )
-                throw error
-            }
+        guard let package = await store.installedPackage(for: extensionID), package.isEnabled else {
+            throw FloorpWebExtensionPackageStoreError.inactivePackageGeneration(extensionID)
         }
+        do {
+            try await reconcile(extensionID, package, .suspend)
+        } catch {
+            try? await store.recordActivationFailure(
+                for: extensionID,
+                expectedGeneration: package.generation
+            )
+            throw error
+        }
+        return package
     }
 
     /// Keeps the native DNR-exemption mutation on the same lifecycle gate as

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionSettingsViewController.swift
@@ -1205,6 +1205,26 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
         }
     }
 
+    private func iconData(for package: FloorpWebExtensionSettingsInstalledPackage) -> Data? {
+        catalogItems.first(where: { $0.id == package.id })?.iconData
+    }
+
+    private func presentExtensionPrompt(
+        _ presentation: FloorpWebExtensionPromptPresentation,
+        onChoice: @escaping FloorpWebExtensionPromptViewController.ChoiceHandler
+    ) {
+        let controller = FloorpWebExtensionPromptViewController(
+            presentation: presentation,
+            windowUUID: windowUUID,
+            themeManager: themeManager,
+            notificationCenter: notificationCenter,
+            onChoice: onChoice
+        )
+        controller.sheetPresentationController?.detents = [.medium(), .large()]
+        controller.sheetPresentationController?.prefersGrabberVisible = true
+        present(controller, animated: true)
+    }
+
     private func showSiteAccess(_ package: FloorpWebExtensionSettingsInstalledPackage) {
         showSiteAccess(package, isPrivateBrowsing: false)
     }
@@ -1214,60 +1234,100 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
         isPrivateBrowsing: Bool
     ) {
         let currentAccess = isPrivateBrowsing ? package.privateHostAccess : package.normalHostAccess
-        let profileTitle = isPrivateBrowsing ? "Private site access" : "Site access"
-        let profileMessage = isPrivateBrowsing
-            ? "Choose exactly where this separately installed private extension may read or change page data."
-            : "Choose exactly where this extension may read or change page data."
-        let alert = UIAlertController(
-            title: "\(profileTitle) for \(package.name)",
-            message: profileMessage,
-            preferredStyle: .actionSheet
-        )
-        alert.addAction(UIAlertAction(title: "No sites", style: .destructive) { [weak self] _ in
+        let selectedSites = Self.selectedSites(from: currentAccess)
+        var choices = [FloorpWebExtensionPromptPresentation.Choice]()
+        var choiceActions = [String: () -> Void]()
+
+        let denyIdentifier = "deny"
+        choices.append(.init(
+            identifier: denyIdentifier,
+            title: FloorpStrings.WebExtensions.noSites,
+            detail: FloorpStrings.WebExtensions.noSitesDetail,
+            icon: .system("hand.raised.slash.fill"),
+            role: .destructive,
+            isSelected: currentAccess == .denied
+        ))
+        choiceActions[denyIdentifier] = { [weak self] in
             self?.setSiteAccess(.denied, for: package.id, isPrivateBrowsing: isPrivateBrowsing)
-        })
-        alert.addAction(UIAlertAction(title: "All requested sites", style: .default) { [weak self] _ in
+        }
+
+        let allIdentifier = "allRequestedSites"
+        choices.append(.init(
+            identifier: allIdentifier,
+            title: FloorpStrings.WebExtensions.allRequestedSitesChoice,
+            detail: FloorpStrings.WebExtensions.allRequestedSites(package.requestedSites.count),
+            icon: .system("globe.americas.fill"),
+            role: .preferred,
+            isSelected: currentAccess == .allRequestedSites
+        ))
+        choiceActions[allIdentifier] = { [weak self] in
             self?.setSiteAccess(.allRequestedSites, for: package.id, isPrivateBrowsing: isPrivateBrowsing)
-        })
-        for site in package.requestedSites {
-            alert.addAction(UIAlertAction(title: "Only \(site.original)", style: .default) { [weak self] _ in
+        }
+
+        for (index, site) in package.requestedSites.enumerated() {
+            let identifier = "only.\(index)"
+            choices.append(.init(
+                identifier: identifier,
+                title: FloorpStrings.WebExtensions.onlySite(site.original),
+                detail: FloorpStrings.WebExtensions.onlySiteDetail,
+                icon: .system("link"),
+                isSelected: selectedSites == [site]
+            ))
+            choiceActions[identifier] = { [weak self] in
                 self?.setSiteAccess(
                     .selectedSites([site]),
                     for: package.id,
                     isPrivateBrowsing: isPrivateBrowsing
                 )
-            })
+            }
         }
-        if case .allRequestedSites = currentAccess {
-            // No narrower controls are needed: every declared site is already
-            // authorized. The explicit "No sites" and "Only" actions above
-            // remain available to reduce access.
-        } else {
-            alert.addAction(UIAlertAction(title: "Add a site…", style: .default) { [weak self] _ in
+        if currentAccess != .allRequestedSites {
+            let addIdentifier = "addSite"
+            choices.append(.init(
+                identifier: addIdentifier,
+                title: FloorpStrings.WebExtensions.addSite,
+                detail: FloorpStrings.WebExtensions.addSiteMessage,
+                icon: .system("plus.circle.fill")
+            ))
+            choiceActions[addIdentifier] = { [weak self] in
                 self?.promptForSelectedSite(package, isPrivateBrowsing: isPrivateBrowsing)
-            })
-            for site in Self.selectedSites(from: currentAccess).sorted(by: { $0.original < $1.original }) {
-                alert.addAction(UIAlertAction(
-                    title: "Remove \(site.original)",
-                    style: .destructive
-                ) { [weak self] _ in
+            }
+            for (index, site) in selectedSites.sorted(by: { $0.original < $1.original }).enumerated() {
+                let identifier = "remove.\(index)"
+                choices.append(.init(
+                    identifier: identifier,
+                    title: FloorpStrings.WebExtensions.removeSite(site.original),
+                    detail: FloorpStrings.WebExtensions.noSitesDetail,
+                    icon: .system("minus.circle.fill"),
+                    role: .destructive
+                ))
+                choiceActions[identifier] = { [weak self] in
                     guard let self else { return }
-                    var selectedSites = Self.selectedSites(from: currentAccess)
-                    selectedSites.remove(site)
+                    var replacementSites = selectedSites
+                    replacementSites.remove(site)
                     self.setSiteAccess(
-                        selectedSites.isEmpty ? .denied : .selectedSites(selectedSites),
+                        replacementSites.isEmpty ? .denied : .selectedSites(replacementSites),
                         for: package.id,
                         isPrivateBrowsing: isPrivateBrowsing
                     )
-                })
+                }
             }
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = view
-            popover.sourceRect = view.bounds
-        }
-        present(alert, animated: true)
+        let prompt = FloorpWebExtensionPromptPresentation(
+            title: FloorpStrings.WebExtensions.siteAccessForTitle(
+                name: package.name,
+                isPrivateBrowsing: isPrivateBrowsing
+            ),
+            message: isPrivateBrowsing
+                ? FloorpStrings.WebExtensions.privateSiteAccessPromptMessage
+                : FloorpStrings.WebExtensions.siteAccessPromptMessage,
+            heroIcon: .extensionIcon(id: package.id, data: iconData(for: package)),
+            choices: choices,
+            accessibilityIdentifier: isPrivateBrowsing
+                ? "Floorp.WebExtensions.PrivateSiteAccess"
+                : "Floorp.WebExtensions.SiteAccess"
+        )
+        presentExtensionPrompt(prompt) { identifier in choiceActions[identifier]?() }
     }
 
     private func confirmPrivateBrowsingChange(
@@ -1278,21 +1338,23 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
             setPrivateBrowsingEnabled(false, for: package.id)
             return
         }
-        let privateBrowsingMessage = [
-            "This installs a separate ephemeral copy for private browsing.",
-            "Its site access starts disabled and private data is removed when the private session ends."
-        ].joined(separator: " ")
-        let alert = UIAlertController(
-            title: "Allow \(package.name) in Private Browsing?",
-            message: privateBrowsingMessage,
-            preferredStyle: .alert
+        let prompt = FloorpWebExtensionPromptPresentation(
+            title: FloorpStrings.WebExtensions.privateBrowsingConsentTitle(name: package.name),
+            message: FloorpStrings.WebExtensions.privateBrowsingConsentMessage,
+            heroIcon: .extensionIcon(id: package.id, data: iconData(for: package)),
+            choices: [.init(
+                identifier: "allow",
+                title: FloorpStrings.WebExtensions.allow,
+                detail: FloorpStrings.WebExtensions.privateBrowsingOptInMessage,
+                icon: .system("eye.slash.fill"),
+                role: .preferred
+            )],
+            accessibilityIdentifier: "Floorp.WebExtensions.PrivateBrowsingConsent"
         )
-        alert.view.accessibilityIdentifier = "Floorp.WebExtensions.PrivateBrowsingConsent"
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Allow", style: .default) { [weak self] _ in
+        presentExtensionPrompt(prompt) { [weak self] identifier in
+            guard identifier == "allow" else { return }
             self?.setPrivateBrowsingEnabled(true, for: package.id)
-        })
-        present(alert, animated: true)
+        }
     }
 
     private func showPrivateSiteAccess(_ package: FloorpWebExtensionSettingsInstalledPackage) {
@@ -1304,8 +1366,8 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
         isPrivateBrowsing: Bool
     ) {
         let alert = UIAlertController(
-            title: "Add a site",
-            message: "Enter a hostname or HTTPS URL. This authorizes only that site, not every requested site.",
+            title: FloorpStrings.WebExtensions.addSite,
+            message: FloorpStrings.WebExtensions.addSiteMessage,
             preferredStyle: .alert
         )
         alert.view.accessibilityIdentifier = "Floorp.WebExtensions.AddSelectedSite"
@@ -1315,8 +1377,8 @@ final class FloorpWebExtensionSettingsViewController: ThemedTableViewController 
             field.autocorrectionType = .no
             field.keyboardType = .URL
         }
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Add", style: .default) { [weak self, weak alert] _ in
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.add, style: .default) { [weak self, weak alert] _ in
             guard let self,
                   let input = alert?.textFields?.first?.text,
                   let selectedSite = Self.selectedSitePattern(from: input) else {

--- a/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionTabs.swift
+++ b/firefox-ios/Floorp/WebExtensions/FloorpWebExtensionTabs.swift
@@ -155,6 +155,18 @@ final class FloorpWebExtensionProfileTabsHost: FloorpWebExtensionTabsHostAdaptin
         sender: any FloorpWebExtensionMessageSender,
         to tab: FloorpWebExtensionTabContext
     ) async throws -> FloorpWebExtensionJSONValue? {
+        // A content script commonly connects to its background and the
+        // background immediately answers with tabs.sendMessage (Dark Reader
+        // does this for its initial theme). Let the inbound WebKit reply
+        // unwind before evaluating back into the same WKWebView; otherwise
+        // WebKit can drop the re-entrant delivery even though both bridges are
+        // already installed. Re-resolve the exact document after the turn so
+        // a navigation during this barrier still fails closed.
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
         let liveTab = try liveTab(for: tab.tabID)
         guard let activeDocument = liveTab.floorpWebExtensionActiveDocumentContext,
               activeDocument.documentGeneration == tab.documentGeneration,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/BrowserCoordinatorTests.swift
@@ -1665,6 +1665,55 @@ final class BrowserCoordinatorTests: XCTestCase,
         XCTAssertTrue(plan.isPrivateBrowsing)
     }
 
+    func testWebExtensionActionConsentAllowsRequestedRedirectForAllSites() throws {
+        let requestedHosts = Set([try FloorpWebExtensionMatchPattern("<all_urls>")])
+
+        XCTAssertTrue(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "https://m.yahoo.co.jp/?source=redirect#top"),
+            requestedHosts: requestedHosts,
+            access: .allRequestedSites
+        ))
+    }
+
+    func testWebExtensionActionConsentKeepsSelectedSiteScopedToHost() throws {
+        let requestedHosts = Set([try FloorpWebExtensionMatchPattern("<all_urls>")])
+        let selectedSite = try FloorpWebExtensionMatchPattern("https://www.example.com/*")
+        let access = FloorpWebExtensionHostAccess.selectedSites([selectedSite])
+
+        XCTAssertTrue(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "https://www.example.com/changed/path?query=1#section"),
+            requestedHosts: requestedHosts,
+            access: access
+        ))
+        XCTAssertFalse(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "https://m.example.com/"),
+            requestedHosts: requestedHosts,
+            access: access
+        ))
+    }
+
+    func testWebExtensionActionConsentRejectsProtectedAndUnrequestedPages() throws {
+        let requestedHosts = Set([
+            try FloorpWebExtensionMatchPattern("https://allowed.example/*")
+        ])
+
+        XCTAssertFalse(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "about:blank"),
+            requestedHosts: requestedHosts,
+            access: .allRequestedSites
+        ))
+        XCTAssertFalse(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "https://other.example/"),
+            requestedHosts: requestedHosts,
+            access: .allRequestedSites
+        ))
+        XCTAssertFalse(BrowserCoordinator.webExtensionActionConsentRemainsValid(
+            currentURL: URL(string: "https://allowed.example/"),
+            requestedHosts: requestedHosts,
+            access: .denied
+        ))
+    }
+
     // MARK: - Route handling
 
     // MARK: canHandle(route:)

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/DefaultThemeManagerTests.swift
@@ -4,6 +4,7 @@
 
 import XCTest
 @testable import Common
+@testable import Client
 
 @MainActor
 final class DefaultThemeManagerTests: XCTestCase {
@@ -11,6 +12,7 @@ final class DefaultThemeManagerTests: XCTestCase {
 
     // MARK: - Variables
 
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var userDefaults: MockUserDefaults!
 
     // MARK: - Test lifecycle
@@ -55,6 +57,15 @@ final class DefaultThemeManagerTests: XCTestCase {
 
         XCTAssertEqual(systemResult, expectedSystemResult)
         XCTAssertEqual(nightModeResult, expectedNightModeResult)
+    }
+
+    func testBuiltInNightModeRemainsDisabledAndClearsLegacyPreference() {
+        userDefaults.set(true, forKey: "profile.NightModeStatus")
+
+        XCTAssertFalse(NightModeHelper.isActivated(userDefaults))
+
+        NightModeHelper.cleanNightModeDefaults(userDefaults)
+        XCTAssertNil(userDefaults.object(forKey: "profile.NightModeStatus"))
     }
 
     func testDTM_onInitialization_hasLightTheme() {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
@@ -498,6 +498,103 @@ final class FloorpWebExtensionAPIHostTests: XCTestCase {
         }
     }
 
+    func testBackgroundRuntimeFetchStreamsLargeAuthorizedResponse() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let requestedURL = try XCTUnwrap(URL(string: "https://styles.example/site.css"))
+        let expectedBody = Data((0..<70_000).map { UInt8($0 % 251) })
+        let hostPattern = try FloorpWebExtensionMatchPattern("https://styles.example/*")
+        let host = try FloorpWebExtensionAPIHost(
+            profileIdentifier: "api-runtime-fetch-profile",
+            isPrivateBrowsing: false,
+            directory: directory,
+            preferredLocales: ["en"],
+            packageResourceLoader: { _, _ in nil },
+            alarmEvents: .init(),
+            permissionBroker: .init(),
+            networkFetchTransport: { url in
+                guard url == requestedURL else {
+                    throw FloorpWebExtensionMessageError.handlerFailed
+                }
+                return .init(
+                    url: url,
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "text/css; charset=utf-8",
+                        "Set-Cookie": "must-not-cross-the-bridge=true"
+                    ],
+                    body: expectedBody
+                )
+            }
+        )
+        await host.activate(
+            extensionID: extensionID,
+            grants: .init(
+                requestedHosts: [hostPattern],
+                normalHostAccess: .allRequestedSites
+            ),
+            defaultLocale: "en",
+            packageGeneration: "network-fetch-generation"
+        )
+        let sender = FloorpWebExtensionBackgroundRuntimeMessageSender(
+            extensionID: extensionID,
+            profileKey: host.profileKey,
+            packageGeneration: "network-fetch-generation",
+            originHost: "network-fetch-fixture"
+        )
+
+        let initialPayload = try await host.dispatch(
+            operation: "runtime.fetch",
+            payload: try payload(["url": requestedURL.absoluteString, "method": "GET"]),
+            sender: sender
+        )
+        let initial = try XCTUnwrap(initialPayload).decode(RuntimeFetchResponseView.self)
+        XCTAssertEqual(initial.status, 200)
+        XCTAssertEqual(initial.headers["Content-Type"], "text/css; charset=utf-8")
+        XCTAssertNil(initial.headers["Set-Cookie"])
+        XCTAssertFalse(initial.done)
+
+        var reconstructedBody = try XCTUnwrap(Data(base64Encoded: initial.bodyBase64))
+        let fetchID = try XCTUnwrap(initial.fetchId)
+        var done = initial.done
+        while !done {
+            let chunkPayload = try await host.dispatch(
+                operation: "runtime.fetch.read",
+                payload: try payload(["fetchId": fetchID]),
+                sender: sender
+            )
+            let chunk = try XCTUnwrap(chunkPayload).decode(RuntimeFetchChunkResponseView.self)
+            reconstructedBody.append(try XCTUnwrap(Data(base64Encoded: chunk.bodyBase64)))
+            done = chunk.done
+        }
+        XCTAssertEqual(reconstructedBody, expectedBody)
+
+        do {
+            _ = try await host.dispatch(
+                operation: "runtime.fetch",
+                payload: try payload(["url": requestedURL.absoluteString, "method": "GET"]),
+                sender: testSender()
+            )
+            XCTFail("A tab content script must not own native network authority")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionMessageError, .unsupportedOperation)
+        }
+
+        do {
+            _ = try await host.dispatch(
+                operation: "runtime.fetch",
+                payload: try payload([
+                    "url": "https://unauthorized.example/site.css",
+                    "method": "GET"
+                ]),
+                sender: sender
+            )
+            XCTFail("Background fetch must remain within durable host access")
+        } catch {
+            XCTAssertEqual(error as? FloorpWebExtensionMessageError, .permissionDenied)
+        }
+    }
+
     func testPermissionsRequestNeedsTrustedConsentAndPersistsBeforeExposure() async throws {
         let directory = temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -1813,6 +1910,19 @@ private struct RuntimeManifestResponse: Decodable, Equatable {
     let manifest_version: Int
     let name: String
     let version: String
+}
+
+private struct RuntimeFetchResponseView: Decodable {
+    let status: Int
+    let headers: [String: String]
+    let bodyBase64: String
+    let fetchId: String?
+    let done: Bool
+}
+
+private struct RuntimeFetchChunkResponseView: Decodable {
+    let bodyBase64: String
+    let done: Bool
 }
 
 private struct RegisteredScriptView: Decodable {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionAPIHostTests.swift
@@ -550,6 +550,7 @@ final class FloorpWebExtensionAPIHostTests: XCTestCase {
         )
         let initial = try XCTUnwrap(initialPayload).decode(RuntimeFetchResponseView.self)
         XCTAssertEqual(initial.status, 200)
+        XCTAssertEqual(initial.statusText, "")
         XCTAssertEqual(initial.headers["Content-Type"], "text/css; charset=utf-8")
         XCTAssertNil(initial.headers["Set-Cookie"])
         XCTAssertFalse(initial.done)
@@ -1914,6 +1915,7 @@ private struct RuntimeManifestResponse: Decodable, Equatable {
 
 private struct RuntimeFetchResponseView: Decodable {
     let status: Int
+    let statusText: String
     let headers: [String: String]
     let bodyBase64: String
     let fetchId: String?

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
@@ -3319,6 +3319,60 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         XCTAssertEqual(cell.accessibilityValue, FloorpStrings.WebExtensions.enabled)
     }
 
+    func testRichExtensionPromptShowsArtworkChoicesAndCurrentSelection() throws {
+        let iconData = try XCTUnwrap(Data(base64Encoded:
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        ))
+        let presentation = FloorpWebExtensionPromptPresentation(
+            title: FloorpStrings.WebExtensions.siteAccessForTitle(
+                name: "Dark Reader",
+                isPrivateBrowsing: false
+            ),
+            message: FloorpStrings.WebExtensions.siteAccessPromptMessage,
+            heroIcon: .extensionIcon(id: extensionID, data: iconData),
+            choices: [
+                .init(
+                    identifier: "deny",
+                    title: FloorpStrings.WebExtensions.noSites,
+                    detail: FloorpStrings.WebExtensions.noSitesDetail,
+                    icon: .system("hand.raised.slash.fill"),
+                    role: .destructive
+                ),
+                .init(
+                    identifier: "all",
+                    title: FloorpStrings.WebExtensions.allRequestedSitesChoice,
+                    detail: FloorpStrings.WebExtensions.allRequestedSites(1),
+                    icon: .system("globe.americas.fill"),
+                    role: .preferred,
+                    isSelected: true
+                )
+            ],
+            accessibilityIdentifier: "Floorp.WebExtensions.Prompt.Test"
+        )
+        let subject = FloorpWebExtensionPromptViewController(
+            presentation: presentation,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: MockThemeManager(),
+            onChoice: { _ in }
+        )
+
+        subject.loadViewIfNeeded()
+
+        XCTAssertEqual(subject.view.accessibilityIdentifier, "Floorp.WebExtensions.Prompt.Test")
+        XCTAssertEqual(subject.displayedChoiceTitles, [
+            FloorpStrings.WebExtensions.noSites,
+            FloorpStrings.WebExtensions.allRequestedSitesChoice
+        ])
+        XCTAssertEqual(subject.displayedHeroIcon?.renderingMode, .alwaysOriginal)
+        let selectedButton = try XCTUnwrap(Self.allSubviews(in: subject.view).first {
+            $0.accessibilityIdentifier == "all"
+        } as? UIButton)
+        XCTAssertEqual(selectedButton.accessibilityValue, FloorpStrings.WebExtensions.currentSelection)
+        XCTAssertTrue(selectedButton.configuration?.subtitle?.contains(
+            FloorpStrings.WebExtensions.currentSelection
+        ) == true)
+    }
+
     func testCatalogArchiveSelectsOnlySafeManifestDeclaredIconData() throws {
         let smallIcon = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x10])
         let preferredIcon = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x80])

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
@@ -3378,7 +3378,7 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         ) == true)
     }
 
-    func testRichExtensionPromptDeliversChoiceBeforeDismissalExactlyOnce() throws {
+    func testRichExtensionPromptDeliversChoiceAfterDismissalExactlyOnce() throws {
         let presentation = FloorpWebExtensionPromptPresentation(
             title: "Site access",
             message: "Choose access",
@@ -3408,10 +3408,11 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         choiceButton.sendActions(for: .touchUpInside)
         choiceButton.sendActions(for: .touchUpInside)
 
-        XCTAssertEqual(selectedIdentifiers, ["all"])
+        XCTAssertTrue(selectedIdentifiers.isEmpty)
         XCTAssertEqual(dismissalCount, 0)
         subject.viewDidDisappear(false)
         subject.viewDidDisappear(false)
+        XCTAssertEqual(selectedIdentifiers, ["all"])
         XCTAssertEqual(dismissalCount, 1)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
@@ -2641,7 +2641,8 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         let store = try FloorpWebExtensionPackageStore(
             profileIdentifier: "signed-bundled-catalog",
             isPrivateBrowsing: false,
-            directory: directory
+            directory: directory,
+            clock: { signing.now }
         )
         let manager = FloorpWebExtensionLivePackageManager(
             store: store,

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/FloorpWebExtensionPackageStoreTests.swift
@@ -1893,9 +1893,13 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
             for: extensionID,
             expectedGeneration: retained.generation
         )
-        try await manager.updateGrants(proposed, authorization: currentAuthorization)
+        let committedResult = try await manager.updateGrants(
+            proposed,
+            authorization: currentAuthorization
+        )
         let committedRecord = await store.installedPackage(for: extensionID)
         let committed = try XCTUnwrap(committedRecord)
+        XCTAssertEqual(committedResult, committed)
         XCTAssertTrue(committed.grants.apiPermissions.contains(.tabs))
         await assertAsyncThrows {
             try await manager.updateGrants(proposed, authorization: currentAuthorization)
@@ -2819,7 +2823,7 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         // A consent token captured before expiry cannot add an optional API
         // permission after the signed catalog lifetime ends.
         do {
-            try await pendingGrantUpdate.value
+            _ = try await pendingGrantUpdate.value
             XCTFail("Expired catalog must not commit a pending optional permission grant")
         } catch {
             XCTAssertEqual(error as? FloorpWebExtensionCatalogError, .expired)
@@ -3371,6 +3375,43 @@ final class FloorpWebExtensionPackageStoreTests: XCTestCase {
         XCTAssertTrue(selectedButton.configuration?.subtitle?.contains(
             FloorpStrings.WebExtensions.currentSelection
         ) == true)
+    }
+
+    func testRichExtensionPromptDeliversChoiceBeforeDismissalExactlyOnce() throws {
+        let presentation = FloorpWebExtensionPromptPresentation(
+            title: "Site access",
+            message: "Choose access",
+            heroIcon: .system("puzzlepiece.extension.fill"),
+            choices: [.init(
+                identifier: "all",
+                title: "All requested sites",
+                detail: "Every requested site",
+                icon: .system("globe.americas.fill")
+            )],
+            accessibilityIdentifier: "Floorp.WebExtensions.Prompt.ChoiceTest"
+        )
+        var selectedIdentifiers = [String]()
+        var dismissalCount = 0
+        let subject = FloorpWebExtensionPromptViewController(
+            presentation: presentation,
+            windowUUID: .XCTestDefaultUUID,
+            themeManager: MockThemeManager(),
+            onChoice: { selectedIdentifiers.append($0) },
+            onDismiss: { dismissalCount += 1 }
+        )
+        subject.loadViewIfNeeded()
+        let choiceButton = try XCTUnwrap(Self.allSubviews(in: subject.view).first {
+            $0.accessibilityIdentifier == "all"
+        } as? UIButton)
+
+        choiceButton.sendActions(for: .touchUpInside)
+        choiceButton.sendActions(for: .touchUpInside)
+
+        XCTAssertEqual(selectedIdentifiers, ["all"])
+        XCTAssertEqual(dismissalCount, 0)
+        subject.viewDidDisappear(false)
+        subject.viewDidDisappear(false)
+        XCTAssertEqual(dismissalCount, 1)
     }
 
     func testCatalogArchiveSelectsOnlySafeManifestDeclaredIconData() throws {

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -41,6 +41,20 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
         XCTAssertFalse(sections[0].isHorizontalTabsSection)
     }
 
+    func testGenerateMenuElements_extensionActionUsesLocalizedCopy() {
+        let wasEnabled = FloorpFlags.isWebExtensionFeatureEnabled(.core)
+        FloorpFlags.setWebExtensionFeature(.core, enabled: true)
+        defer { FloorpFlags.setWebExtensionFeature(.core, enabled: wasEnabled) }
+
+        let sections = configUtility.generateMenuElements(with: getTabInfo(), and: windowUUID)
+        let item = sections.flatMap(\.options).first {
+            $0.title == FloorpStrings.WebExtensions.actions
+        }
+
+        XCTAssertEqual(item?.a11yLabel, FloorpStrings.WebExtensions.actions)
+        XCTAssertEqual(item?.a11yHint, FloorpStrings.WebExtensions.actionsAccessibilityHint)
+    }
+
     func testGenerateMenuElements_siteSectionHasMoreOptions_whenIsExpandedFalse() {
         let sections = configUtility.generateMenuElements(with: getTabInfo(), and: windowUUID, isExpanded: false)
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/MainMenu/MainMenuConfigurationUtilityTests.swift
@@ -11,6 +11,7 @@ import SummarizeKit
 
 @MainActor
 final class MainMenuConfigurationUtilityTests: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var configUtility: MainMenuConfigurationUtility!
     let windowUUID: WindowUUID = .XCTestDefaultUUID
 
@@ -71,6 +72,17 @@ final class MainMenuConfigurationUtilityTests: XCTestCase {
 
         XCTAssertTrue(titles.contains(String.MainMenu.Submenus.Tools.PageZoom))
         XCTAssertTrue(titles.contains(String.MainMenu.Submenus.Tools.Print))
+    }
+
+    func testGenerateMenuElements_hidesBuiltInWebsiteDarkMode() {
+        let sections = configUtility.generateMenuElements(
+            with: getTabInfo(),
+            and: windowUUID,
+            isExpanded: true
+        )
+        let titles = sections.flatMap(\.options).map(\.title)
+
+        XCTAssertFalse(titles.contains(String.MainMenu.Submenus.Tools.WebsiteDarkMode))
     }
 
     func testGenerateMenuElements_readerViewItem_whenSummarizerLanguageExpansionEnabled() {

--- a/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/L10nSnapshotTests/L10nSuite2SnapshotTests.swift
@@ -82,12 +82,6 @@ class L10nSuite2SnapshotTests: L10nBaseSnapshotTests {
         mozWaitForElementToNotExist(app.staticTexts["XCUITests-Runner pasted from Fennec"])
         navigator.goto(BrowserTabMenu)
         snapshot("MenuOnWebPage-01")
-
-        navigator.toggleOn(userState.nightMode, withAction: Action.ToggleNightMode)
-
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenu)
-        snapshot("MenuOnWebPage-02")
     }
 
     @MainActor

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/NightModeTests.swift
@@ -4,49 +4,14 @@
 
 import XCTest
 class NightModeTests: BaseTestCase {
-    var nightModeOnCell: XCUIElement {
+    private var nightModeCell: XCUIElement {
         app.tables.cells["MainMenu.NightModeOn"]
     }
 
-    private func checkNightModeOn() {
-        mozWaitForElementToExist(nightModeOnCell)
-        XCTAssertTrue(nightModeOnCell.label == "Website Dark Mode")
-        if !iPad() {
-            mozWaitForElementToExist(app.tables.staticTexts["On"])
-        } else {
-            mozWaitForElementToExist(app.tables.staticTexts.matching(identifier: "On").element(boundBy: 1))
-        }
-        // Turn off night mode
-        nightModeOnCell.waitAndTap()
-    }
-
-    private func checkNightModeOff() {
-        mozWaitForElementToExist(nightModeOnCell)
-        XCTAssertTrue(nightModeOnCell.label == "Website Dark Mode")
-        if !iPad() {
-            mozWaitForElementToExist(app.tables.staticTexts.matching(identifier: "Off").element(boundBy: 1))
-        } else {
-            mozWaitForElementToExist(app.tables.staticTexts["Off"])
-        }
-    }
-
-    // https://mozilla.testrail.io/index.php?/cases/view/2307056
-    func testNightModeUI() {
-        let url1 = TestPages.exampleHTML
-        // Go to a webpage, and select night mode on and off, check it's applied or not
-        navigator.openURL(path(forTestPage: url1))
+    func testBuiltInNightModeIsNotExposed() {
+        navigator.openURL(path(forTestPage: TestPages.exampleHTML))
         waitUntilPageLoad()
-        // turn on the night mode
         navigator.goto(BrowserTabMenuMore)
-        navigator.performAction(Action.ToggleNightMode)
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenuMore)
-        // checking night mode on or off
-        checkNightModeOn()
-
-        // checking night mode on or off
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenuMore)
-        checkNightModeOff()
+        XCTAssertFalse(nightModeCell.exists)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/ScreenGraphTest.swift
@@ -9,7 +9,9 @@ import Shared
 
 @MainActor
 class ScreenGraphTest: XCTestCase {
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var navigator: MMNavigator<TestUserState>!
+    // swiftlint:disable:next implicitly_unwrapped_optional
     var app: XCUIApplication!
 
     func mozWaitForElementToNotExist(_ element: XCUIElement, timeout: TimeInterval? = TIMEOUT) {
@@ -69,29 +71,6 @@ extension ScreenGraphTest {
         let currentURL = navigator.userState.url as String?
         XCTAssertTrue(currentURL?.starts(with: "mozilla.org") ?? false, "Current url recorded by from the url bar is \(currentURL ?? "nil")")
     }
-
-    func testSimpleToggleAction() {
-        navigator.userState.url = "https://mozilla.org"
-        navigator.performAction(TestActions.LoadURLByTyping)
-        waitUntilPageLoad()
-        // Switch night mode on, by toggling.
-        navigator.performAction(TestActions.ToggleNightMode)
-        XCTAssertTrue(navigator.userState.nightMode)
-
-        navigator.nowAt(BrowserTab)
-        navigator.goto(BrowserTabMenuMore)
-        XCTAssertEqual(navigator.screenState, BrowserTabMenuMore)
-
-        // Nothing should happen here, because night mode is already on.
-        navigator.toggleOn(navigator.userState.nightMode, withAction: TestActions.ToggleNightMode)
-        XCTAssertTrue(navigator.userState.nightMode)
-        XCTAssertEqual(navigator.screenState, BrowserTabMenuMore)
-
-        // Switch night mode off.
-        navigator.toggleOff(navigator.userState.nightMode, withAction: TestActions.ToggleNighModeOff)
-        XCTAssertFalse(navigator.userState.nightMode)
-        XCTAssertEqual(navigator.screenState, BrowserTabMenuMore)
-    }
 }
 
 private let defaultURL = "https://example.com"
@@ -104,7 +83,6 @@ class TestUserState: MMUserState {
     }
 
     var url: String?
-    var nightMode = false
     var passcode: String?
     var newPasscode = "111111"
 }
@@ -112,8 +90,6 @@ class TestUserState: MMUserState {
 let WebPageLoading = "WebPageLoading"
 
 private class TestActions {
-    static let ToggleNightMode = "ToggleNightMode"
-    static let ToggleNighModeOff = "ToggleNightModeOff"
     static let LoadURL = "LoadURL"
     static let LoadURLByTyping = "LoadURLByTyping"
     static let LoadURLByPasting = "LoadURLByPasting"
@@ -159,18 +135,6 @@ private func createTestGraph(for test: XCTestCase, with app: XCUIApplication) ->
             app.tables["Context Menu"].cells[AccessibilityIdentifiers.Photon.pasteAndGoAction].waitAndTap()
         }
     }
-    map.addScreenState(BrowserTabMenuMore) { screenState in
-        // Web Site Dark Mode
-        screenState.gesture(forAction: TestActions.ToggleNightMode) { userState in
-            userState.nightMode = true
-            app.tables.cells[AccessibilityIdentifiers.MainMenu.nightMode].tap()
-        }
-        screenState.gesture(forAction: TestActions.ToggleNighModeOff) { userState in
-            userState.nightMode = false
-            app.tables.cells[AccessibilityIdentifiers.MainMenu.nightMode].tap()
-        }
-    }
-
     map.addScreenState(URLBarOpen) { screenState in
         screenState.gesture(forAction: TestActions.LoadURLByTyping, TestActions.LoadURL) { userState in
             let urlString = userState.url ?? defaultURL

--- a/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/XCUITests/registerTabMenuNavigation.swift
@@ -15,10 +15,6 @@ func registerTabMenuNavigation(in map: MMScreenGraph<FxUserState>, app: XCUIAppl
         screenState.tap(
             app.tables.cells[AccessibilityIdentifiers.MainMenu.addToShortcuts],
             forAction: Action.PinToTopSitesPAM)
-        // Web Site Dark Mode
-        screenState.tap(
-            app.tables.cells[AccessibilityIdentifiers.MainMenu.nightMode],
-            forAction: Action.ToggleNightMode)
         // Save As PDF (TODO)
         // Print
         screenState.tap(

--- a/package-lock.json
+++ b/package-lock.json
@@ -2262,9 +2262,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -2423,9 +2423,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -5158,9 +5158,9 @@
       }
     },
     "dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "requires": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -5269,9 +5269,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true
     },
     "fastest-levenshtein": {


### PR DESCRIPTION
## Summary
- redesign extension permission, site-access, and action-selection dialogs in a Firefox-style presentation
- fix action popup consent sequencing and keep permission choices bound to the live tab scope
- add a permission-scoped native CSS fetch bridge so Dark Reader can style sites such as Yahoo Japan
- disable and hide the built-in website night mode so Dark Reader is the sole page-darkening implementation
- add regression coverage for permission prompts, network fetch chunking, and retired night-mode UI

## Verification
- Fennec Fennec_Testing simulator build succeeded
- 5 focused WebExtension permission and fetch tests passed
- 2 built-in night-mode retirement tests passed
- verified Dark Reader styling on yahoo.co.jp in the iOS Simulator