### PR TITLE
Fix native extension popup presentation and UI

### DIFF
--- a/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
+++ b/firefox-ios/Client/Coordinators/Browser/BrowserCoordinator.swift
@@ -586,27 +586,15 @@ final class BrowserCoordinator: BaseCoordinator,
             return
         }
 
-        let alert = UIAlertController(
-            title: FloorpStrings.WebExtensions.actions,
-            message: FloorpStrings.WebExtensions.chooseActionMessage,
-            preferredStyle: .actionSheet
-        )
-        actions.forEach { action in
-            alert.addAction(UIAlertAction(title: action.label, style: .default) { [weak self, weak host, weak tab] _ in
+        let picker = FloorpNativeWebExtensionActionPickerViewController(
+            actions: actions,
+            windowUUID: windowUUID,
+            onSelection: { [weak self, weak host, weak tab] action in
                 guard let self, let host, let tab else { return }
                 self.performWebExtensionAction(action, host: host, tab: tab)
-            })
-        }
-        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.cancel, style: .cancel))
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = browserViewController.view
-            popover.sourceRect = browserViewController.view.bounds
-        }
-        // `DefaultRouter` assigns itself as the presentation controller
-        // delegate. UIKit forbids changing that delegate for
-        // `UIAlertController`, so alerts and action sheets are presented by
-        // their owning view controller directly.
-        browserViewController.present(alert, animated: true)
+            }
+        )
+        browserViewController.present(picker, animated: true)
     }
 
     func openURLInNewTab(_ url: URL?) {
@@ -630,8 +618,7 @@ final class BrowserCoordinator: BaseCoordinator,
         do {
             try host.performAction(
                 contextIdentifier: action.contextIdentifier,
-                for: tab,
-                present: { [weak self] popup in self?.present(popup) }
+                for: tab
             )
         } catch {
             presentWebExtensionActionsAlert(

--- a/firefox-ios/Floorp/Floorp.xcstrings
+++ b/firefox-ios/Floorp/Floorp.xcstrings
@@ -1645,28 +1645,28 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "プロファイル" } }
       }
     },
-    "Floorp.WebExtensions.SiteAccessStartsOffTitle.v1" : {
+    "Floorp.WebExtensions.SiteAccessGrantedTitle.v1" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site access starts off" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイトへのアクセスは最初はオフです" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Required website access" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "必須のウェブサイトアクセス" } }
       }
     },
-    "Floorp.WebExtensions.SiteAccessStartsOffMessage.v1" : {
+    "Floorp.WebExtensions.SiteAccessGrantedMessage.v1" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "After adding the extension, choose the sites where it may read or change content." } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能を追加した後、コンテンツの読み取りや変更を許可するサイトを選んでください。" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Adding this extension grants access to the required websites listed below. You can review or change access later." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能を追加すると、以下の必須ウェブサイトへのアクセスが許可されます。アクセスは後から確認または変更できます。" } }
       }
     },
-    "Floorp.WebExtensions.SiteAccessPreservedTitle.v1" : {
+    "Floorp.WebExtensions.SiteAccessUpdateTitle.v1" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site choices stay unchanged" } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイトの選択は引き継がれます" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Website access after update" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アップデート後のウェブサイトアクセス" } }
       }
     },
-    "Floorp.WebExtensions.SiteAccessPreservedMessage.v1" : {
+    "Floorp.WebExtensions.SiteAccessUpdateMessage.v1" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Your existing choices are preserved. Newly requested sites stay off until you allow them." } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在の選択は引き継がれます。新たに要求されたサイトは、許可するまでオフのままです。" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Updating preserves existing website access and grants access to any newly required websites listed below. You can review or change access later." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アップデートすると既存のウェブサイトアクセスが維持され、以下の新たな必須ウェブサイトへのアクセスも許可されます。アクセスは後から確認または変更できます。" } }
       }
     },
     "Floorp.WebExtensions.PrivateBrowsingOptInTitle.v1" : {
@@ -1685,6 +1685,12 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Not supported on this version of Floorp" } },
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "このバージョンのFloorpでは利用できません" } }
+      }
+    },
+    "Floorp.WebExtensions.RequiresOperatingSystem.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Requires %1$@ or later" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@ 以降が必要です" } }
       }
     },
     "Floorp.WebExtensions.PublisherLabel.v1" : {
@@ -1797,8 +1803,8 @@
     },
     "Floorp.WebExtensions.PostInstallSiteAccessGuidance.v1" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Site access is still off. Open Site Access to choose where this extension can run." } },
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイトへのアクセスはまだオフです。［サイトへのアクセス］を開き、この拡張機能を実行できるサイトを選んでください。" } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Required website access is enabled. Open Site Access to review or change where this extension can run." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "必須のウェブサイトアクセスは有効です。［サイトへのアクセス］を開くと、この拡張機能を実行できる場所を確認または変更できます。" } }
       }
     },
     "Floorp.WebExtensions.Permission.SiteData.v1" : {
@@ -1919,6 +1925,18 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow this extension to run in standard browsing." } },
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能を通常のブラウジングで実行できるようにします。" } }
+      }
+    },
+    "Floorp.WebExtensions.StandardBrowsingDisableMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Stop this extension from running in standard browsing." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能を通常のブラウジングで実行しないようにします。" } }
+      }
+    },
+    "Floorp.WebExtensions.Diagnostics.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Diagnostics" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "診断情報" } }
       }
     },
     "Floorp.WebExtensions.CatalogRevokedDisabledMessage.v1" : {

--- a/firefox-ios/Floorp/Floorp.xcstrings
+++ b/firefox-ios/Floorp/Floorp.xcstrings
@@ -1969,6 +1969,84 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "選択したサイト %1$d 件" } }
       }
     },
+    "Floorp.WebExtensions.DarkReaderSummary.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Dark mode for every website, powered by WebKit’s native extension engine." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "WebKit のネイティブ拡張機能エンジンで、すべてのウェブサイトをダークモードにします。" } }
+      }
+    },
+    "Floorp.WebExtensions.UBlockOriginLiteSummary.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Efficient content blocking through WebKit’s native declarative rule engine." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "WebKit のネイティブ宣言型ルールエンジンで、コンテンツを効率よくブロックします。" } }
+      }
+    },
+    "Floorp.WebExtensions.PermissionRequestTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow Extension Access?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能のアクセスを許可しますか？" } }
+      }
+    },
+    "Floorp.WebExtensions.WebsiteAccessRequestTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow Website Access?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ウェブサイトへのアクセスを許可しますか？" } }
+      }
+    },
+    "Floorp.WebExtensions.EnableAction.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enable Extension" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能を有効にする" } }
+      }
+    },
+    "Floorp.WebExtensions.DisableAction.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Disable Extension" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能を無効にする" } }
+      }
+    },
+    "Floorp.WebExtensions.OptionalAccess.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Optional Access" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "任意のアクセス権" } }
+      }
+    },
+    "Floorp.WebExtensions.OptionalAccessMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Floorp asks before the extension receives any optional access." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "任意のアクセス権を付与する前に Floorp が確認します。" } }
+      }
+    },
+    "Floorp.WebExtensions.AllowPrivateBrowsingAction.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Allow in Private Browsing" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートブラウジングで許可" } }
+      }
+    },
+    "Floorp.WebExtensions.DisallowPrivateBrowsingAction.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Turn Off in Private Browsing" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プライベートブラウジングでは無効にする" } }
+      }
+    },
+    "Floorp.WebExtensions.UninstallTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove %1$@?" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "%1$@を削除しますか？" } }
+      }
+    },
+    "Floorp.WebExtensions.UninstallMessage.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "The extension and its WebKit-managed data will be removed from this profile." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この拡張機能と WebKit が管理するデータを、このプロファイルから削除します。" } }
+      }
+    },
+    "Floorp.WebExtensions.ChangeErrorTitle.v1" : {
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Extension could not be changed" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "拡張機能を変更できませんでした" } }
+      }
+    },
     "Floorp.WebExtensions.GenericExtensionName.v1" : {
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Extension" } },

--- a/firefox-ios/Floorp/FloorpStrings.swift
+++ b/firefox-ios/Floorp/FloorpStrings.swift
@@ -934,6 +934,16 @@ enum FloorpStrings {
             value: "Add reviewed extensions, then choose exactly where they can run.",
             comment: "Introductory explanation on the extension management screen"
         )
+        static let darkReaderSummary = string(
+            "Floorp.WebExtensions.DarkReaderSummary.v1",
+            value: "Dark mode for every website, powered by WebKit’s native extension engine.",
+            comment: "Catalog summary for Dark Reader"
+        )
+        static let uBlockOriginLiteSummary = string(
+            "Floorp.WebExtensions.UBlockOriginLiteSummary.v1",
+            value: "Efficient content blocking through WebKit’s native declarative rule engine.",
+            comment: "Catalog summary for uBlock Origin Lite"
+        )
         static let installedSection = string(
             "Floorp.WebExtensions.InstalledSection.v1",
             value: "Installed",
@@ -1024,6 +1034,16 @@ enum FloorpStrings {
             value: "Disabled",
             comment: "Status for a disabled extension"
         )
+        static let enableAction = string(
+            "Floorp.WebExtensions.EnableAction.v1",
+            value: "Enable Extension",
+            comment: "Action that enables an installed extension"
+        )
+        static let disableAction = string(
+            "Floorp.WebExtensions.DisableAction.v1",
+            value: "Disable Extension",
+            comment: "Action that disables an installed extension"
+        )
         static let revoked = string(
             "Floorp.WebExtensions.Revoked.v1",
             value: "Disabled for your protection",
@@ -1063,6 +1083,26 @@ enum FloorpStrings {
             "Floorp.WebExtensions.Allow.v1",
             value: "Allow",
             comment: "Action that grants an extension capability"
+        )
+        static let optionalAccess = string(
+            "Floorp.WebExtensions.OptionalAccess.v1",
+            value: "Optional Access",
+            comment: "Heading for optional extension permissions"
+        )
+        static let optionalAccessMessage = string(
+            "Floorp.WebExtensions.OptionalAccessMessage.v1",
+            value: "Floorp asks before the extension receives any optional access.",
+            comment: "Explanation for optional extension permissions"
+        )
+        static let permissionRequestTitle = string(
+            "Floorp.WebExtensions.PermissionRequestTitle.v1",
+            value: "Allow Extension Access?",
+            comment: "Title shown when an extension requests an additional permission"
+        )
+        static let websiteAccessRequestTitle = string(
+            "Floorp.WebExtensions.WebsiteAccessRequestTitle.v1",
+            value: "Allow Website Access?",
+            comment: "Title shown when an extension requests access to websites"
         )
         static let actions = string(
             "Floorp.WebExtensions.Actions.v1",
@@ -1364,6 +1404,16 @@ enum FloorpStrings {
             value: "Private Browsing",
             comment: "Action and heading for extension Private Browsing access"
         )
+        static let allowPrivateBrowsingAction = string(
+            "Floorp.WebExtensions.AllowPrivateBrowsingAction.v1",
+            value: "Allow in Private Browsing",
+            comment: "Action that allows an extension in Private Browsing"
+        )
+        static let disallowPrivateBrowsingAction = string(
+            "Floorp.WebExtensions.DisallowPrivateBrowsingAction.v1",
+            value: "Turn Off in Private Browsing",
+            comment: "Action that removes an extension's Private Browsing access"
+        )
         private static let privateBrowsingConsentTitleFormat = string(
             "Floorp.WebExtensions.PrivateBrowsingConsentTitle.v1",
             value: "Allow %1$@ in Private Browsing?",
@@ -1404,6 +1454,21 @@ enum FloorpStrings {
             "Floorp.WebExtensions.Uninstall.v1",
             value: "Remove Extension",
             comment: "Destructive action that uninstalls an extension"
+        )
+        private static let uninstallTitleFormat = string(
+            "Floorp.WebExtensions.UninstallTitle.v1",
+            value: "Remove %1$@?",
+            comment: "Confirmation title for uninstalling an extension; argument is the extension name"
+        )
+        static let uninstallMessage = string(
+            "Floorp.WebExtensions.UninstallMessage.v1",
+            value: "The extension and its WebKit-managed data will be removed from this profile.",
+            comment: "Explanation shown before uninstalling an extension"
+        )
+        static let changeErrorTitle = string(
+            "Floorp.WebExtensions.ChangeErrorTitle.v1",
+            value: "Extension could not be changed",
+            comment: "Error title when an extension management operation fails"
         )
         static let installing = string(
             "Floorp.WebExtensions.Installing.v1",
@@ -1517,6 +1582,10 @@ enum FloorpStrings {
 
         static func installTitle(name: String) -> String {
             localizedStringWithFormat(installTitleFormat, name)
+        }
+
+        static func uninstallTitle(name: String) -> String {
+            localizedStringWithFormat(uninstallTitleFormat, name)
         }
 
         static func actionSiteAccessTitle(name: String) -> String {

--- a/firefox-ios/Floorp/FloorpStrings.swift
+++ b/firefox-ios/Floorp/FloorpStrings.swift
@@ -1199,25 +1199,27 @@ enum FloorpStrings {
             value: "Profiles",
             comment: "Section heading for extension browsing-profile behavior"
         )
-        static let siteAccessStartsOffTitle = string(
-            "Floorp.WebExtensions.SiteAccessStartsOffTitle.v1",
-            value: "Site access starts off",
-            comment: "Install disclosure title explaining the default site-access state"
+        static let siteAccessGrantedTitle = string(
+            "Floorp.WebExtensions.SiteAccessGrantedTitle.v1",
+            value: "Required website access",
+            comment: "Install disclosure title explaining that required website access is granted"
         )
-        static let siteAccessStartsOffMessage = string(
-            "Floorp.WebExtensions.SiteAccessStartsOffMessage.v1",
-            value: "After adding the extension, choose the sites where it may read or change content.",
-            comment: "Install disclosure explaining how to enable extension site access"
+        static let siteAccessGrantedMessage = string(
+            "Floorp.WebExtensions.SiteAccessGrantedMessage.v1",
+            value: "Adding this extension grants access to the required websites listed below. "
+                + "You can review or change access later.",
+            comment: "Install disclosure explaining required website access"
         )
-        static let siteAccessPreservedTitle = string(
-            "Floorp.WebExtensions.SiteAccessPreservedTitle.v1",
-            value: "Site choices stay unchanged",
-            comment: "Update disclosure title explaining that existing site-access choices are preserved"
+        static let siteAccessUpdateTitle = string(
+            "Floorp.WebExtensions.SiteAccessUpdateTitle.v1",
+            value: "Website access after update",
+            comment: "Update disclosure title explaining required website access"
         )
-        static let siteAccessPreservedMessage = string(
-            "Floorp.WebExtensions.SiteAccessPreservedMessage.v1",
-            value: "Your existing choices are preserved. Newly requested sites stay off until you allow them.",
-            comment: "Update disclosure explaining preserved and newly requested extension site access"
+        static let siteAccessUpdateMessage = string(
+            "Floorp.WebExtensions.SiteAccessUpdateMessage.v1",
+            value: "Updating preserves existing website access and grants access to any newly required websites "
+                + "listed below. You can review or change access later.",
+            comment: "Update disclosure explaining preserved and newly required website access"
         )
         static let privateBrowsingOptInTitle = string(
             "Floorp.WebExtensions.PrivateBrowsingOptInTitle.v1",
@@ -1234,6 +1236,11 @@ enum FloorpStrings {
             value: "Not supported on this version of Floorp",
             comment: "Status for an extension or capability that this Floorp version cannot use"
         )
+        private static let requiresOperatingSystemFormat = string(
+            "Floorp.WebExtensions.RequiresOperatingSystem.v1",
+            value: "Requires %1$@ or later",
+            comment: "Unavailable extension status; argument is the minimum operating-system version"
+        )
         static let privateAccessNotAllowed = string(
             "Floorp.WebExtensions.PrivateAccessNotAllowed.v1",
             value: "Not allowed",
@@ -1248,6 +1255,16 @@ enum FloorpStrings {
             "Floorp.WebExtensions.StandardBrowsingEnabledMessage.v1",
             value: "Allow this extension to run in standard browsing.",
             comment: "Detail shown beside the standard-browsing enabled switch"
+        )
+        static let standardBrowsingDisableMessage = string(
+            "Floorp.WebExtensions.StandardBrowsingDisableMessage.v1",
+            value: "Stop this extension from running in standard browsing.",
+            comment: "Detail shown beside the action that disables an extension in standard browsing"
+        )
+        static let diagnostics = string(
+            "Floorp.WebExtensions.Diagnostics.v1",
+            value: "Diagnostics",
+            comment: "Heading for extension package, runtime, and host diagnostics"
         )
         static let catalogRevokedDisabledMessage = string(
             "Floorp.WebExtensions.CatalogRevokedDisabledMessage.v1",
@@ -1492,8 +1509,8 @@ enum FloorpStrings {
         )
         static let postInstallSiteAccessGuidance = string(
             "Floorp.WebExtensions.PostInstallSiteAccessGuidance.v1",
-            value: "Site access is still off. Open Site Access to choose where this extension can run.",
-            comment: "Guidance shown after installation before any site access is granted"
+            value: "Required website access is enabled. Open Site Access to review or change where this extension can run.",
+            comment: "Guidance shown after installation about required website access"
         )
         static let permissionSiteData = string(
             "Floorp.WebExtensions.Permission.SiteData.v1",
@@ -1578,6 +1595,10 @@ enum FloorpStrings {
 
         static func version(_ version: String) -> String {
             localizedStringWithFormat(versionFormat, version)
+        }
+
+        static func requiresOperatingSystem(_ version: String) -> String {
+            localizedStringWithFormat(requiresOperatingSystemFormat, version)
         }
 
         static func installTitle(name: String) -> String {

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
@@ -287,7 +287,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                     WKWebExtension.Permission(rawValue: $0.value).floorpDisplayName
                 }).sorted(),
                 optionalPermissions: context?.webExtension.optionalPermissions
-                    .map(\.rawValue).sorted() ?? [],
+                    .map(\.floorpDisplayName).sorted() ?? [],
                 matchPatterns: record.grantedMatchPatterns.map(\.value).sorted(),
                 optionalMatchPatterns: context?.webExtension.optionalPermissionMatchPatterns
                     .map(\.string).sorted() ?? [],
@@ -1091,6 +1091,17 @@ final class FloorpNativeWebExtensionHost: NSObject {
         let tabViewController = (tab as? FloorpNativeWebExtensionTab)?.tab?.webView?.window?.rootViewController
         if let tabViewController {
             return Self.topViewController(from: tabViewController)
+        }
+        if let focused = lastFocusedWindow,
+           let manager = tabManager(for: focused.windowUUID) {
+            let focusedTabs = focused.isPrivate ? manager.privateTabs : manager.normalTabs
+            let selectedTab = manager.selectedTab.flatMap { $0.isPrivate == focused.isPrivate ? $0 : nil }
+            let candidates = [selectedTab].compactMap { $0 } + focusedTabs
+            if let focusedRoot = candidates.lazy.compactMap({
+                $0.webView?.window?.rootViewController
+            }).first {
+                return Self.topViewController(from: focusedRoot)
+            }
         }
         let root = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
@@ -80,7 +80,6 @@ final class FloorpNativeWebExtensionHost: NSObject {
     private var announcedTabs = Set<ObjectIdentifier>()
     private var announcedWindows = Set<WindowKey>()
     private var lastFocusedWindow: WindowKey?
-    private var popupPresenters = [String: (UIViewController) -> Void]()
 
     private init(profile: Profile, logger: Logger = DefaultLogger.shared) throws {
         self.profile = profile
@@ -277,12 +276,16 @@ final class FloorpNativeWebExtensionHost: NSObject {
             return FloorpNativeWebExtensionSettingsItem(
                 identifier: record.id,
                 name: record.displayName,
+                summary: item?.summary,
                 version: record.installedVersion,
+                iconData: context?.webExtension.icon(for: CGSize(width: 64, height: 64))?.pngData(),
                 source: item?.source ?? "Managed Floorp catalog",
                 license: item?.license ?? "See package metadata",
                 isEnabled: record.isEnabled,
                 hasPrivateAccess: record.hasPrivateAccess,
-                permissions: record.grantedPermissions.map(\.value).sorted(),
+                permissions: Set(record.grantedPermissions.map {
+                    WKWebExtension.Permission(rawValue: $0.value).floorpDisplayName
+                }).sorted(),
                 optionalPermissions: context?.webExtension.optionalPermissions
                     .map(\.rawValue).sorted() ?? [],
                 matchPatterns: record.grantedMatchPatterns.map(\.value).sorted(),
@@ -305,10 +308,9 @@ final class FloorpNativeWebExtensionHost: NSObject {
             identifier: identifier,
             name: webExtension.displayName ?? prepared.item.name,
             version: webExtension.version ?? "0",
-            requiredPermissions: webExtension.requestedPermissions
-                .map(\.floorpDisplayName).sorted(),
-            optionalPermissions: webExtension.optionalPermissions
-                .map(\.floorpDisplayName).sorted(),
+            iconData: webExtension.icon(for: CGSize(width: 64, height: 64))?.pngData(),
+            requiredPermissions: Set(webExtension.requestedPermissions.map(\.floorpDisplayName)).sorted(),
+            optionalPermissions: Set(webExtension.optionalPermissions.map(\.floorpDisplayName)).sorted(),
             requiredMatchPatterns: webExtension.requestedPermissionMatchPatterns
                 .map(\.string).sorted(),
             optionalMatchPatterns: webExtension.optionalPermissionMatchPatterns
@@ -545,7 +547,8 @@ final class FloorpNativeWebExtensionHost: NSObject {
         }
         configuration.websiteDataStore = isPrivate ? .nonPersistent() : .default()
         let page = FloorpNativeWebExtensionPageViewController(
-            title: "\(context.webExtension.displayName ?? "Extension") Options",
+            title: "\(context.webExtension.displayName ?? FloorpStrings.WebExtensions.genericExtensionName)"
+                + " · \(FloorpStrings.WebExtensions.options)",
             url: url,
             configuration: configuration
         )
@@ -564,6 +567,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
             return FloorpNativeWebExtensionActionItem(
                 contextIdentifier: record.id,
                 label: action.label.isEmpty ? record.displayName : action.label,
+                version: record.installedVersion,
                 icon: action.icon(for: CGSize(width: 32, height: 32)),
                 isEnabled: action.isEnabled
             )
@@ -572,8 +576,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
 
     func performAction(
         contextIdentifier: String,
-        for tab: Tab,
-        present: @escaping (UIViewController) -> Void
+        for tab: Tab
     ) throws {
         guard let context = contexts[contextIdentifier], context.isLoaded else {
             throw FloorpNativeWebExtensionError.extensionDisabled(contextIdentifier)
@@ -582,12 +585,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
             throw FloorpNativeWebExtensionError.privateAccessDenied
         }
         let adapter = tabAdapter(for: tab)
-        popupPresenters[contextIdentifier] = present
-        context.userGesturePerformed(in: adapter)
         context.performAction(for: adapter)
-        if context.action(for: adapter)?.presentsPopup != true {
-            popupPresenters.removeValue(forKey: contextIdentifier)
-        }
     }
 
     /// Returns true when the caller must cancel the current navigation because
@@ -1102,6 +1100,62 @@ final class FloorpNativeWebExtensionHost: NSObject {
         return root.flatMap(Self.topViewController(from:))
     }
 
+    private func presentActionPopup(
+        _ popup: UIViewController,
+        for tab: (any WKWebExtensionTab)?,
+        remainingTransitionRetries: Int = 4,
+        completionHandler: @escaping ((any Error)?) -> Void
+    ) {
+        guard let presenter = presenter(for: tab), presenter.viewIfLoaded?.window != nil else {
+            completionHandler(FloorpNativeWebExtensionError.hostUnavailable)
+            return
+        }
+
+        let isTransitioning = presenter.isBeingDismissed
+            || presenter.isBeingPresented
+            || presenter.presentingViewController?.isBeingDismissed == true
+        if isTransitioning {
+            guard remainingTransitionRetries > 0 else {
+                completionHandler(FloorpNativeWebExtensionError.unsupportedOperation("action popup presentation"))
+                return
+            }
+            let retry = { [weak self] in
+                guard let self else {
+                    completionHandler(FloorpNativeWebExtensionError.hostUnavailable)
+                    return
+                }
+                self.presentActionPopup(
+                    popup,
+                    for: tab,
+                    remainingTransitionRetries: remainingTransitionRetries - 1,
+                    completionHandler: completionHandler
+                )
+            }
+            if let transitionCoordinator = presenter.transitionCoordinator {
+                transitionCoordinator.animate(alongsideTransition: nil) { _ in retry() }
+            } else {
+                DispatchQueue.main.async(execute: retry)
+            }
+            return
+        }
+
+        if let popover = popup.popoverPresentationController,
+           popover.barButtonItem == nil,
+           popover.sourceView == nil {
+            popover.sourceView = presenter.view
+            popover.sourceRect = CGRect(
+                x: presenter.view.bounds.midX,
+                y: presenter.view.bounds.midY,
+                width: 1,
+                height: 1
+            )
+            popover.permittedArrowDirections = []
+        }
+        presenter.present(popup, animated: true) {
+            completionHandler(nil)
+        }
+    }
+
     private static func topViewController(from root: UIViewController) -> UIViewController {
         if let presented = root.presentedViewController {
             return topViewController(from: presented)
@@ -1126,8 +1180,12 @@ final class FloorpNativeWebExtensionHost: NSObject {
             return
         }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "Don't Allow", style: .cancel) { _ in completion(false) })
-        alert.addAction(UIAlertAction(title: "Allow", style: .default) { _ in completion(true) })
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.cancel, style: .cancel) { _ in
+            completion(false)
+        })
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.allow, style: .default) { _ in
+            completion(true)
+        })
         presenter.present(alert, animated: true)
     }
 }
@@ -1283,9 +1341,12 @@ extension FloorpNativeWebExtensionHost: WKWebExtensionControllerDelegate {
         completionHandler: @escaping (Set<WKWebExtension.Permission>, Date?) -> Void
     ) {
         let eligible = permissions.filter { $0 != .nativeMessaging }
-        let detail = eligible.map(\.floorpDisplayName).sorted().map { "• \($0)" }.joined(separator: "\n")
+        let detail = Set(eligible.map(\.floorpDisplayName))
+            .sorted()
+            .map { "• \($0)" }
+            .joined(separator: "\n")
         prompt(
-            title: "Allow Extension Permission?",
+            title: FloorpStrings.WebExtensions.permissionRequestTitle,
             message: detail,
             in: tab
         ) { [weak self, weak extensionContext] allowed in
@@ -1303,7 +1364,11 @@ extension FloorpNativeWebExtensionHost: WKWebExtensionControllerDelegate {
         completionHandler: @escaping (Set<URL>, Date?) -> Void
     ) {
         let detail = urls.map(\.absoluteString).sorted().prefix(8).map { "• \($0)" }.joined(separator: "\n")
-        prompt(title: "Allow Website Access?", message: detail, in: tab) { [weak self, weak extensionContext] allowed in
+        prompt(
+            title: FloorpStrings.WebExtensions.websiteAccessRequestTitle,
+            message: detail,
+            in: tab
+        ) { [weak self, weak extensionContext] allowed in
             completionHandler(allowed ? urls : [], allowed ? .distantFuture : nil)
             guard let self, let extensionContext else { return }
             DispatchQueue.main.async { self.persistPermissionState(for: extensionContext) }
@@ -1318,7 +1383,11 @@ extension FloorpNativeWebExtensionHost: WKWebExtensionControllerDelegate {
         completionHandler: @escaping (Set<WKWebExtension.MatchPattern>, Date?) -> Void
     ) {
         let detail = matchPatterns.map(\.string).sorted().prefix(8).map { "• \($0)" }.joined(separator: "\n")
-        prompt(title: "Allow Website Access?", message: detail, in: tab) { [weak self, weak extensionContext] allowed in
+        prompt(
+            title: FloorpStrings.WebExtensions.websiteAccessRequestTitle,
+            message: detail,
+            in: tab
+        ) { [weak self, weak extensionContext] allowed in
             completionHandler(allowed ? matchPatterns : [], allowed ? .distantFuture : nil)
             guard let self, let extensionContext else { return }
             DispatchQueue.main.async { self.persistPermissionState(for: extensionContext) }
@@ -1339,15 +1408,16 @@ extension FloorpNativeWebExtensionHost: WKWebExtensionControllerDelegate {
         for context: WKWebExtensionContext,
         completionHandler: @escaping ((any Error)?) -> Void
     ) {
-        guard let identifier = identifier(for: context),
-              let presenter = popupPresenters.removeValue(forKey: identifier),
+        guard identifier(for: context) != nil,
               let popup = action.popupViewController else {
             completionHandler(FloorpNativeWebExtensionError.unsupportedOperation("action popup"))
             return
         }
-        popup.modalPresentationStyle = .formSheet
-        presenter(popup)
-        completionHandler(nil)
+        presentActionPopup(
+            popup,
+            for: action.associatedTab,
+            completionHandler: completionHandler
+        )
     }
 
     func webExtensionController(

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionModels.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionModels.swift
@@ -67,7 +67,7 @@ enum FloorpNativeWebExtensionCatalog {
         baseURLHost: "darkreader.floorp.internal",
         minimumOS: FloorpOperatingSystemVersion(18, 4),
         name: "Dark Reader",
-        summary: "Dark mode for every website. Runs through WebKit's native WebExtension engine.",
+        summary: FloorpStrings.WebExtensions.darkReaderSummary,
         source: "https://github.com/darkreader/darkreader/releases/tag/v4.9.129",
         sourceRevision: "c2a707302a39b8047543712e9c582bac07835d34",
         license: "MIT",
@@ -91,7 +91,7 @@ enum FloorpNativeWebExtensionCatalog {
         baseURLHost: "ubol.floorp.internal",
         minimumOS: FloorpOperatingSystemVersion(18, 6),
         name: "uBlock Origin Lite",
-        summary: "Efficient content blocking through WebKit's native Declarative Net Request engine.",
+        summary: FloorpStrings.WebExtensions.uBlockOriginLiteSummary,
         source: "https://github.com/uBlockOrigin/uBOL-home/releases/tag/2026.825.1619",
         sourceRevision: "080d4a2c9d8264e076daa512cf7bbd97f8a2ca6b",
         license: "GPL-3.0-or-later",
@@ -327,6 +327,7 @@ struct FloorpNativeWebExtensionInstallationPreview: Sendable {
     let identifier: String
     let name: String
     let version: String
+    let iconData: Data?
     let requiredPermissions: [String]
     let optionalPermissions: [String]
     let requiredMatchPatterns: [String]
@@ -341,7 +342,9 @@ struct FloorpNativeWebExtensionInstallationPreview: Sendable {
 struct FloorpNativeWebExtensionSettingsItem: Hashable, Sendable {
     let identifier: String
     let name: String
+    let summary: String?
     let version: String
+    let iconData: Data?
     let source: String
     let license: String
     let isEnabled: Bool
@@ -359,6 +362,7 @@ struct FloorpNativeWebExtensionSettingsItem: Hashable, Sendable {
 struct FloorpNativeWebExtensionActionItem {
     let contextIdentifier: String
     let label: String
+    let version: String
     let icon: UIImage?
     let isEnabled: Bool
 }
@@ -420,22 +424,25 @@ enum FloorpNativeWebExtensionError: LocalizedError {
 extension WKWebExtension.Permission {
     var floorpDisplayName: String {
         switch self {
-        case .activeTab: return "Access the current tab after a user action"
-        case .alarms: return "Run scheduled extension work"
-        case .clipboardWrite: return "Write to the clipboard"
-        case .contextMenus, .menus: return "Add items to browser menus"
-        case .cookies: return "Read and change cookies"
+        case .activeTab, .tabs: return FloorpStrings.WebExtensions.permissionTabs
+        case .alarms: return FloorpStrings.WebExtensions.permissionAlarms
+        case .clipboardWrite,
+             .contextMenus,
+             .menus,
+             .scripting:
+            return FloorpStrings.WebExtensions.permissionBrowserAutomation
+        case .cookies,
+             .webNavigation,
+             .webRequest:
+            return FloorpStrings.WebExtensions.permissionSiteData
         case .declarativeNetRequest,
              .declarativeNetRequestFeedback,
              .declarativeNetRequestWithHostAccess:
-            return "Block or redirect network requests"
-        case .nativeMessaging: return "Communicate with native applications"
-        case .scripting: return "Run scripts on permitted websites"
-        case .storage: return "Store extension settings"
-        case .tabs: return "Read permitted tab information"
-        case .unlimitedStorage: return "Use additional extension storage"
-        case .webNavigation: return "Observe page navigation"
-        case .webRequest: return "Observe network requests"
+            return FloorpStrings.WebExtensions.permissionNetworkBlocking
+        case .storage, .unlimitedStorage:
+            return FloorpStrings.WebExtensions.permissionStorage
+        case .nativeMessaging:
+            return FloorpStrings.WebExtensions.permissionGenericExplanation
         default: return rawValue
         }
     }

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionSettingsViewController.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionSettingsViewController.swift
@@ -338,6 +338,7 @@ class FloorpNativeWebExtensionPromptViewController: UIViewController,
     let presentation: FloorpNativeWebExtensionPromptPresentation
     private let notificationCenter: NotificationProtocol
     private let onChoice: @MainActor (FloorpNativeWebExtensionPromptPresentation.Choice) -> Void
+    private let dismissalHandler: ((@escaping () -> Void) -> Void)?
     private let scrollView: UIScrollView = .build()
     private let contentStack: UIStackView = .build()
     private let heroCard: UIView = .build()
@@ -366,12 +367,14 @@ class FloorpNativeWebExtensionPromptViewController: UIViewController,
         windowUUID: WindowUUID,
         themeManager: ThemeManager = AppContainer.shared.resolve(),
         notificationCenter: NotificationProtocol = NotificationCenter.default,
+        dismissalHandler: ((@escaping () -> Void) -> Void)? = nil,
         onChoice: @escaping @MainActor (FloorpNativeWebExtensionPromptPresentation.Choice) -> Void
     ) {
         self.presentation = presentation
         self.windowUUID = windowUUID
         self.themeManager = themeManager
         self.notificationCenter = notificationCenter
+        self.dismissalHandler = dismissalHandler
         self.onChoice = onChoice
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .pageSheet
@@ -388,13 +391,6 @@ class FloorpNativeWebExtensionPromptViewController: UIViewController,
         listenForThemeChanges(withNotificationCenter: notificationCenter)
         applyTheme()
         sheetPresentationController?.prefersGrabberVisible = true
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        guard let pendingChoice else { return }
-        self.pendingChoice = nil
-        onChoice(pendingChoice)
     }
 
     func applyTheme() {
@@ -578,7 +574,16 @@ class FloorpNativeWebExtensionPromptViewController: UIViewController,
         didFinish = true
         pendingChoice = choice
         setControlsEnabled(false)
-        dismiss(animated: true)
+        let completion = { [weak self] in
+            guard let self, let pendingChoice = self.pendingChoice else { return }
+            self.pendingChoice = nil
+            self.onChoice(pendingChoice)
+        }
+        if let dismissalHandler {
+            dismissalHandler(completion)
+        } else {
+            dismiss(animated: true, completion: completion)
+        }
     }
 
     private func finishWithCancel() {
@@ -600,6 +605,7 @@ final class FloorpNativeWebExtensionActionPickerViewController:
     init(
         actions: [FloorpNativeWebExtensionActionItem],
         windowUUID: WindowUUID,
+        dismissalHandler: ((@escaping () -> Void) -> Void)? = nil,
         onSelection: @escaping @MainActor (FloorpNativeWebExtensionActionItem) -> Void
     ) {
         let actionsByIdentifier = Dictionary(
@@ -625,6 +631,7 @@ final class FloorpNativeWebExtensionActionPickerViewController:
                 accessibilityIdentifier: "Floorp.NativeWebExtensions.ActionPicker"
             ),
             windowUUID: windowUUID,
+            dismissalHandler: dismissalHandler,
             onChoice: { choice in
                 guard let action = actionsByIdentifier[choice.identifier] else { return }
                 onSelection(action)
@@ -776,7 +783,7 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
                 version: item.expectedVersion,
                 status: item.isAvailableOnCurrentOS
                     ? FloorpStrings.WebExtensions.add
-                    : FloorpStrings.WebExtensions.notSupported,
+                    : FloorpStrings.WebExtensions.requiresOperatingSystem(item.minimumOS.description),
                 statusStyle: item.isAvailableOnCurrentOS ? .accent : .critical,
                 icon: nil,
                 fallbackSymbol: "puzzlepiece.extension.fill",
@@ -918,11 +925,11 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
             infoRows.append(.init(
                 symbol: "hand.raised.fill",
                 title: preview.isUpdate
-                    ? FloorpStrings.WebExtensions.siteAccessPreservedTitle
-                    : FloorpStrings.WebExtensions.siteAccessStartsOffTitle,
+                    ? FloorpStrings.WebExtensions.siteAccessUpdateTitle
+                    : FloorpStrings.WebExtensions.siteAccessGrantedTitle,
                 detail: (preview.isUpdate
-                    ? FloorpStrings.WebExtensions.siteAccessPreservedMessage
-                    : FloorpStrings.WebExtensions.siteAccessStartsOffMessage)
+                    ? FloorpStrings.WebExtensions.siteAccessUpdateMessage
+                    : FloorpStrings.WebExtensions.siteAccessGrantedMessage)
                     + "\n\n• " + preview.requiredMatchPatterns.joined(separator: "\n• ")
             ))
         }
@@ -953,8 +960,8 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
                 ? FloorpStrings.WebExtensions.update
                 : FloorpStrings.WebExtensions.install,
             detail: preview.isUpdate
-                ? FloorpStrings.WebExtensions.siteAccessPreservedMessage
-                : FloorpStrings.WebExtensions.siteAccessStartsOffMessage,
+                ? FloorpStrings.WebExtensions.siteAccessUpdateMessage
+                : FloorpStrings.WebExtensions.siteAccessGrantedMessage,
             icon: UIImage(systemName: preview.isUpdate ? "arrow.down.circle.fill" : "arrow.down.app.fill"),
             usesTemplateIcon: true,
             role: .preferred
@@ -987,6 +994,27 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
     }
 
     private func showActions(for item: FloorpNativeWebExtensionSettingsItem) {
+        let sheet = FloorpNativeWebExtensionPromptViewController(
+            presentation: .init(
+                title: item.name,
+                message: item.summary ?? FloorpStrings.WebExtensions.detailTitle,
+                heroImage: item.iconData.flatMap(UIImage.init(data:)),
+                heroUsesTemplateImage: item.iconData == nil,
+                infoRows: managementInfoRows(for: item),
+                choices: managementChoices(for: item),
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Manage.\(item.identifier)"
+            ),
+            windowUUID: windowUUID,
+            onChoice: { [weak self] choice in
+                self?.handleManagementChoice(choice.identifier, for: item)
+            }
+        )
+        present(sheet, animated: true)
+    }
+
+    private func managementInfoRows(
+        for item: FloorpNativeWebExtensionSettingsItem
+    ) -> [FloorpNativeWebExtensionPromptPresentation.InfoRow] {
         var infoRows = [
             FloorpNativeWebExtensionPromptPresentation.InfoRow(
                 symbol: "number",
@@ -1015,20 +1043,52 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
                 detail: "• " + item.matchPatterns.joined(separator: "\n• ")
             ))
         }
-        if let error = item.errorDescription {
+        let optionalAccess = Set(item.optionalPermissions + item.optionalMatchPatterns).sorted()
+        if !optionalAccess.isEmpty {
+            infoRows.append(.init(
+                symbol: "hand.tap.fill",
+                title: FloorpStrings.WebExtensions.optionalAccess,
+                detail: FloorpStrings.WebExtensions.optionalAccessMessage
+                    + "\n\n• " + optionalAccess.joined(separator: "\n• ")
+            ))
+        }
+        let diagnosticDetails = item.diagnostics.map {
+            "[\($0.phase.rawValue)] \($0.domain) (\($0.code)): \($0.message)"
+        }
+        let uniqueDiagnosticDetails = diagnosticDetails.reduce(into: [String]()) { details, detail in
+            guard !details.contains(detail) else { return }
+            details.append(detail)
+        }
+        if !uniqueDiagnosticDetails.isEmpty {
+            infoRows.append(.init(
+                symbol: "stethoscope",
+                title: FloorpStrings.WebExtensions.diagnostics,
+                detail: "• " + uniqueDiagnosticDetails.joined(separator: "\n• ")
+            ))
+        }
+        if let error = item.errorDescription,
+           !item.diagnostics.contains(where: { $0.message == error }) {
             infoRows.append(.init(
                 symbol: "exclamationmark.triangle.fill",
                 title: FloorpStrings.WebExtensions.loadErrorTitle,
                 detail: error
             ))
         }
+        return infoRows
+    }
+
+    private func managementChoices(
+        for item: FloorpNativeWebExtensionSettingsItem
+    ) -> [FloorpNativeWebExtensionPromptPresentation.Choice] {
         var choices = [
             FloorpNativeWebExtensionPromptPresentation.Choice(
                 identifier: "toggle-enabled",
                 title: item.isEnabled
                     ? FloorpStrings.WebExtensions.disableAction
                     : FloorpStrings.WebExtensions.enableAction,
-                detail: FloorpStrings.WebExtensions.standardBrowsingEnabledMessage,
+                detail: item.isEnabled
+                    ? FloorpStrings.WebExtensions.standardBrowsingDisableMessage
+                    : FloorpStrings.WebExtensions.standardBrowsingEnabledMessage,
                 icon: UIImage(systemName: item.isEnabled ? "pause.circle.fill" : "play.circle.fill"),
                 usesTemplateIcon: true
             ),
@@ -1072,22 +1132,7 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
             usesTemplateIcon: true,
             role: .destructive
         ))
-        let sheet = FloorpNativeWebExtensionPromptViewController(
-            presentation: .init(
-                title: item.name,
-                message: item.summary ?? FloorpStrings.WebExtensions.detailTitle,
-                heroImage: item.iconData.flatMap(UIImage.init(data:)),
-                heroUsesTemplateImage: item.iconData == nil,
-                infoRows: infoRows,
-                choices: choices,
-                accessibilityIdentifier: "Floorp.NativeWebExtensions.Manage.\(item.identifier)"
-            ),
-            windowUUID: windowUUID,
-            onChoice: { [weak self] choice in
-                self?.handleManagementChoice(choice.identifier, for: item)
-            }
-        )
-        present(sheet, animated: true)
+        return choices
     }
 
     private func handleManagementChoice(

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionSettingsViewController.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionSettingsViewController.swift
@@ -7,6 +7,637 @@ import UIKit
 import WebKit
 
 @MainActor
+private final class FloorpNativeWebExtensionHeroHeaderView: UIView, ThemeApplicable {
+    private let cardView: UIView = .build()
+    private let iconView: UIImageView = .build()
+    private let titleLabel: UILabel = .build()
+    private let messageLabel: UILabel = .build()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyTheme(theme: Theme) {
+        backgroundColor = theme.colors.layer1
+        cardView.backgroundColor = theme.colors.layer2
+        cardView.layer.borderColor = theme.colors.borderPrimary.cgColor
+        iconView.tintColor = theme.colors.iconAccent
+        titleLabel.textColor = theme.colors.textPrimary
+        messageLabel.textColor = theme.colors.textSecondary
+    }
+
+    private func setupView() {
+        directionalLayoutMargins = NSDirectionalEdgeInsets(top: 12, leading: 20, bottom: 12, trailing: 20)
+        cardView.layer.cornerRadius = 18
+        cardView.layer.cornerCurve = .continuous
+        cardView.layer.borderWidth = 1
+        iconView.image = UIImage(systemName: "puzzlepiece.extension.fill")
+        iconView.contentMode = .scaleAspectFit
+        iconView.isAccessibilityElement = false
+        titleLabel.text = FloorpStrings.WebExtensions.introTitle
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        messageLabel.text = FloorpStrings.WebExtensions.introMessage
+        messageLabel.font = .preferredFont(forTextStyle: .subheadline)
+        messageLabel.adjustsFontForContentSizeCategory = true
+        messageLabel.numberOfLines = 0
+
+        let labels: UIStackView = .build()
+        labels.axis = .vertical
+        labels.spacing = 4
+        labels.addArrangedSubview(titleLabel)
+        labels.addArrangedSubview(messageLabel)
+        cardView.addSubview(iconView)
+        cardView.addSubview(labels)
+        addSubview(cardView)
+        NSLayoutConstraint.activate([
+            cardView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            cardView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            cardView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            cardView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+            iconView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 18),
+            iconView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 42),
+            iconView.heightAnchor.constraint(equalTo: iconView.widthAnchor),
+            labels.topAnchor.constraint(equalTo: cardView.topAnchor, constant: 18),
+            labels.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 14),
+            labels.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -18),
+            labels.bottomAnchor.constraint(equalTo: cardView.bottomAnchor, constant: -18)
+        ])
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+        accessibilityLabel = "\(FloorpStrings.WebExtensions.introTitle). \(FloorpStrings.WebExtensions.introMessage)"
+    }
+}
+
+@MainActor
+private final class FloorpNativeWebExtensionCardCell: UITableViewCell, ThemeApplicable {
+    enum StatusStyle {
+        case accent
+        case secondary
+        case critical
+    }
+
+    static let reuseIdentifier = "FloorpNativeWebExtensionCardCell"
+
+    private let iconView: UIImageView = .build()
+    private let titleLabel: UILabel = .build()
+    private let summaryLabel: UILabel = .build()
+    private let versionLabel: UILabel = .build()
+    private let statusLabel: UILabel = .build()
+    private let separatorLabel: UILabel = .build()
+    private let metadataStack: UIStackView = .build()
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
+    private var statusStyle = StatusStyle.secondary
+    private var usesTemplateIcon = true
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        iconView.image = nil
+        activityIndicator.stopAnimating()
+        accessoryView = nil
+        accessoryType = .none
+        accessibilityIdentifier = nil
+        accessibilityLabel = nil
+        accessibilityValue = nil
+    }
+
+    func configure(
+        title: String,
+        summary: String,
+        version: String?,
+        status: String?,
+        statusStyle: StatusStyle,
+        icon: UIImage?,
+        fallbackSymbol: String,
+        isBusy: Bool,
+        isSelectable: Bool,
+        accessibilityIdentifier: String,
+        theme: Theme
+    ) {
+        titleLabel.text = title
+        summaryLabel.text = summary
+        versionLabel.text = version.map(FloorpStrings.WebExtensions.version)
+        statusLabel.text = status
+        versionLabel.isHidden = version == nil
+        statusLabel.isHidden = status == nil
+        separatorLabel.isHidden = version == nil || status == nil
+        metadataStack.isHidden = version == nil && status == nil
+        self.statusStyle = statusStyle
+        if let icon {
+            iconView.image = icon.withRenderingMode(.alwaysOriginal)
+            usesTemplateIcon = false
+        } else {
+            iconView.image = UIImage(systemName: fallbackSymbol)?.withRenderingMode(.alwaysTemplate)
+            usesTemplateIcon = true
+        }
+        selectionStyle = isSelectable ? .default : .none
+        isUserInteractionEnabled = isSelectable && !isBusy
+        if isBusy {
+            activityIndicator.startAnimating()
+            accessoryView = activityIndicator
+            accessoryType = .none
+        } else {
+            activityIndicator.stopAnimating()
+            accessoryView = nil
+            accessoryType = isSelectable ? .disclosureIndicator : .none
+        }
+        self.accessibilityIdentifier = accessibilityIdentifier
+        accessibilityTraits = isSelectable ? .button : .staticText
+        accessibilityLabel = [title, status, version.map(FloorpStrings.WebExtensions.version), summary]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+        accessibilityValue = isBusy ? FloorpStrings.WebExtensions.loading : status
+        applyTheme(theme: theme)
+    }
+
+    func applyTheme(theme: Theme) {
+        backgroundColor = theme.colors.layer2
+        contentView.backgroundColor = theme.colors.layer2
+        titleLabel.textColor = theme.colors.textPrimary
+        summaryLabel.textColor = theme.colors.textSecondary
+        versionLabel.textColor = theme.colors.textSecondary
+        separatorLabel.textColor = theme.colors.textSecondary
+        statusLabel.textColor = switch statusStyle {
+        case .accent: theme.colors.textAccent
+        case .secondary: theme.colors.textSecondary
+        case .critical: theme.colors.textCritical
+        }
+        iconView.tintColor = usesTemplateIcon ? theme.colors.iconAccent : nil
+        activityIndicator.color = theme.colors.iconAccent
+        let selectedBackground = UIView()
+        selectedBackground.backgroundColor = theme.colors.layer5Hover
+        selectedBackgroundView = selectedBackground
+    }
+
+    private func setupView() {
+        isAccessibilityElement = true
+        iconView.contentMode = .scaleAspectFit
+        iconView.isAccessibilityElement = false
+        titleLabel.font = .preferredFont(forTextStyle: .headline)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 2
+        summaryLabel.font = .preferredFont(forTextStyle: .subheadline)
+        summaryLabel.adjustsFontForContentSizeCategory = true
+        summaryLabel.numberOfLines = 3
+        versionLabel.font = .preferredFont(forTextStyle: .footnote)
+        versionLabel.adjustsFontForContentSizeCategory = true
+        statusLabel.font = .preferredFont(forTextStyle: .footnote)
+        statusLabel.adjustsFontForContentSizeCategory = true
+        statusLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        separatorLabel.text = "·"
+        separatorLabel.font = .preferredFont(forTextStyle: .footnote)
+        metadataStack.axis = .horizontal
+        metadataStack.spacing = 5
+        metadataStack.alignment = .firstBaseline
+        metadataStack.addArrangedSubview(statusLabel)
+        metadataStack.addArrangedSubview(separatorLabel)
+        metadataStack.addArrangedSubview(versionLabel)
+        activityIndicator.hidesWhenStopped = true
+
+        contentView.addSubview(iconView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(summaryLabel)
+        contentView.addSubview(metadataStack)
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            iconView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconView.widthAnchor.constraint(equalToConstant: 44),
+            iconView.heightAnchor.constraint(equalTo: iconView.widthAnchor),
+            titleLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 13),
+            titleLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -14),
+            summaryLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+            summaryLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            summaryLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            metadataStack.topAnchor.constraint(equalTo: summaryLabel.bottomAnchor, constant: 6),
+            metadataStack.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            metadataStack.trailingAnchor.constraint(lessThanOrEqualTo: titleLabel.trailingAnchor),
+            metadataStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -13),
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 92)
+        ])
+        separatorInset = UIEdgeInsets(top: 0, left: 72, bottom: 0, right: 0)
+    }
+}
+
+struct FloorpNativeWebExtensionPromptPresentation {
+    struct InfoRow {
+        let symbol: String
+        let title: String
+        let detail: String
+    }
+
+    struct Choice {
+        enum Role {
+            case standard
+            case preferred
+            case destructive
+        }
+
+        let identifier: String
+        let title: String
+        let detail: String
+        let icon: UIImage?
+        let usesTemplateIcon: Bool
+        var role: Role = .standard
+    }
+
+    let title: String
+    let message: String
+    let heroImage: UIImage?
+    let heroUsesTemplateImage: Bool
+    let infoRows: [InfoRow]
+    let choices: [Choice]
+    var cancelTitle = FloorpStrings.WebExtensions.cancel
+    let accessibilityIdentifier: String
+}
+
+@MainActor
+class FloorpNativeWebExtensionPromptViewController: UIViewController,
+                                                       Themeable,
+                                                       InjectedThemeUUIDIdentifiable {
+    private final class ChoiceButton: UIButton {
+        let choice: FloorpNativeWebExtensionPromptPresentation.Choice
+
+        init(choice: FloorpNativeWebExtensionPromptPresentation.Choice) {
+            self.choice = choice
+            super.init(frame: .zero)
+            translatesAutoresizingMaskIntoConstraints = false
+            contentHorizontalAlignment = .leading
+            accessibilityIdentifier = choice.identifier
+            accessibilityLabel = choice.title
+            accessibilityHint = choice.detail
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        func applyTheme(theme: Theme) {
+            var configuration = UIButton.Configuration.plain()
+            configuration.title = choice.title
+            configuration.subtitle = choice.detail
+            if let image = choice.icon {
+                configuration.image = image.withRenderingMode(
+                    choice.usesTemplateIcon ? .alwaysTemplate : .alwaysOriginal
+                )
+            }
+            configuration.imagePlacement = .leading
+            configuration.imagePadding = 14
+            configuration.titleAlignment = .leading
+            configuration.contentInsets = NSDirectionalEdgeInsets(
+                top: 12,
+                leading: 14,
+                bottom: 12,
+                trailing: 14
+            )
+            configuration.background.backgroundColor = theme.colors.layer2
+            configuration.background.strokeColor = theme.colors.borderPrimary
+            configuration.background.strokeWidth = choice.role == .preferred ? 2 : 1
+            configuration.background.cornerRadius = 14
+            configuration.baseForegroundColor = switch choice.role {
+            case .standard: theme.colors.textPrimary
+            case .preferred: theme.colors.textAccent
+            case .destructive: theme.colors.textCritical
+            }
+            configuration.titleTextAttributesTransformer = .init { incoming in
+                var outgoing = incoming
+                outgoing.font = .preferredFont(forTextStyle: .headline)
+                return outgoing
+            }
+            configuration.subtitleTextAttributesTransformer = .init { incoming in
+                var outgoing = incoming
+                outgoing.font = .preferredFont(forTextStyle: .subheadline)
+                outgoing.foregroundColor = theme.colors.textSecondary
+                return outgoing
+            }
+            self.configuration = configuration
+        }
+    }
+
+    let windowUUID: WindowUUID
+    var currentWindowUUID: WindowUUID? { windowUUID }
+    var themeManager: ThemeManager
+    var themeListenerCancellable: Any?
+
+    let presentation: FloorpNativeWebExtensionPromptPresentation
+    private let notificationCenter: NotificationProtocol
+    private let onChoice: @MainActor (FloorpNativeWebExtensionPromptPresentation.Choice) -> Void
+    private let scrollView: UIScrollView = .build()
+    private let contentStack: UIStackView = .build()
+    private let heroCard: UIView = .build()
+    private let heroIconView: UIImageView = .build()
+    private let titleLabel: UILabel = .build()
+    private let messageLabel: UILabel = .build()
+    private let cancelButton: UIButton = .build()
+    private var choiceButtons = [ChoiceButton]()
+    private var themedCards = [UIView]()
+    private var primaryLabels = [UILabel]()
+    private var secondaryLabels = [UILabel]()
+    private var infoIconViews = [UIImageView]()
+    private var separators = [UIView]()
+    private var pendingChoice: FloorpNativeWebExtensionPromptPresentation.Choice?
+    private var didFinish = false
+
+    var displayedChoiceTitles: [String] { choiceButtons.map(\.choice.title) }
+
+    func selectChoice(identifier: String) {
+        guard let choice = presentation.choices.first(where: { $0.identifier == identifier }) else { return }
+        finish(with: choice)
+    }
+
+    init(
+        presentation: FloorpNativeWebExtensionPromptPresentation,
+        windowUUID: WindowUUID,
+        themeManager: ThemeManager = AppContainer.shared.resolve(),
+        notificationCenter: NotificationProtocol = NotificationCenter.default,
+        onChoice: @escaping @MainActor (FloorpNativeWebExtensionPromptPresentation.Choice) -> Void
+    ) {
+        self.presentation = presentation
+        self.windowUUID = windowUUID
+        self.themeManager = themeManager
+        self.notificationCenter = notificationCenter
+        self.onChoice = onChoice
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .pageSheet
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.accessibilityIdentifier = presentation.accessibilityIdentifier
+        setupView()
+        listenForThemeChanges(withNotificationCenter: notificationCenter)
+        applyTheme()
+        sheetPresentationController?.prefersGrabberVisible = true
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        guard let pendingChoice else { return }
+        self.pendingChoice = nil
+        onChoice(pendingChoice)
+    }
+
+    func applyTheme() {
+        let theme = themeManager.getCurrentTheme(for: windowUUID)
+        view.backgroundColor = theme.colors.layer1
+        scrollView.backgroundColor = theme.colors.layer1
+        themedCards.forEach {
+            $0.backgroundColor = theme.colors.layer2
+            $0.layer.borderColor = theme.colors.borderPrimary.cgColor
+        }
+        heroIconView.tintColor = presentation.heroUsesTemplateImage ? theme.colors.iconAccent : nil
+        primaryLabels.forEach { $0.textColor = theme.colors.textPrimary }
+        secondaryLabels.forEach { $0.textColor = theme.colors.textSecondary }
+        infoIconViews.forEach { $0.tintColor = theme.colors.iconAccent }
+        separators.forEach { $0.backgroundColor = theme.colors.borderPrimary }
+        choiceButtons.forEach { $0.applyTheme(theme: theme) }
+
+        var cancelConfiguration = UIButton.Configuration.gray()
+        cancelConfiguration.title = presentation.cancelTitle
+        cancelConfiguration.baseForegroundColor = theme.colors.textPrimary
+        cancelConfiguration.cornerStyle = .large
+        cancelButton.configuration = cancelConfiguration
+    }
+
+    private func setupView() {
+        contentStack.axis = .vertical
+        contentStack.spacing = 12
+        contentStack.alignment = .fill
+        view.addSubview(scrollView)
+        scrollView.addSubview(contentStack)
+        view.addSubview(cancelButton)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: cancelButton.topAnchor, constant: -12),
+            contentStack.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            contentStack.leadingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.leadingAnchor, constant: 20),
+            contentStack.trailingAnchor.constraint(equalTo: scrollView.frameLayoutGuide.trailingAnchor, constant: -20),
+            contentStack.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            cancelButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            cancelButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12),
+            cancelButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        ])
+
+        addHero()
+        if !presentation.infoRows.isEmpty {
+            addInfoCard()
+        }
+        presentation.choices.forEach(addChoice)
+        cancelButton.accessibilityIdentifier = "\(presentation.accessibilityIdentifier).Cancel"
+        cancelButton.addAction(UIAction { [weak self] _ in self?.finishWithCancel() }, for: .touchUpInside)
+    }
+
+    private func addHero() {
+        heroCard.layer.cornerRadius = 18
+        heroCard.layer.cornerCurve = .continuous
+        heroCard.layer.borderWidth = 1
+        themedCards.append(heroCard)
+        let heroStack: UIStackView = .build()
+        heroStack.axis = .vertical
+        heroStack.alignment = .center
+        heroStack.spacing = 10
+        heroIconView.image = (presentation.heroImage
+            ?? UIImage(systemName: "puzzlepiece.extension.fill"))?.withRenderingMode(
+                presentation.heroUsesTemplateImage ? .alwaysTemplate : .alwaysOriginal
+            )
+        heroIconView.contentMode = .scaleAspectFit
+        heroIconView.isAccessibilityElement = false
+        titleLabel.text = presentation.title
+        titleLabel.font = .preferredFont(forTextStyle: .title2)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        titleLabel.textAlignment = .center
+        primaryLabels.append(titleLabel)
+        messageLabel.text = presentation.message
+        messageLabel.font = .preferredFont(forTextStyle: .body)
+        messageLabel.adjustsFontForContentSizeCategory = true
+        messageLabel.numberOfLines = 0
+        messageLabel.textAlignment = .center
+        secondaryLabels.append(messageLabel)
+        heroStack.addArrangedSubview(heroIconView)
+        heroStack.addArrangedSubview(titleLabel)
+        heroStack.addArrangedSubview(messageLabel)
+        heroCard.addSubview(heroStack)
+        NSLayoutConstraint.activate([
+            heroStack.topAnchor.constraint(equalTo: heroCard.topAnchor, constant: 20),
+            heroStack.leadingAnchor.constraint(equalTo: heroCard.leadingAnchor, constant: 18),
+            heroStack.trailingAnchor.constraint(equalTo: heroCard.trailingAnchor, constant: -18),
+            heroStack.bottomAnchor.constraint(equalTo: heroCard.bottomAnchor, constant: -20),
+            heroIconView.widthAnchor.constraint(equalToConstant: 58),
+            heroIconView.heightAnchor.constraint(equalTo: heroIconView.widthAnchor)
+        ])
+        contentStack.addArrangedSubview(heroCard)
+    }
+
+    private func addInfoCard() {
+        let card: UIStackView = .build()
+        card.axis = .vertical
+        card.spacing = 0
+        card.layer.cornerRadius = 14
+        card.layer.cornerCurve = .continuous
+        card.layer.borderWidth = 1
+        card.isLayoutMarginsRelativeArrangement = true
+        card.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0)
+        themedCards.append(card)
+        for (index, row) in presentation.infoRows.enumerated() {
+            if index > 0 {
+                let separator: UIView = .build()
+                separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
+                card.addArrangedSubview(separator)
+                separators.append(separator)
+            }
+            card.addArrangedSubview(makeInfoRow(row))
+        }
+        contentStack.addArrangedSubview(card)
+    }
+
+    private func makeInfoRow(_ row: FloorpNativeWebExtensionPromptPresentation.InfoRow) -> UIView {
+        let container: UIView = .build()
+        let iconView: UIImageView = .build()
+        iconView.image = UIImage(systemName: row.symbol)?.withRenderingMode(.alwaysTemplate)
+        iconView.contentMode = .scaleAspectFit
+        iconView.isAccessibilityElement = false
+        infoIconViews.append(iconView)
+        let rowTitle = makeLabel(text: row.title, style: .headline, primary: true)
+        let detail = makeLabel(text: row.detail, style: .footnote, primary: false)
+        let labels: UIStackView = .build()
+        labels.axis = .vertical
+        labels.spacing = 4
+        labels.addArrangedSubview(rowTitle)
+        labels.addArrangedSubview(detail)
+        container.addSubview(iconView)
+        container.addSubview(labels)
+        NSLayoutConstraint.activate([
+            iconView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            iconView.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            iconView.widthAnchor.constraint(equalToConstant: 24),
+            iconView.heightAnchor.constraint(equalToConstant: 24),
+            labels.topAnchor.constraint(equalTo: container.topAnchor, constant: 14),
+            labels.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 13),
+            labels.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            labels.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -14)
+        ])
+        container.isAccessibilityElement = true
+        container.accessibilityLabel = "\(row.title). \(row.detail)"
+        return container
+    }
+
+    private func makeLabel(
+        text: String,
+        style: UIFont.TextStyle,
+        primary: Bool
+    ) -> UILabel {
+        let label: UILabel = .build()
+        label.text = text
+        label.font = .preferredFont(forTextStyle: style)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
+        if primary {
+            primaryLabels.append(label)
+        } else {
+            secondaryLabels.append(label)
+        }
+        return label
+    }
+
+    private func addChoice(_ choice: FloorpNativeWebExtensionPromptPresentation.Choice) {
+        let button = ChoiceButton(choice: choice)
+        button.addAction(UIAction { [weak self] _ in
+            self?.selectChoice(identifier: choice.identifier)
+        }, for: .touchUpInside)
+        choiceButtons.append(button)
+        contentStack.addArrangedSubview(button)
+        button.heightAnchor.constraint(greaterThanOrEqualToConstant: 68).isActive = true
+    }
+
+    private func finish(with choice: FloorpNativeWebExtensionPromptPresentation.Choice) {
+        guard !didFinish else { return }
+        didFinish = true
+        pendingChoice = choice
+        setControlsEnabled(false)
+        dismiss(animated: true)
+    }
+
+    private func finishWithCancel() {
+        guard !didFinish else { return }
+        didFinish = true
+        setControlsEnabled(false)
+        dismiss(animated: true)
+    }
+
+    private func setControlsEnabled(_ enabled: Bool) {
+        choiceButtons.forEach { $0.isEnabled = enabled }
+        cancelButton.isEnabled = enabled
+    }
+}
+
+@MainActor
+final class FloorpNativeWebExtensionActionPickerViewController:
+    FloorpNativeWebExtensionPromptViewController {
+    init(
+        actions: [FloorpNativeWebExtensionActionItem],
+        windowUUID: WindowUUID,
+        onSelection: @escaping @MainActor (FloorpNativeWebExtensionActionItem) -> Void
+    ) {
+        let actionsByIdentifier = Dictionary(
+            uniqueKeysWithValues: actions.map { ($0.contextIdentifier, $0) }
+        )
+        let choices = actions.map { action in
+            FloorpNativeWebExtensionPromptPresentation.Choice(
+                identifier: action.contextIdentifier,
+                title: action.label,
+                detail: FloorpStrings.WebExtensions.version(action.version),
+                icon: action.icon ?? UIImage(systemName: "puzzlepiece.extension.fill"),
+                usesTemplateIcon: action.icon == nil
+            )
+        }
+        super.init(
+            presentation: .init(
+                title: FloorpStrings.WebExtensions.actions,
+                message: FloorpStrings.WebExtensions.chooseActionMessage,
+                heroImage: UIImage(systemName: "puzzlepiece.extension.fill"),
+                heroUsesTemplateImage: true,
+                infoRows: [],
+                choices: choices,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.ActionPicker"
+            ),
+            windowUUID: windowUUID,
+            onChoice: { choice in
+                guard let action = actionsByIdentifier[choice.identifier] else { return }
+                onSelection(action)
+            }
+        )
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+@MainActor
 final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewController {
     private enum Section: Int, CaseIterable {
         case installed
@@ -14,8 +645,8 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
 
         var title: String {
             switch self {
-            case .installed: return "Installed"
-            case .available: return "Available from Floorp"
+            case .installed: return FloorpStrings.WebExtensions.installedSection
+            case .available: return FloorpStrings.WebExtensions.availableSection
             }
         }
     }
@@ -23,7 +654,8 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
     private enum Row {
         case installed(FloorpNativeWebExtensionSettingsItem)
         case available(FloorpNativeWebExtensionCatalogItem)
-        case empty
+        case emptyInstalled
+        case emptyAvailable
         case unavailable
     }
 
@@ -31,6 +663,8 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
     private weak var tabManager: (any TabManager)?
     private var installedItems = [FloorpNativeWebExtensionSettingsItem]()
     private var isMutating = false
+    private var busyIdentifier: String?
+    private let heroHeader = FloorpNativeWebExtensionHeroHeaderView()
 
     init(
         windowUUID: WindowUUID,
@@ -48,14 +682,32 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Extensions"
+        title = FloorpStrings.WebExtensions.title
         tableView.accessibilityIdentifier = "Floorp.NativeWebExtensions.Settings"
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 104
+        tableView.register(
+            FloorpNativeWebExtensionCardCell.self,
+            forCellReuseIdentifier: FloorpNativeWebExtensionCardCell.reuseIdentifier
+        )
+        tableView.tableHeaderView = heroHeader
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             barButtonSystemItem: .refresh,
             target: self,
             action: #selector(refresh)
         )
+        navigationItem.rightBarButtonItem?.accessibilityLabel = FloorpStrings.WebExtensions.retry
         refresh()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        updateHeaderSize()
+    }
+
+    override func applyTheme() {
+        super.applyTheme()
+        heroHeader.applyTheme(theme: themeManager.getCurrentTheme(for: windowUUID))
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -76,7 +728,7 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
     }
 
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        guard host != nil else { return "Extensions" }
+        guard host != nil else { return FloorpStrings.WebExtensions.title }
         return Section(rawValue: section)?.title
     }
 
@@ -88,48 +740,93 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
         _ tableView: UITableView,
         cellForRowAt indexPath: IndexPath
     ) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: FloorpNativeWebExtensionCardCell.reuseIdentifier,
+            for: indexPath
+        ) as? FloorpNativeWebExtensionCardCell else {
+            return UITableViewCell()
+        }
         let theme = themeManager.getCurrentTheme(for: windowUUID)
-        cell.backgroundColor = theme.colors.layer2
-        cell.textLabel?.textColor = theme.colors.textPrimary
-        cell.detailTextLabel?.textColor = theme.colors.textSecondary
-        cell.detailTextLabel?.numberOfLines = 0
 
         switch rows(in: indexPath.section)[indexPath.row] {
         case .installed(let item):
-            cell.textLabel?.text = item.name
-            var detail = ["Version \(item.version)", item.isEnabled ? "Enabled" : "Disabled"]
-            detail.append(item.hasPrivateAccess ? "Allowed in private browsing" : "Private browsing off")
-            if item.hasUpdate {
-                detail.append("Update available")
-            }
-            if !item.diagnostics.isEmpty {
-                detail.append("\(item.diagnostics.count) diagnostic(s)")
-            }
-            if let error = item.errorDescription {
-                detail.append(error)
-            }
-            cell.detailTextLabel?.text = detail.joined(separator: " · ")
-            cell.accessoryType = .disclosureIndicator
-            cell.accessibilityIdentifier = "Floorp.NativeWebExtensions.Installed.\(item.identifier)"
+            let status = item.hasUpdate
+                ? FloorpStrings.WebExtensions.updateAvailable
+                : (item.isEnabled ? FloorpStrings.WebExtensions.enabled : FloorpStrings.WebExtensions.disabled)
+            let statusStyle: FloorpNativeWebExtensionCardCell.StatusStyle = item.errorDescription == nil
+                ? (item.hasUpdate ? .accent : .secondary)
+                : .critical
+            cell.configure(
+                title: item.name,
+                summary: item.summary ?? FloorpStrings.WebExtensions.introMessage,
+                version: item.version,
+                status: status,
+                statusStyle: statusStyle,
+                icon: item.iconData.flatMap(UIImage.init(data:)),
+                fallbackSymbol: "puzzlepiece.extension.fill",
+                isBusy: busyIdentifier == item.identifier,
+                isSelectable: true,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Installed.\(item.identifier)",
+                theme: theme
+            )
         case .available(let item):
-            cell.textLabel?.text = item.name
-            if item.isAvailableOnCurrentOS {
-                cell.detailTextLabel?.text = item.summary
-                cell.accessoryType = .disclosureIndicator
-            } else {
-                cell.detailTextLabel?.text = "Requires \(item.minimumOS.description) or later"
-                cell.selectionStyle = .none
-            }
-            cell.accessibilityIdentifier = "Floorp.NativeWebExtensions.Available.\(item.identifier)"
-        case .empty:
-            cell.textLabel?.text = "No extensions installed"
-            cell.detailTextLabel?.text = "Install a reviewed extension from the Floorp catalog below."
-            cell.selectionStyle = .none
+            cell.configure(
+                title: item.name,
+                summary: item.summary,
+                version: item.expectedVersion,
+                status: item.isAvailableOnCurrentOS
+                    ? FloorpStrings.WebExtensions.add
+                    : FloorpStrings.WebExtensions.notSupported,
+                statusStyle: item.isAvailableOnCurrentOS ? .accent : .critical,
+                icon: nil,
+                fallbackSymbol: "puzzlepiece.extension.fill",
+                isBusy: busyIdentifier == item.identifier,
+                isSelectable: item.isAvailableOnCurrentOS,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Available.\(item.identifier)",
+                theme: theme
+            )
+        case .emptyInstalled:
+            cell.configure(
+                title: FloorpStrings.WebExtensions.noInstalledTitle,
+                summary: FloorpStrings.WebExtensions.noInstalledMessage,
+                version: nil,
+                status: nil,
+                statusStyle: .secondary,
+                icon: nil,
+                fallbackSymbol: "square.stack.3d.up.slash",
+                isBusy: false,
+                isSelectable: false,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.EmptyInstalled",
+                theme: theme
+            )
+        case .emptyAvailable:
+            cell.configure(
+                title: FloorpStrings.WebExtensions.noAvailableTitle,
+                summary: FloorpStrings.WebExtensions.noAvailableMessage,
+                version: nil,
+                status: nil,
+                statusStyle: .secondary,
+                icon: nil,
+                fallbackSymbol: "checkmark.seal.fill",
+                isBusy: false,
+                isSelectable: false,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.EmptyAvailable",
+                theme: theme
+            )
         case .unavailable:
-            cell.textLabel?.text = "Extensions are unavailable"
-            cell.detailTextLabel?.text = "The native WebKit extension host did not start."
-            cell.selectionStyle = .none
+            cell.configure(
+                title: FloorpStrings.WebExtensions.loadErrorTitle,
+                summary: FloorpStrings.WebExtensions.loadErrorMessage,
+                version: nil,
+                status: nil,
+                statusStyle: .critical,
+                icon: nil,
+                fallbackSymbol: "exclamationmark.triangle.fill",
+                isBusy: false,
+                isSelectable: false,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Unavailable",
+                theme: theme
+            )
         }
         return cell
     }
@@ -142,7 +839,7 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
             showActions(for: item)
         case .available(let item):
             confirmInstall(item)
-        case .empty, .unavailable:
+        case .emptyInstalled, .emptyAvailable, .unavailable:
             break
         }
     }
@@ -152,13 +849,26 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
         guard let section = Section(rawValue: sectionIndex) else { return [] }
         switch section {
         case .installed:
-            return installedItems.isEmpty ? [.empty] : installedItems.map(Row.installed)
+            return installedItems.isEmpty ? [.emptyInstalled] : installedItems.map(Row.installed)
         case .available:
             let installed = Set(installedItems.map(\.identifier))
-            return FloorpNativeWebExtensionCatalog.items
+            let available = FloorpNativeWebExtensionCatalog.items
                 .filter { !installed.contains($0.identifier) }
                 .map(Row.available)
+            return available.isEmpty ? [.emptyAvailable] : available
         }
+    }
+
+    private func updateHeaderSize() {
+        guard let header = tableView.tableHeaderView, tableView.bounds.width > 0 else { return }
+        let targetSize = header.systemLayoutSizeFitting(
+            CGSize(width: tableView.bounds.width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        guard abs(header.frame.height - targetSize.height) > 0.5 else { return }
+        header.frame.size = CGSize(width: tableView.bounds.width, height: targetSize.height)
+        tableView.tableHeaderView = header
     }
 
     private func confirmInstall(_ item: FloorpNativeWebExtensionCatalogItem) {
@@ -168,159 +878,308 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
         }
         guard let host, !isMutating else { return }
         isMutating = true
+        busyIdentifier = item.identifier
         tableView.isUserInteractionEnabled = false
+        tableView.reloadData()
         Task { [weak self, host] in
             do {
                 let preview = try await host.installationPreview(identifier: item.identifier)
                 guard let self else { return }
                 isMutating = false
+                busyIdentifier = nil
                 tableView.isUserInteractionEnabled = true
+                tableView.reloadData()
                 presentInstallConfirmation(preview)
             } catch {
                 guard let self else { return }
                 isMutating = false
+                busyIdentifier = nil
                 tableView.isUserInteractionEnabled = true
+                tableView.reloadData()
                 presentError(error)
             }
         }
     }
 
     private func presentInstallConfirmation(_ preview: FloorpNativeWebExtensionInstallationPreview) {
-        var sections = [
-            "Version: \(preview.version)",
-            "Source: \(preview.source)",
-            "License: \(preview.license)"
-        ]
+        var infoRows = [FloorpNativeWebExtensionPromptPresentation.InfoRow(
+            symbol: "checkmark.seal.fill",
+            title: FloorpStrings.WebExtensions.reviewed,
+            detail: FloorpStrings.WebExtensions.version(preview.version)
+        )]
         if !preview.requiredPermissions.isEmpty {
-            sections.append("Required permissions:\n• \(preview.requiredPermissions.joined(separator: "\n• "))")
+            infoRows.append(.init(
+                symbol: "checkmark.shield.fill",
+                title: FloorpStrings.WebExtensions.accessSection,
+                detail: "• " + preview.requiredPermissions.joined(separator: "\n• ")
+            ))
         }
         if !preview.requiredMatchPatterns.isEmpty {
-            sections.append("Required website access:\n• \(preview.requiredMatchPatterns.joined(separator: "\n• "))")
+            infoRows.append(.init(
+                symbol: "hand.raised.fill",
+                title: preview.isUpdate
+                    ? FloorpStrings.WebExtensions.siteAccessPreservedTitle
+                    : FloorpStrings.WebExtensions.siteAccessStartsOffTitle,
+                detail: (preview.isUpdate
+                    ? FloorpStrings.WebExtensions.siteAccessPreservedMessage
+                    : FloorpStrings.WebExtensions.siteAccessStartsOffMessage)
+                    + "\n\n• " + preview.requiredMatchPatterns.joined(separator: "\n• ")
+            ))
         }
         if !preview.optionalPermissions.isEmpty || !preview.optionalMatchPatterns.isEmpty {
-            sections.append("Optional access will be requested only when the extension needs it.")
+            let optionalAccess = (preview.optionalPermissions + preview.optionalMatchPatterns).sorted()
+            infoRows.append(.init(
+                symbol: "hand.tap.fill",
+                title: FloorpStrings.WebExtensions.optionalAccess,
+                detail: FloorpStrings.WebExtensions.optionalAccessMessage
+                    + (optionalAccess.isEmpty ? "" : "\n\n• " + optionalAccess.joined(separator: "\n• "))
+            ))
         }
-        sections.append(
-            "Private browsing remains off until you explicitly enable it. "
-                + "Extension settings and storage remain in this profile."
+        infoRows.append(.init(
+            symbol: "eye.slash.fill",
+            title: FloorpStrings.WebExtensions.privateBrowsingOptInTitle,
+            detail: FloorpStrings.WebExtensions.privateBrowsingOptInMessage
+        ))
+        infoRows.append(.init(
+            symbol: "doc.text.fill",
+            title: "\(FloorpStrings.WebExtensions.sourceLabel) · \(FloorpStrings.WebExtensions.licenseLabel)",
+            detail: "\(preview.source) · \(preview.license)"
+        ))
+        let catalogSummary = FloorpNativeWebExtensionCatalog.item(identifier: preview.identifier)?.summary
+            ?? FloorpStrings.WebExtensions.introMessage
+        let installChoice = FloorpNativeWebExtensionPromptPresentation.Choice(
+            identifier: "install",
+            title: preview.isUpdate
+                ? FloorpStrings.WebExtensions.update
+                : FloorpStrings.WebExtensions.install,
+            detail: preview.isUpdate
+                ? FloorpStrings.WebExtensions.siteAccessPreservedMessage
+                : FloorpStrings.WebExtensions.siteAccessStartsOffMessage,
+            icon: UIImage(systemName: preview.isUpdate ? "arrow.down.circle.fill" : "arrow.down.app.fill"),
+            usesTemplateIcon: true,
+            role: .preferred
         )
-        let verb = preview.isUpdate ? "Update" : "Install"
-        let alert = UIAlertController(
-            title: "\(verb) \(preview.name)?",
-            message: sections.joined(separator: "\n\n"),
-            preferredStyle: .alert
-        )
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: verb, style: .default) { [weak self] _ in
-            self?.mutate {
-                try await $0.installBundledExtension(identifier: preview.identifier)
+        let sheet = FloorpNativeWebExtensionPromptViewController(
+            presentation: .init(
+                title: preview.isUpdate
+                    ? "\(FloorpStrings.WebExtensions.update) · \(preview.name)"
+                    : FloorpStrings.WebExtensions.installTitle(name: preview.name),
+                message: catalogSummary,
+                heroImage: preview.iconData.flatMap(UIImage.init(data:)),
+                heroUsesTemplateImage: preview.iconData == nil,
+                infoRows: infoRows,
+                choices: [installChoice],
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.InstallConsent.\(preview.identifier)"
+            ),
+            windowUUID: windowUUID,
+            onChoice: { [weak self] _ in
+                self?.mutate(
+                    identifier: preview.identifier,
+                    progress: preview.isUpdate
+                        ? FloorpStrings.WebExtensions.updating
+                        : FloorpStrings.WebExtensions.installing
+                ) {
+                    try await $0.installBundledExtension(identifier: preview.identifier)
+                }
             }
-        })
-        present(alert, animated: true)
+        )
+        present(sheet, animated: true)
     }
 
     private func showActions(for item: FloorpNativeWebExtensionSettingsItem) {
-        var detail = [
-            "Version: \(item.version)",
-            "Source: \(item.source)",
-            "License: \(item.license)"
+        var infoRows = [
+            FloorpNativeWebExtensionPromptPresentation.InfoRow(
+                symbol: "number",
+                title: FloorpStrings.WebExtensions.version(item.version),
+                detail: item.isEnabled
+                    ? FloorpStrings.WebExtensions.enabled
+                    : FloorpStrings.WebExtensions.disabled
+            ),
+            .init(
+                symbol: "doc.text.fill",
+                title: "\(FloorpStrings.WebExtensions.sourceLabel) · \(FloorpStrings.WebExtensions.licenseLabel)",
+                detail: "\(item.source) · \(item.license)"
+            )
         ]
         if !item.permissions.isEmpty {
-            detail.append("Permissions:\n• \(item.permissions.joined(separator: "\n• "))")
-        }
-        if !item.optionalPermissions.isEmpty {
-            detail.append("Optional permissions:\n• \(item.optionalPermissions.joined(separator: "\n• "))")
+            infoRows.append(.init(
+                symbol: "checkmark.shield.fill",
+                title: FloorpStrings.WebExtensions.accessSection,
+                detail: "• " + item.permissions.joined(separator: "\n• ")
+            ))
         }
         if !item.matchPatterns.isEmpty {
-            detail.append("Website access:\n• \(item.matchPatterns.joined(separator: "\n• "))")
-        }
-        if !item.optionalMatchPatterns.isEmpty {
-            detail.append("Optional website access:\n• \(item.optionalMatchPatterns.joined(separator: "\n• "))")
-        }
-        if !item.diagnostics.isEmpty {
-            detail.append("Diagnostics:\n• " + item.diagnostics.map {
-                "[\($0.phase.rawValue)] \($0.message) (\($0.domain):\($0.code))"
-            }.joined(separator: "\n• "))
+            infoRows.append(.init(
+                symbol: "hand.raised.fill",
+                title: FloorpStrings.WebExtensions.siteAccess,
+                detail: "• " + item.matchPatterns.joined(separator: "\n• ")
+            ))
         }
         if let error = item.errorDescription {
-            detail.append("Last error: \(error)")
+            infoRows.append(.init(
+                symbol: "exclamationmark.triangle.fill",
+                title: FloorpStrings.WebExtensions.loadErrorTitle,
+                detail: error
+            ))
         }
-        let alert = UIAlertController(
-            title: item.name,
-            message: detail.joined(separator: "\n\n"),
-            preferredStyle: .actionSheet
-        )
-        alert.addAction(UIAlertAction(
-            title: item.isEnabled ? "Disable" : "Enable",
-            style: .default
-        ) { [weak self] _ in
-            self?.mutate { try await $0.setEnabled(!item.isEnabled, identifier: item.identifier) }
-        })
-        alert.addAction(UIAlertAction(
-            title: item.hasPrivateAccess ? "Disable in Private Browsing" : "Allow in Private Browsing",
-            style: .default
-        ) { [weak self] _ in
-            self?.mutate { try $0.setPrivateAccess(!item.hasPrivateAccess, identifier: item.identifier) }
-        })
+        var choices = [
+            FloorpNativeWebExtensionPromptPresentation.Choice(
+                identifier: "toggle-enabled",
+                title: item.isEnabled
+                    ? FloorpStrings.WebExtensions.disableAction
+                    : FloorpStrings.WebExtensions.enableAction,
+                detail: FloorpStrings.WebExtensions.standardBrowsingEnabledMessage,
+                icon: UIImage(systemName: item.isEnabled ? "pause.circle.fill" : "play.circle.fill"),
+                usesTemplateIcon: true
+            ),
+            .init(
+                identifier: "toggle-private",
+                title: item.hasPrivateAccess
+                    ? FloorpStrings.WebExtensions.disallowPrivateBrowsingAction
+                    : FloorpStrings.WebExtensions.allowPrivateBrowsingAction,
+                detail: item.hasPrivateAccess
+                    ? FloorpStrings.WebExtensions.enabled
+                    : FloorpStrings.WebExtensions.privateAccessNotAllowed,
+                icon: UIImage(systemName: "eye.slash.fill"),
+                usesTemplateIcon: true
+            )
+        ]
         if item.hasOptionsPage {
-            alert.addAction(UIAlertAction(title: "Options", style: .default) { [weak self] _ in
-                guard let self, let host else { return }
-                do {
-                    let options = try host.optionsViewController(identifier: item.identifier)
-                    options.modalPresentationStyle = .formSheet
-                    present(options, animated: true)
-                } catch {
-                    presentError(error)
-                }
-            })
+            choices.append(.init(
+                identifier: "options",
+                title: FloorpStrings.WebExtensions.options,
+                detail: item.name,
+                icon: UIImage(systemName: "gearshape.fill"),
+                usesTemplateIcon: true
+            ))
         }
         if item.hasUpdate,
-           let catalogItem = FloorpNativeWebExtensionCatalog.item(identifier: item.identifier) {
-            alert.addAction(UIAlertAction(title: "Update", style: .default) { [weak self] _ in
-                self?.confirmInstall(catalogItem)
-            })
+           FloorpNativeWebExtensionCatalog.item(identifier: item.identifier) != nil {
+            choices.append(.init(
+                identifier: "update",
+                title: FloorpStrings.WebExtensions.update,
+                detail: FloorpStrings.WebExtensions.updateAvailable,
+                icon: UIImage(systemName: "arrow.down.circle.fill"),
+                usesTemplateIcon: true,
+                role: .preferred
+            ))
         }
-        alert.addAction(UIAlertAction(title: "Uninstall", style: .destructive) { [weak self] _ in
-            self?.confirmUninstall(item)
-        })
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = view
-            popover.sourceRect = view.bounds
+        choices.append(.init(
+            identifier: "uninstall",
+            title: FloorpStrings.WebExtensions.uninstall,
+            detail: FloorpStrings.WebExtensions.uninstallMessage,
+            icon: UIImage(systemName: "trash.fill"),
+            usesTemplateIcon: true,
+            role: .destructive
+        ))
+        let sheet = FloorpNativeWebExtensionPromptViewController(
+            presentation: .init(
+                title: item.name,
+                message: item.summary ?? FloorpStrings.WebExtensions.detailTitle,
+                heroImage: item.iconData.flatMap(UIImage.init(data:)),
+                heroUsesTemplateImage: item.iconData == nil,
+                infoRows: infoRows,
+                choices: choices,
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Manage.\(item.identifier)"
+            ),
+            windowUUID: windowUUID,
+            onChoice: { [weak self] choice in
+                self?.handleManagementChoice(choice.identifier, for: item)
+            }
+        )
+        present(sheet, animated: true)
+    }
+
+    private func handleManagementChoice(
+        _ identifier: String,
+        for item: FloorpNativeWebExtensionSettingsItem
+    ) {
+        switch identifier {
+        case "toggle-enabled":
+            mutate(identifier: item.identifier, progress: FloorpStrings.WebExtensions.loading) {
+                try await $0.setEnabled(!item.isEnabled, identifier: item.identifier)
+            }
+        case "toggle-private":
+            mutate(identifier: item.identifier, progress: FloorpStrings.WebExtensions.loading) {
+                try $0.setPrivateAccess(!item.hasPrivateAccess, identifier: item.identifier)
+            }
+        case "options":
+            guard let host else { return }
+            do {
+                let options = try host.optionsViewController(identifier: item.identifier)
+                present(options, animated: true)
+            } catch {
+                presentError(error)
+            }
+        case "update":
+            if let catalogItem = FloorpNativeWebExtensionCatalog.item(identifier: item.identifier) {
+                confirmInstall(catalogItem)
+            }
+        case "uninstall":
+            confirmUninstall(item)
+        default:
+            break
         }
-        present(alert, animated: true)
     }
 
     private func confirmUninstall(_ item: FloorpNativeWebExtensionSettingsItem) {
-        let alert = UIAlertController(
-            title: "Uninstall \(item.name)?",
-            message: "The extension and all WebKit-managed extension storage will be removed from this profile.",
-            preferredStyle: .alert
+        let sheet = FloorpNativeWebExtensionPromptViewController(
+            presentation: .init(
+                title: FloorpStrings.WebExtensions.uninstallTitle(name: item.name),
+                message: FloorpStrings.WebExtensions.uninstallMessage,
+                heroImage: item.iconData.flatMap(UIImage.init(data:)),
+                heroUsesTemplateImage: item.iconData == nil,
+                infoRows: [],
+                choices: [.init(
+                    identifier: "confirm-uninstall",
+                    title: FloorpStrings.WebExtensions.uninstall,
+                    detail: FloorpStrings.WebExtensions.uninstallMessage,
+                    icon: UIImage(systemName: "trash.fill"),
+                    usesTemplateIcon: true,
+                    role: .destructive
+                )],
+                accessibilityIdentifier: "Floorp.NativeWebExtensions.Uninstall.\(item.identifier)"
+            ),
+            windowUUID: windowUUID,
+            onChoice: { [weak self] _ in
+                self?.mutate(
+                    identifier: item.identifier,
+                    progress: FloorpStrings.WebExtensions.removing
+                ) {
+                    try await $0.uninstall(identifier: item.identifier)
+                }
+            }
         )
-        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-        alert.addAction(UIAlertAction(title: "Uninstall", style: .destructive) { [weak self] _ in
-            self?.mutate { try await $0.uninstall(identifier: item.identifier) }
-        })
-        present(alert, animated: true)
+        present(sheet, animated: true)
     }
 
     private func mutate(
+        identifier: String,
+        progress: String,
         _ operation: @escaping @MainActor (FloorpNativeWebExtensionHost) async throws -> Void
     ) {
         guard let host, !isMutating else { return }
         isMutating = true
+        busyIdentifier = identifier
         tableView.isUserInteractionEnabled = false
+        navigationItem.prompt = progress
+        tableView.reloadData()
         Task { [weak self, host] in
             do {
                 try await operation(host)
                 guard let self else { return }
                 isMutating = false
+                busyIdentifier = nil
                 tableView.isUserInteractionEnabled = true
+                navigationItem.prompt = nil
                 refresh()
             } catch {
                 guard let self else { return }
                 isMutating = false
+                busyIdentifier = nil
                 tableView.isUserInteractionEnabled = true
+                navigationItem.prompt = nil
+                tableView.reloadData()
                 presentError(error)
             }
         }
@@ -328,11 +1187,11 @@ final class FloorpNativeWebExtensionSettingsViewController: ThemedTableViewContr
 
     private func presentError(_ error: Error) {
         let alert = UIAlertController(
-            title: "Extension could not be changed",
+            title: FloorpStrings.WebExtensions.changeErrorTitle,
             message: error.localizedDescription,
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        alert.addAction(UIAlertAction(title: FloorpStrings.WebExtensions.done, style: .default))
         present(alert, animated: true)
     }
 }

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
@@ -45,11 +45,51 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
 
         XCTAssertTrue(context.isLoaded)
         XCTAssertNotNil(context.optionsPageURL)
+        let action = try XCTUnwrap(context.action(for: nil))
+        XCTAssertTrue(action.presentsPopup)
+        XCTAssertNotNil(action.popupViewController)
         XCTAssertTrue(webExtension.hasBackgroundContent)
         XCTAssertTrue(webExtension.hasInjectedContent)
         XCTAssertTrue(webExtension.requestedPermissions.contains(.storage))
         XCTAssertTrue(webExtension.requestedPermissions.contains(.scripting))
         XCTAssertFalse(webExtension.requestedPermissions.contains(.nativeMessaging))
+    }
+
+    func testActionPickerListsEveryActionAndDefersSelectionUntilDismissal() {
+        let actions = [
+            FloorpNativeWebExtensionActionItem(
+                contextIdentifier: "dark-reader",
+                label: "Dark Reader",
+                version: "4.9.129",
+                icon: nil,
+                isEnabled: true
+            ),
+            FloorpNativeWebExtensionActionItem(
+                contextIdentifier: "ubol",
+                label: "uBlock Origin Lite",
+                version: "2026.825.1619",
+                icon: nil,
+                isEnabled: true
+            )
+        ]
+        var selections = [String]()
+        let picker = FloorpNativeWebExtensionActionPickerViewController(
+            actions: actions,
+            windowUUID: UUID(),
+            onSelection: { selections.append($0.contextIdentifier) }
+        )
+
+        picker.loadViewIfNeeded()
+
+        XCTAssertEqual(picker.displayedChoiceTitles, ["Dark Reader", "uBlock Origin Lite"])
+        XCTAssertEqual(picker.view.accessibilityIdentifier, "Floorp.NativeWebExtensions.ActionPicker")
+        picker.selectChoice(identifier: "ubol")
+        XCTAssertTrue(selections.isEmpty)
+
+        picker.viewDidDisappear(false)
+        picker.viewDidDisappear(false)
+
+        XCTAssertEqual(selections, ["ubol"])
     }
 
     func testNativeRegistryV2RoundTripsIdentityPermissionsAndTransactionState() throws {
@@ -307,7 +347,9 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 500_000_000)
 
         XCTAssertTrue(context.isLoaded)
-        XCTAssertNotNil(context.action(for: nil))
+        let action = try XCTUnwrap(context.action(for: nil))
+        XCTAssertTrue(action.presentsPopup)
+        XCTAssertNotNil(action.popupViewController)
         XCTAssertNotNil(context.optionsPageURL)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
@@ -46,8 +46,9 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         XCTAssertTrue(context.isLoaded)
         XCTAssertNotNil(context.optionsPageURL)
         let action = try XCTUnwrap(context.action(for: nil))
+        // Materializing an unpresented popup view controller makes WebKit tear down its
+        // process pool asynchronously and can crash the next WebKit test on iOS 26.2.
         XCTAssertTrue(action.presentsPopup)
-        XCTAssertNotNil(action.popupViewController)
         XCTAssertTrue(webExtension.hasBackgroundContent)
         XCTAssertTrue(webExtension.hasInjectedContent)
         XCTAssertTrue(webExtension.requestedPermissions.contains(.storage))
@@ -348,8 +349,8 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
 
         XCTAssertTrue(context.isLoaded)
         let action = try XCTUnwrap(context.action(for: nil))
+        // Popup presentation itself is exercised by the host and action-picker tests.
         XCTAssertTrue(action.presentsPopup)
-        XCTAssertNotNil(action.popupViewController)
         XCTAssertNotNil(context.optionsPageURL)
     }
 

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
@@ -74,9 +74,11 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
             )
         ]
         var selections = [String]()
+        var dismissalCompletion: (() -> Void)?
         let picker = FloorpNativeWebExtensionActionPickerViewController(
             actions: actions,
             windowUUID: UUID(),
+            dismissalHandler: { dismissalCompletion = $0 },
             onSelection: { selections.append($0.contextIdentifier) }
         )
 
@@ -87,8 +89,8 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         picker.selectChoice(identifier: "ubol")
         XCTAssertTrue(selections.isEmpty)
 
-        picker.viewDidDisappear(false)
-        picker.viewDidDisappear(false)
+        dismissalCompletion?()
+        dismissalCompletion?()
 
         XCTAssertEqual(selections, ["ubol"])
     }


### PR DESCRIPTION
## Summary
- restore WebExtension action popup presentation for menu and programmatic actions
- replace the regressed extension management UI with localized, themed install and settings surfaces
- deduplicate displayed permissions and add popup lifecycle coverage

## Validation
- Debug Fennec simulator build succeeded
- FloorpRelease simulator build succeeded
- manually verified uBlock Origin Lite and Dark Reader picker/direct popup flows on iOS 26.5 Simulator

## Known test infrastructure issue
- ClientTests currently fails to compile because of pre-existing FloorpNotesTests API errors; the modified app targets compile successfully