### PR TITLE
Enable Floorp Default Web Browser entitlement

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -139,9 +139,11 @@ Adding Push later requires restoring that target where needed, production entitl
 
 ### Managed browser entitlements
 
-The private Internal TestFlight line intentionally omits `com.apple.developer.web-browser`. Apple has not approved that managed capability for the Floorp App ID, so these builds will not appear as a default-browser choice. Apple's request form requires an App Store build or a public TestFlight link, so the request is intentionally deferred while distribution remains private. When Floorp adopts external testing or public distribution, first provide an assessment build without the entitlement; after Apple approves the request, enable the capability for `app.floorp.Floorp`, regenerate the distribution profile, re-add the entitlement, and verify it in the signed archive.
+Apple has assigned `com.apple.developer.web-browser` to `app.floorp.Floorp`. `FloorpReleaseApplication.entitlements` declares it as `true`, allowing eligible signed builds to appear in iOS’s Default Browser App settings. `FloorpReleaseInfo.plist` already registers the required `http` and `https` URL schemes.
 
-The Floorp release entitlement omits `com.apple.developer.browser.app-installation`, which is for installing alternative-distribution apps from a website. Add it only if Floorp deliberately adopts that distribution path and Apple approves the request.
+The capability is managed. Before producing a distribution archive, let Xcode refresh the automatically managed provisioning profile for Team `DV2U35YBHT`, then verify the signed archive contains `com.apple.developer.web-browser = true`.
+
+The Floorp release entitlement continues to omit `com.apple.developer.browser.app-installation`, which is for installing alternative-distribution apps from a website. Add it only if Floorp deliberately adopts that distribution path and Apple approves the request.
 
 ### Versioning
 
@@ -175,7 +177,7 @@ Complete the remaining unchecked steps before broad public distribution:
 - [x] Omit Push/APNs and AutoFill Credential Provider from the initial Client-only release.
 - [ ] Confirm Multipath remains a product requirement; it is currently retained because networking code uses `.handover`.
 - [x] Disable Hosted Summarizer, its App Attest path, and Quick Answers; retain Apple on-device summarization.
-- [ ] Request the default-browser managed entitlement.
+- [x] Request and enable the default-browser managed entitlement.
 - [x] Omit the browser app-installation entitlement from the initial release configuration.
 - [ ] Choose the Floorp marketing-version policy and initial version.
 - [x] Create the Floorp app record in App Store Connect (`6796708699`).
@@ -229,7 +231,8 @@ its source SHA, archived marketing version/build, signing identity,
 entitlements, archive and IPA digests, and the dSYM UUID inventory.
 `scripts/release/validate-floorp-release-evidence.py` re-verifies the document
 against `scripts/release/floorp-release-evidence.schema.json` and rejects mixed
-build IDs, forbidden entitlements, missing dSYMs, and digest mismatches.
+build IDs, a missing default-browser entitlement, forbidden entitlements, missing
+dSYMs, and digest mismatches.
 
 `scripts/release/app-store-connect-api.py` is the only App Store Connect
 surface. Its read allowlist covers the required workflow, repository, and Git

--- a/firefox-ios/Client/Entitlements/FloorpReleaseApplication.entitlements
+++ b/firefox-ios/Client/Entitlements/FloorpReleaseApplication.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.developer.networking.multipath</key>
 	<true/>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(FLOORP_APP_GROUP_IDENTIFIER)</string>

--- a/scripts/ci/check-floorp-branding.sh
+++ b/scripts/ci/check-floorp-branding.sh
@@ -165,6 +165,48 @@ require_plist_string_value() {
     fi
 }
 
+plist_key_has_true_value() {
+    local plist_file="$1"
+    local key="$2"
+
+    awk -v expected_key="<key>${key}</key>" '
+        {
+            line = $0
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+        }
+        line == expected_key {
+            awaiting_value = 1
+            next
+        }
+        awaiting_value && line == "<true/>" {
+            found = 1
+            exit
+        }
+        awaiting_value && line != "" {
+            exit
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    ' "$plist_file"
+}
+
+require_plist_true_value() {
+    local plist_file="$1"
+    local key="$2"
+    local description="$3"
+
+    if ! require_file "$plist_file"; then
+        return
+    fi
+
+    if plist_key_has_true_value "$plist_file" "$key"; then
+        pass "$description"
+    else
+        fail "$description ($key must map to true in $plist_file)"
+    fi
+}
+
 find_permission_description_matches() {
     local file="$1"
 
@@ -815,9 +857,13 @@ require_fixed "$RELEASE_CONFIG" "MOZ_PUBLIC_URL_SCHEME = floorp" "Public URL sch
 require_fixed "$RELEASE_CONFIG" "MOZ_INTERNAL_URL_SCHEME = floorp-internal" "Internal URL scheme is fixed"
 
 require_fixed "$RELEASE_ENTITLEMENTS" "\$(AppIdentifierPrefix)app.floorp.Floorp" "Floorp keychain group is fixed"
-forbid_fixed_in_files \
+require_plist_true_value \
+    "$RELEASE_ENTITLEMENTS" \
     "com.apple.developer.web-browser" \
-    "FloorpRelease omits the unapproved default-browser entitlement" \
+    "FloorpRelease enables the approved default-browser entitlement"
+forbid_fixed_in_files \
+    "com.apple.developer.browser.app-installation" \
+    "FloorpRelease omits the unapproved browser app-installation entitlement" \
     "$RELEASE_ENTITLEMENTS"
 require_fixed "$RELEASE_PLIST" "\$(FLOORP_APP_GROUP_IDENTIFIER)" "Release plist uses the Floorp App Group setting"
 require_fixed "$RELEASE_PLIST" "app.floorp.sync.part1" "Background sync task 1 is fixed"

--- a/scripts/release/fixtures/floorp-privacy-entitlements-default-browser.plist
+++ b/scripts/release/fixtures/floorp-privacy-entitlements-default-browser.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>application-identifier</key>
+	<string>DV2U35YBHT.app.floorp.Floorp</string>
+	<key>com.apple.developer.web-browser</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/release/fixtures/floorp-release-evidence-cloud-archive.json
+++ b/scripts/release/fixtures/floorp-release-evidence-cloud-archive.json
@@ -17,6 +17,7 @@
   },
   "entitlements": {
     "com.apple.developer.networking.multipath": true,
+    "com.apple.developer.web-browser": true,
     "com.apple.security.application-groups": [
       "group.app.floorp.Floorp.DV2U35YBHT"
     ],

--- a/scripts/release/fixtures/floorp-release-evidence-valid.json
+++ b/scripts/release/fixtures/floorp-release-evidence-valid.json
@@ -21,6 +21,7 @@
   },
   "entitlements": {
     "application-identifier": "ABCDEF1234.app.floorp.Floorp",
+    "com.apple.developer.web-browser": true,
     "keychain-access-groups": ["ABCDEF1234.app.floorp.Floorp"],
     "com.apple.security.application-groups": ["group.app.floorp.Floorp.DV2U35YBHT"]
   },

--- a/scripts/release/tests/test_validate_floorp_privacy.py
+++ b/scripts/release/tests/test_validate_floorp_privacy.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import plistlib
 import tempfile
 import unittest
 from pathlib import Path
@@ -61,6 +62,32 @@ class FloorpPrivacyValidatorTests(unittest.TestCase):
             self.run_validator(entitlements=FIXTURES / "floorp-privacy-entitlements-forbidden.plist"),
             1,
         )
+
+    def test_enabled_default_browser_entitlement_passes(self):
+        self.assertEqual(
+            self.run_validator(
+                entitlements=FIXTURES / "floorp-privacy-entitlements-default-browser.plist"
+            ),
+            0,
+        )
+
+    def test_missing_default_browser_entitlement_fails(self):
+        source = FIXTURES / "floorp-privacy-entitlements-default-browser.plist"
+        with tempfile.TemporaryDirectory() as tmp:
+            entitlements = plistlib.loads(source.read_bytes())
+            entitlements.pop("com.apple.developer.web-browser")
+            path = Path(tmp) / "entitlements.plist"
+            path.write_bytes(plistlib.dumps(entitlements))
+            self.assertEqual(self.run_validator(entitlements=path), 1)
+
+    def test_browser_app_installation_entitlement_fails(self):
+        source = FIXTURES / "floorp-privacy-entitlements-default-browser.plist"
+        with tempfile.TemporaryDirectory() as tmp:
+            entitlements = plistlib.loads(source.read_bytes())
+            entitlements["com.apple.developer.browser.app-installation"] = True
+            path = Path(tmp) / "entitlements.plist"
+            path.write_bytes(plistlib.dumps(entitlements))
+            self.assertEqual(self.run_validator(entitlements=path), 1)
 
     def test_static_endpoint_outside_matrix_fails(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/release/tests/test_validate_floorp_release_evidence.py
+++ b/scripts/release/tests/test_validate_floorp_release_evidence.py
@@ -65,6 +65,26 @@ class FloorpReleaseEvidenceValidatorTests(unittest.TestCase):
     def test_forbidden_entitlement_fails(self):
         self.assertEqual(self.run_validator(FIXTURES / "floorp-release-evidence-wrong-entitlement.json"), 1)
 
+    def test_default_browser_entitlement_is_required(self):
+        evidence = json.loads(
+            (FIXTURES / "floorp-release-evidence-valid.json").read_text()
+        )
+        evidence["entitlements"].pop("com.apple.developer.web-browser")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ev.json"
+            path.write_text(json.dumps(evidence))
+            self.assertEqual(self.run_validator(path), 1)
+
+    def test_browser_app_installation_entitlement_is_forbidden(self):
+        evidence = json.loads(
+            (FIXTURES / "floorp-release-evidence-valid.json").read_text()
+        )
+        evidence["entitlements"]["com.apple.developer.browser.app-installation"] = True
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ev.json"
+            path.write_text(json.dumps(evidence))
+            self.assertEqual(self.run_validator(path), 1)
+
     def test_missing_dsym_inventory_fails(self):
         self.assertEqual(self.run_validator(FIXTURES / "floorp-release-evidence-missing-dsym.json"), 1)
 

--- a/scripts/release/validate-floorp-privacy.py
+++ b/scripts/release/validate-floorp-privacy.py
@@ -9,7 +9,8 @@ artifact, and rejects:
   - any traced or statically referenced host outside the matrix, and any
     disabled-service host that appears in a trace;
   - missing dSYM UUIDs for frameworks embedded in the archive;
-  - forbidden entitlements (APNs, web-browser, browser app-installation);
+  - a missing default-browser entitlement, or forbidden APNs and browser
+    app-installation entitlements;
   - internally inconsistent App Privacy / export-compliance metadata.
 
 Exit codes:
@@ -125,11 +126,12 @@ def validate_entitlements(entitlements_path: Path) -> None:
     entitlements = load_entitlements(entitlements_path)
     forbidden = [
         "aps-environment",
-        "com.apple.developer.web-browser",
         "com.apple.developer.browser.app-installation",
     ]
     for name in forbidden:
         check(name not in entitlements, f"forbidden entitlement present: {name}")
+    check(entitlements.get("com.apple.developer.web-browser") is True,
+          "default-browser entitlement must be enabled")
     application_identifier = entitlements.get("application-identifier", "")
     check("app.floorp.Floorp" in application_identifier,
           "application-identifier must contain app.floorp.Floorp")

--- a/scripts/release/validate-floorp-release-evidence.py
+++ b/scripts/release/validate-floorp-release-evidence.py
@@ -8,8 +8,8 @@ schema conformance this validator enforces the release contract:
   - the archive's captured version/build/team/bundle match the evidence and
     the Floorp release identity (DV2U35YBHT / app.floorp.Floorp);
   - the IPA's version/build match the archive (no mixed build IDs);
-  - the signed entitlements match the approved Floorp capability set and
-    omit the denied capabilities (APNs, web-browser, browser app-installation);
+  - the signed entitlements include the approved default-browser capability
+    and omit denied capabilities (APNs and browser app-installation);
   - the dSYM inventory is non-empty with unique UUIDs;
   - the IPA SHA-256 is recomputed when the file is present.
 
@@ -94,11 +94,12 @@ def validate_shape(schema: dict, evidence: dict) -> None:
 def validate_entitlements(entitlements: dict) -> None:
     denied = [
         "aps-environment",
-        "com.apple.developer.web-browser",
         "com.apple.developer.browser.app-installation",
     ]
     for name in denied:
         check(name not in entitlements, f"forbidden entitlement present: {name}")
+    check(entitlements.get("com.apple.developer.web-browser") is True,
+          "default-browser entitlement must be enabled")
 
     application_identifier = entitlements.get("application-identifier")
     if application_identifier is not None:


### PR DESCRIPTION
## :scroll: Tickets
N/A — Apple Developer assigned the Default Web Browser entitlement to `app.floorp.Floorp`; no Jira or GitHub issue was supplied.

## :bulb: Description
- Enable `com.apple.developer.web-browser` for the Floorp release target.
- Require the entitlement in release evidence and privacy validation while keeping APNs and browser app-installation disallowed.
- Add CI coverage, fixtures, and release documentation for provisioning-profile refresh and signed-archive verification.

## :movie_camera: Demos
Not applicable — signing and release-configuration change only.

## :pencil: Checklist
- [x] I filled in the available ticket context and a description of my work
- [x] I ensured unit tests pass and wrote tests for new code
- [x] I updated documentation
- [x] UI, telemetry, and localization review are not applicable