### PR TITLE
Accept Xcode 26 test execution markers in release gate

### DIFF
--- a/scripts/release/tests/test_validate_floorp_ci_release_gate.py
+++ b/scripts/release/tests/test_validate_floorp_ci_release_gate.py
@@ -50,7 +50,7 @@ class FloorpCIReleaseGateTests(unittest.TestCase):
             (artifact / "ubol-release-acceptance.log").write_text(
                 log
                 if log is not None
-                else "FLOORP_UBOL_RELEASE_GATE report\n** TEST SUCCEEDED **\n",
+                else "FLOORP_UBOL_RELEASE_GATE report\n** TEST EXECUTE SUCCEEDED **\n",
                 encoding="utf-8",
             )
             output = root / "receipt.json"
@@ -70,6 +70,13 @@ class FloorpCIReleaseGateTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(receipt["head_sha"], HEAD_SHA)
         self.assertEqual(receipt["ci_run_id"], RUN_ID)
+        self.assertEqual(receipt["status"], "release-gate-passed")
+
+    def test_legacy_xcodebuild_success_marker_passes(self):
+        result, receipt = self.run_gate(
+            log="FLOORP_UBOL_RELEASE_GATE report\n** TEST SUCCEEDED **\n"
+        )
+        self.assertEqual(result, 0)
         self.assertEqual(receipt["status"], "release-gate-passed")
 
     def test_different_source_sha_fails(self):
@@ -94,13 +101,36 @@ class FloorpCIReleaseGateTests(unittest.TestCase):
         self.assertIsNone(receipt)
 
     def test_acceptance_without_completion_marker_fails(self):
-        result, receipt = self.run_gate(log="** TEST SUCCEEDED **\n")
+        result, receipt = self.run_gate(log="** TEST EXECUTE SUCCEEDED **\n")
+        self.assertEqual(result, 1)
+        self.assertIsNone(receipt)
+
+    def test_acceptance_without_xcodebuild_success_marker_fails(self):
+        result, receipt = self.run_gate(log="FLOORP_UBOL_RELEASE_GATE report\n")
         self.assertEqual(result, 1)
         self.assertIsNone(receipt)
 
     def test_failed_acceptance_log_fails(self):
         result, receipt = self.run_gate(
+            log="FLOORP_UBOL_RELEASE_GATE report\n** TEST EXECUTE FAILED **\n"
+        )
+        self.assertEqual(result, 1)
+        self.assertIsNone(receipt)
+
+    def test_legacy_failure_marker_fails(self):
+        result, receipt = self.run_gate(
             log="FLOORP_UBOL_RELEASE_GATE report\n** TEST FAILED **\n"
+        )
+        self.assertEqual(result, 1)
+        self.assertIsNone(receipt)
+
+    def test_failure_marker_overrides_xcodebuild_success_marker(self):
+        result, receipt = self.run_gate(
+            log=(
+                "FLOORP_UBOL_RELEASE_GATE report\n"
+                "** TEST EXECUTE SUCCEEDED **\n"
+                "** TEST EXECUTE FAILED **\n"
+            )
         )
         self.assertEqual(result, 1)
         self.assertIsNone(receipt)

--- a/scripts/release/validate-floorp-ci-release-gate.py
+++ b/scripts/release/validate-floorp-ci-release-gate.py
@@ -12,6 +12,14 @@ from pathlib import Path
 SHA1 = re.compile(r"^[0-9a-f]{40}$")
 EXPECTED_WORKFLOW = ".github/workflows/ci.yml"
 ACCEPTANCE_MARKER = "FLOORP_UBOL_RELEASE_GATE report"
+XCODEBUILD_SUCCESS_MARKERS = (
+    "** TEST SUCCEEDED **",
+    "** TEST EXECUTE SUCCEEDED **",
+)
+XCODEBUILD_FAILURE_MARKERS = (
+    "** TEST FAILED **",
+    "** TEST EXECUTE FAILED **",
+)
 
 
 def require(condition: bool, message: str) -> None:
@@ -66,8 +74,10 @@ def validate(arguments: argparse.Namespace) -> dict:
     log_bytes = log.read_bytes()
     log_text = log_bytes.decode("utf-8", errors="replace")
     require(ACCEPTANCE_MARKER in log_text, "uBO acceptance completion marker is missing")
-    require("** TEST SUCCEEDED **" in log_text, "uBO acceptance test did not succeed")
-    require("** TEST FAILED **" not in log_text, "uBO acceptance log records a failure")
+    require(not any(marker in log_text for marker in XCODEBUILD_FAILURE_MARKERS),
+            "uBO acceptance log records a failure")
+    require(any(marker in log_text for marker in XCODEBUILD_SUCCESS_MARKERS),
+            "uBO acceptance test did not succeed")
 
     return {
         "artifact_name": f"floorp-ubol-release-acceptance-{arguments.expected_run_id}",


### PR DESCRIPTION
## Summary
- accept both legacy and Xcode 26 xcodebuild success markers
- reject both legacy and Xcode 26 failure markers before accepting success
- cover legacy/current success, missing success, and mixed success/failure cases

## Evidence
- 20 focused release-gate/workflow tests pass
- all 211 release tests pass
- validator accepts the exact successful uBO artifact from main CI run 34166830611
- failed TestFlight bridge run 34297328703 never reached Apple or started Xcode Cloud