### PR TITLE
Stabilize Dark Reader cold readiness on iOS 26

### DIFF
--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
@@ -120,6 +120,20 @@ final class FloorpNativeWebExtensionHost: NSObject {
         case failed(any Error)
     }
 
+    private enum BackgroundReadinessMode {
+        case interactive
+        case coldLifecycle
+
+        var allowsSupplementalDarkReaderGesturesRecovery: Bool {
+            switch self {
+            case .interactive:
+                return false
+            case .coldLifecycle:
+                return true
+            }
+        }
+    }
+
     @MainActor
     private final class BackgroundContentLoadGate {
         private var continuation: CheckedContinuation<Void, any Error>?
@@ -836,9 +850,19 @@ final class FloorpNativeWebExtensionHost: NSObject {
     }
 
     static func readinessPageNavigationTimeoutForTesting(
+        identifier: String,
+        isColdLifecycle: Bool = false
+    ) -> UInt64 {
+        readinessPageNavigationTimeout(
+            for: identifier,
+            mode: isColdLifecycle ? .coldLifecycle : .interactive
+        )
+    }
+
+    static func coldBackgroundReadinessTimeoutForTesting(
         identifier: String
     ) -> UInt64 {
-        readinessPageNavigationTimeout(for: identifier)
+        coldBackgroundReadinessTimeoutPolicy(for: identifier)
     }
 
     static func supplementalReadinessRetryBudgetForTesting(
@@ -1130,7 +1154,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                         timeoutNanoseconds: coldBackgroundReadinessTimeout(
                             for: record.id
                         ),
-                        allowsSupplementalDarkReaderGesturesRecovery: true
+                        mode: .coldLifecycle
                     )
                     try validateTransition(for: record.id, generation: generation)
                     setContextReady(true, identifier: record.id)
@@ -1511,20 +1535,36 @@ final class FloorpNativeWebExtensionHost: NSObject {
     }
 
     private func backgroundReadinessTimeout(for identifier: String) -> UInt64 {
+        Self.backgroundReadinessTimeoutPolicy(for: identifier)
+    }
+
+    private static func backgroundReadinessTimeoutPolicy(
+        for identifier: String
+    ) -> UInt64 {
         FloorpNativeWebExtensionCatalog.item(identifier: identifier)?
             .navigationReadinessFailurePolicy == .failClosed
             ? 90_000_000_000
             : 15_000_000_000
     }
 
-    private static func readinessPageNavigationTimeout(for identifier: String) -> UInt64 {
+    private static func readinessPageNavigationTimeout(
+        for identifier: String,
+        mode: BackgroundReadinessMode
+    ) -> UInt64 {
         // A pristine uBO Lite context can spend more than the generic 15-second
         // page budget creating WebExtension storage and preparing its large DNR
-        // ruleset on iOS 26. Keep that one owned WebView alive for a bounded
-        // extension-specific window without weakening Dark Reader's timeout.
-        identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier
-            ? 30_000_000_000
-            : 15_000_000_000
+        // ruleset on iOS 26. Dark Reader can spend most of that same generic
+        // budget launching its first WebContent process. Only lifecycle-owned
+        // surfaces receive the longer bounded window; interactive probes keep
+        // their existing latency cap.
+        if identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier {
+            return 30_000_000_000
+        }
+        if identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier,
+           case .coldLifecycle = mode {
+            return 30_000_000_000
+        }
+        return 15_000_000_000
     }
 
     private func extensionSurfaceCloseUIBudget() -> UInt64 {
@@ -1537,14 +1577,24 @@ final class FloorpNativeWebExtensionHost: NSObject {
     }
 
     private func coldBackgroundReadinessTimeout(for identifier: String) -> UInt64 {
+        Self.coldBackgroundReadinessTimeoutPolicy(for: identifier)
+    }
+
+    private static func coldBackgroundReadinessTimeoutPolicy(
+        for identifier: String
+    ) -> UInt64 {
         // On a fresh uBO context WebKit compiles more than 100,000 static
-        // rules and the dynamic regex realm before the first semantic probe
-        // can return. Keep navigation/action probes bounded at 90 seconds,
-        // while allowing cold install, restore, and re-enable enough time for
-        // that one-time native compilation to finish on slower devices.
-        identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier
-            ? 240_000_000_000
-            : backgroundReadinessTimeout(for: identifier)
+        // rules and the dynamic regex realm before the first semantic probe can
+        // return. Dark Reader can also spend the generic 15-second budget just
+        // launching the first WebContent process on iOS 26. Keep interactive
+        // probes unchanged while giving owned cold lifecycle work enough time.
+        if identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier {
+            return 240_000_000_000
+        }
+        if identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier {
+            return 30_000_000_000
+        }
+        return backgroundReadinessTimeoutPolicy(for: identifier)
     }
 
     private func waitForStartupNavigationReadiness() async {
@@ -2260,7 +2310,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                     in: newContext,
                     identifier: identifier,
                     timeoutNanoseconds: coldBackgroundReadinessTimeout(for: identifier),
-                    allowsSupplementalDarkReaderGesturesRecovery: true
+                    mode: .coldLifecycle
                 )
                 try validateTransition(for: identifier, generation: generation)
                 setContextReady(true, identifier: identifier)
@@ -2369,7 +2419,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                                 in: previousContext,
                                 identifier: identifier,
                                 timeoutNanoseconds: coldBackgroundReadinessTimeout(for: identifier),
-                                allowsSupplementalDarkReaderGesturesRecovery: true
+                                mode: .coldLifecycle
                             )
                             try validateTransition(
                                 for: identifier,
@@ -2654,7 +2704,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                 in: context,
                 identifier: identifier,
                 timeoutNanoseconds: coldBackgroundReadinessTimeout(for: identifier),
-                allowsSupplementalDarkReaderGesturesRecovery: true
+                mode: .coldLifecycle
             )
             try validateTransition(for: identifier, generation: generation)
             setContextReady(true, identifier: identifier)
@@ -4359,7 +4409,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
         in context: WKWebExtensionContext,
         identifier: String,
         timeoutNanoseconds: UInt64 = 15_000_000_000,
-        allowsSupplementalDarkReaderGesturesRecovery: Bool = false,
+        mode: BackgroundReadinessMode = .interactive,
         runsLifecycleStabilityHook: Bool = false
     ) async throws {
         guard context.isLoaded,
@@ -4372,8 +4422,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                 in: context,
                 identifier: identifier,
                 timeoutNanoseconds: timeoutNanoseconds,
-                allowsSupplementalDarkReaderGesturesRecovery:
-                    allowsSupplementalDarkReaderGesturesRecovery,
+                mode: mode,
                 runsLifecycleStabilityHook: runsLifecycleStabilityHook
             )
             return
@@ -4439,7 +4488,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
         in context: WKWebExtensionContext,
         identifier: String,
         timeoutNanoseconds: UInt64 = 90_000_000_000,
-        allowsSupplementalDarkReaderGesturesRecovery: Bool = false
+        mode: BackgroundReadinessMode = .interactive
     ) async throws {
         guard context.isLoaded,
               context.webExtension.hasBackgroundContent,
@@ -4463,8 +4512,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                 in: context,
                 identifier: identifier,
                 timeoutNanoseconds: try remainingTimeout(),
-                allowsSupplementalDarkReaderGesturesRecovery:
-                    allowsSupplementalDarkReaderGesturesRecovery,
+                mode: mode,
                 runsLifecycleStabilityHook: true
             )
             // uBO itself waits until realm-ruleset promise identity is stable.
@@ -4540,7 +4588,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
         in context: WKWebExtensionContext,
         identifier: String,
         timeoutNanoseconds: UInt64,
-        allowsSupplementalDarkReaderGesturesRecovery: Bool,
+        mode: BackgroundReadinessMode,
         runsLifecycleStabilityHook: Bool
     ) async throws {
         let start = DispatchTime.now().uptimeNanoseconds
@@ -4599,15 +4647,19 @@ final class FloorpNativeWebExtensionHost: NSObject {
             attempt += 1
             let attemptStart = DispatchTime.now().uptimeNanoseconds
             let remainingBudget = try remainingTimeout()
+            let pageNavigationBudget = Self.readinessPageNavigationTimeout(
+                for: identifier,
+                mode: mode
+            )
             // uBO Lite can legitimately spend longer than 15 seconds compiling
             // and enabling its DNR rulesets on a cold launch. A timed-out
             // callAsyncJavaScript callback cannot be abandoned or retried
             // safely, so give its fail-closed probe the full bounded deadline.
-            // Delivered WebKit errors still retry below without extending it.
+            // Other attempts use the owned page's mode-specific limit.
             let attemptBudget = identifier
                 == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier
                 ? remainingBudget
-                : min(remainingBudget, 15_000_000_000)
+                : min(remainingBudget, pageNavigationBudget)
             let attemptAddition = attemptStart.addingReportingOverflow(attemptBudget)
             let attemptDeadline = attemptAddition.overflow
                 ? UInt64.max
@@ -4650,7 +4702,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                     identifier: identifier,
                     timeoutNanoseconds: min(
                         try remainingAttemptTimeout(),
-                        Self.readinessPageNavigationTimeout(for: identifier)
+                        pageNavigationBudget
                     )
                 )
                 if !didLoadBackgroundContent {
@@ -4719,7 +4771,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
                     identifier: identifier,
                     after: error,
                     allowsSupplementalDarkReaderGesturesRecovery:
-                        allowsSupplementalDarkReaderGesturesRecovery,
+                        mode.allowsSupplementalDarkReaderGesturesRecovery,
                     callbackRequiresRetention: callbackRequiresRetention,
                     hasUnfinishedOperation: hasUnfinishedOperation,
                     isTaskCancelled: Task.isCancelled,
@@ -4878,10 +4930,9 @@ final class FloorpNativeWebExtensionHost: NSObject {
               isGesturesIdleDeinitTransition(error) else {
             return nil
         }
-        // Dark Reader's ordinary cold-readiness deadline remains 15 seconds.
-        // Only this delivered iOS 26 WebKit error receives one new bounded
+        // Only this delivered iOS 26 WebKit error receives one new 15-second
         // surface attempt; timeouts and unfinished native callbacks never do.
-        return readinessPageNavigationTimeout(for: identifier)
+        return readinessPageNavigationTimeout(for: identifier, mode: .interactive)
     }
 
     private func hasRetiredBackgroundReadinessSurface(

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
@@ -87,7 +87,7 @@ private final class FloorpClosePreparationTestGate {
 
 @MainActor
 final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
-    func testReadinessPageNavigationBudgetIsExtendedOnlyForUBOL() throws {
+    func testColdReadinessBudgetsStayScopedToLifecycleOwnedSurfaces() throws {
 #if DEBUG || TESTING
         XCTAssertEqual(
             FloorpNativeWebExtensionHost.readinessPageNavigationTimeoutForTesting(
@@ -103,6 +103,32 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         )
         XCTAssertEqual(
             FloorpNativeWebExtensionHost.readinessPageNavigationTimeoutForTesting(
+                identifier: FloorpNativeWebExtensionCatalog.darkReader.identifier,
+                isColdLifecycle: true
+            ),
+            30_000_000_000
+        )
+        XCTAssertEqual(
+            FloorpNativeWebExtensionHost.readinessPageNavigationTimeoutForTesting(
+                identifier: "unknown-extension",
+                isColdLifecycle: true
+            ),
+            15_000_000_000
+        )
+        XCTAssertEqual(
+            FloorpNativeWebExtensionHost.coldBackgroundReadinessTimeoutForTesting(
+                identifier: FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier
+            ),
+            240_000_000_000
+        )
+        XCTAssertEqual(
+            FloorpNativeWebExtensionHost.coldBackgroundReadinessTimeoutForTesting(
+                identifier: FloorpNativeWebExtensionCatalog.darkReader.identifier
+            ),
+            30_000_000_000
+        )
+        XCTAssertEqual(
+            FloorpNativeWebExtensionHost.coldBackgroundReadinessTimeoutForTesting(
                 identifier: "unknown-extension"
             ),
             15_000_000_000
@@ -2549,14 +2575,12 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
             ]
         )
         var attemptedSurfaces = [Int]()
-        var attemptedWebViews = [WKWebView]()
+        var createdSurfaceCount = 0
         var grantedSupplementalBudgets = [UInt64]()
         var successfulResponseCount = 0
-        host.backgroundReadinessSurfaceCreatedHookForTesting = { hookIdentifier, _, webView in
+        host.backgroundReadinessSurfaceCreatedHookForTesting = { hookIdentifier, _, _ in
             guard hookIdentifier == item.identifier else { return }
-            // Retain both surfaces so allocator address reuse cannot make two
-            // distinct WebViews appear to have the same ObjectIdentifier.
-            attemptedWebViews.append(webView)
+            createdSurfaceCount += 1
         }
         host.supplementalReadinessRetryGrantedHookForTesting = { hookIdentifier, _, budget in
             guard hookIdentifier == item.identifier else { return }
@@ -2585,10 +2609,7 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         try await host.installBundledExtension(identifier: item.identifier)
 
         XCTAssertEqual(attemptedSurfaces, [1, 2])
-        XCTAssertEqual(attemptedWebViews.count, 2)
-        let firstWebView = try XCTUnwrap(attemptedWebViews.first)
-        let secondWebView = try XCTUnwrap(attemptedWebViews.dropFirst().first)
-        XCTAssertFalse(firstWebView === secondWebView)
+        XCTAssertEqual(createdSurfaceCount, 2)
         XCTAssertEqual(grantedSupplementalBudgets, [15_000_000_000])
         XCTAssertEqual(successfulResponseCount, 1)
         let context = try XCTUnwrap(host.installedContext(identifier: item.identifier))

--- a/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
+++ b/firefox-ios/firefox-ios-tests/Tests/FloorpCI.xctestplan
@@ -716,6 +716,7 @@
         "SettingsCoordinatorTests/testWebExtensionsSettingsDelegate_pushedExtensionsSettings()",
         "SettingsCoordinatorTests/testWebExtensionsSettingsRoute_showsExtensionsSettingsPage()",
         "MainMenuCoordinatorTests/testHandleNavigation_webExtensionActions_callsDelegate()",
+        "FloorpNativeWebExtensionIntegrationTests/testColdReadinessBudgetsStayScopedToLifecycleOwnedSurfaces()",
         "FloorpNativeWebExtensionIntegrationTests/testBundledDarkReaderZIPIsVerifiedAndLoadsWithNativeWebKit()",
         "FloorpNativeWebExtensionIntegrationTests/testMainMenuSelectsDarkReaderFromTwoActionPickerAndPresentsInteractivePopup()",
         "FloorpNativeWebExtensionIntegrationTests/testMainMenuOpensOnlyAvailableDarkReaderActionDirectlyOnMinimumOS()",

--- a/scripts/ci/tests/test_floorp_ci_python_contracts.py
+++ b/scripts/ci/tests/test_floorp_ci_python_contracts.py
@@ -186,33 +186,51 @@ class FloorpCIPythonContractTests(unittest.TestCase):
             "    private func waitForBundledExtensionInitialization(\n", 1
         )[1].split("\n    private func", 1)[0]
         self.assertIn(
+            "let pageNavigationBudget = Self.readinessPageNavigationTimeout(\n"
+            "                for: identifier,\n"
+            "                mode: mode\n"
+            "            )",
+            production_readiness,
+        )
+        self.assertIn(
             "timeoutNanoseconds: min(\n"
             "                        try remainingAttemptTimeout(),\n"
-            "                        Self.readinessPageNavigationTimeout(for: identifier)\n"
+            "                        pageNavigationBudget\n"
             "                    )",
             production_readiness,
         )
         self.assertEqual(
             production_readiness.count(
-                "Self.readinessPageNavigationTimeout(for: identifier)"
+                "Self.readinessPageNavigationTimeout("
             ),
             1,
         )
         semantic_probe = production_readiness.split(
             "probe.callAsyncJavaScript(", 1
         )[1].split(")\n                }()", 1)[0]
-        self.assertNotIn("readinessPageNavigationTimeout", semantic_probe)
+        self.assertNotIn("pageNavigationBudget", semantic_probe)
         production_navigation_timeout = host_source.split(
-            "    private static func readinessPageNavigationTimeout(for identifier: String) "
-            "-> UInt64 {\n",
+            "    private static func readinessPageNavigationTimeout(\n"
+            "        for identifier: String,\n"
+            "        mode: BackgroundReadinessMode\n"
+            "    ) -> UInt64 {\n",
             1,
         )[1].split("\n    private func", 1)[0]
         self.assertIn(
             "identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier",
             production_navigation_timeout,
         )
-        self.assertIn("? 30_000_000_000", production_navigation_timeout)
-        self.assertIn(": 15_000_000_000", production_navigation_timeout)
+        self.assertIn(
+            "identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier",
+            production_navigation_timeout,
+        )
+        self.assertIn("case .coldLifecycle = mode", production_navigation_timeout)
+        self.assertEqual(
+            production_navigation_timeout.count("return 30_000_000_000"),
+            2,
+        )
+        self.assertIn("return 15_000_000_000", production_navigation_timeout)
+        self.assertEqual(host_source.count("mode: .coldLifecycle"), 4)
 
         preserve_timeout = navigation_waiter.split(
             "case .preserveWebViewForProcessLifetime:\n", 1


### PR DESCRIPTION
## Summary
- distinguish lifecycle-owned cold readiness from interactive readiness
- extend only Dark Reader cold install, restore, rollback restore, and re-enable outer/page budgets from 15 to 30 seconds
- preserve the 15-second interactive cap, 3-second navigation preflight, existing uBO Lite budgets, and unfinished-callback quarantine
- keep the delivered Gestures recovery narrow, single-use, and independently bounded to 15 seconds
- cover the timeout policy in FloorpCI and avoid retaining test WKWebViews beyond production lifetime

## Failure evidence
Main run https://github.com/Floorp-Projects/floorp-ios/actions/runs/34552357609 failed at the first Dark Reader install in the two-extension main-menu acceptance test. The readiness WebView used its 15-second navigation deadline while iOS 26 was still launching the WebContent process; the reported Gestures idle-to-deinit transition occurred later during rollback teardown and was secondary.

## Tests
- iOS 26.0 test build succeeded
- failing main-menu Page Action path: 10/10 process-relaunched passes; zero guarded WebKit error signatures
- Dark Reader focused/official acceptance: 8 passed, including background-resume-popup completion
- uBlock Origin Lite production-host blocking/dashboard: passed
- official uBO Lite release acceptance: passed through report completion
- native WebExtension contracts: 181 passed
- CI contracts: 324 passed
- staging contracts: 130 passed
- release contracts: 217 passed
- bundled extension provenance, license, and release metadata verification passed
- strict SwiftLint, FloorpCI selection, JSON, and diff checks passed