### PR TITLE
Bugfix FXIOS-178 [WebExtensions] Stabilize Dark Reader cold startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1550,10 +1550,22 @@ jobs:
 
           run_test \
             "$modern_destination" \
+            "ClientTests/FloorpNativeWebExtensionIntegrationTests/testDarkReaderReadinessRecoversOnceFromDeliveredGesturesDeinitTransition" \
+            "floorp-webextension-os-matrix-ios-26-0-darkreader-readiness-recovery" \
+            "0" \
+            ""
+          run_test \
+            "$modern_destination" \
             "ClientTests/FloorpNativeWebExtensionIntegrationTests/testMainMenuSelectsDarkReaderFromTwoActionPickerAndPresentsInteractivePopup" \
             "floorp-webextension-os-matrix-ios-26-0-main-menu" \
             "0" \
             ""
+          run_test \
+            "$modern_destination" \
+            "ClientTests/FloorpDarkReaderWebKitAcceptanceTests/testOfficialDarkReaderAppliesThemeAndRendersInteractivePopup" \
+            "floorp-webextension-os-matrix-ios-26-0-darkreader-acceptance" \
+            "0" \
+            "FLOORP_DARKREADER_RELEASE_GATE background-resume-popup"
           run_test \
             "$modern_destination" \
             "ClientTests/FloorpNativeWebExtensionIntegrationTests/testBundledUBOLBlocksProductionHostTabsAndRendersDashboard" \

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -92,10 +92,12 @@ deletable iOS 18.4 (22E238) runtime UUID by identifier, version, and build,
 deletes that runtime, waits for that exact UUID to disappear from validated
 inventory, and records the reclaimed space before obtaining iOS 26.0 with the
 same download mechanism. The iOS 26.2 build-support runtime remains installed.
-The subsequently created iOS 26.0 simulator verifies the Dark Reader/uBlock
-Origin Lite action picker and popup, uBlock Origin Lite on a production host,
-and the opt-in official uBlock Origin Lite acceptance. The built products and Derived Data remain in place;
-the iOS 26.0 tests use `test-without-building` rather than rebuilding. Every
+The subsequently created iOS 26.0 simulator verifies Dark Reader cold-readiness
+ordering and recovery, the Dark Reader/uBlock Origin Lite action picker and
+popup, official Dark Reader acceptance, uBlock Origin Lite on a production
+host, and the opt-in official uBlock Origin Lite acceptance. The built products
+and Derived Data remain in place; the iOS 26.0 tests use
+`test-without-building` rather than rebuilding. Every
 selected test must report an XCTest pass, and both official acceptance tests
 must emit their release completion marker. The job always uploads its cleanup
 and download logs, free-space reports, runtime inventories, and `.xcresult`

--- a/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
+++ b/firefox-ios/Floorp/NativeWebExtensions/FloorpNativeWebExtensionHost.swift
@@ -261,6 +261,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
             CheckedContinuation<BackgroundReadinessJavaScriptValue, any Error>?
         private var timeoutTask: Task<Void, Never>?
         private var operationToken: UUID?
+        private var expectedNavigation: WKNavigation?
         private(set) var requiresProcessLifetimeRetention = false
 
         func load(
@@ -281,7 +282,14 @@ final class FloorpNativeWebExtensionHost: NSObject {
                         identifier: identifier,
                         timeoutNanoseconds: timeoutNanoseconds
                     )
-                    webView.load(URLRequest(url: url))
+                    guard let navigation = webView.load(URLRequest(url: url)) else {
+                        completeNavigation(
+                            .failure(FloorpNativeWebExtensionError.hostUnavailable),
+                            token: token
+                        )
+                        return
+                    }
+                    expectedNavigation = navigation
                 }
             } onCancel: { [weak self] in
                 Task { @MainActor in
@@ -332,6 +340,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
             timeoutTask?.cancel()
             timeoutTask = nil
             operationToken = nil
+            expectedNavigation = nil
             webView?.stopLoading()
             webView?.navigationDelegate = nil
             webView = nil
@@ -342,7 +351,10 @@ final class FloorpNativeWebExtensionHost: NSObject {
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
-            guard webView === self.webView, let token = operationToken else { return }
+            guard webView === self.webView,
+                  let navigation,
+                  navigation === expectedNavigation,
+                  let token = operationToken else { return }
             completeNavigation(.success(()), token: token)
         }
 
@@ -351,7 +363,10 @@ final class FloorpNativeWebExtensionHost: NSObject {
             didFail navigation: WKNavigation?,
             withError error: any Error
         ) {
-            guard webView === self.webView, let token = operationToken else { return }
+            guard webView === self.webView,
+                  let navigation,
+                  navigation === expectedNavigation,
+                  let token = operationToken else { return }
             completeNavigation(.failure(error), token: token)
         }
 
@@ -360,7 +375,10 @@ final class FloorpNativeWebExtensionHost: NSObject {
             didFailProvisionalNavigation navigation: WKNavigation?,
             withError error: any Error
         ) {
-            guard webView === self.webView, let token = operationToken else { return }
+            guard webView === self.webView,
+                  let navigation,
+                  navigation === expectedNavigation,
+                  let token = operationToken else { return }
             completeNavigation(.failure(error), token: token)
         }
 
@@ -396,6 +414,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
         ) {
             guard operationToken == token, let continuation = navigationContinuation else { return }
             operationToken = nil
+            expectedNavigation = nil
             navigationContinuation = nil
             timeoutTask?.cancel()
             timeoutTask = nil
@@ -819,6 +838,10 @@ final class FloorpNativeWebExtensionHost: NSObject {
     var backgroundReadinessTransientFailureHookForTesting:
         ((String, Int) -> (any Error)?)?
     var backgroundReadinessSurfaceCreatedHookForTesting:
+        ((String, Int, WKWebView) -> Void)?
+    var backgroundLoadCompletedBeforeReadinessNavigationHookForTesting:
+        ((String, Int, WKWebView) -> Void)?
+    var backgroundReadinessSurfaceDeferredReleaseHookForTesting:
         ((String, Int, WKWebView) -> Void)?
     var supplementalReadinessRetryGrantedHookForTesting:
         ((String, Int, UInt64) -> Void)?
@@ -1592,7 +1615,7 @@ final class FloorpNativeWebExtensionHost: NSObject {
             return 240_000_000_000
         }
         if identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier {
-            return 30_000_000_000
+            return 60_000_000_000
         }
         return backgroundReadinessTimeoutPolicy(for: identifier)
     }
@@ -4652,14 +4675,19 @@ final class FloorpNativeWebExtensionHost: NSObject {
                 mode: mode
             )
             // uBO Lite can legitimately spend longer than 15 seconds compiling
-            // and enabling its DNR rulesets on a cold launch. A timed-out
-            // callAsyncJavaScript callback cannot be abandoned or retried
-            // safely, so give its fail-closed probe the full bounded deadline.
-            // Other attempts use the owned page's mode-specific limit.
-            let attemptBudget = identifier
-                == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier
-                ? remainingBudget
-                : min(remainingBudget, pageNavigationBudget)
+            // and enabling its DNR rulesets on a cold launch. Dark Reader's
+            // serialized cold background wake also precedes its bounded page
+            // navigation. Give those attempts the full outer deadline while
+            // keeping the navigation itself capped below.
+            let attemptBudget: UInt64
+            if identifier == FloorpNativeWebExtensionCatalog.uBlockOriginLite.identifier {
+                attemptBudget = remainingBudget
+            } else if identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier,
+                      case .coldLifecycle = mode {
+                attemptBudget = remainingBudget
+            } else {
+                attemptBudget = min(remainingBudget, pageNavigationBudget)
+            }
             let attemptAddition = attemptStart.addingReportingOverflow(attemptBudget)
             let attemptDeadline = attemptAddition.overflow
                 ? UInt64.max
@@ -4696,6 +4724,26 @@ final class FloorpNativeWebExtensionHost: NSObject {
             activeBackgroundReadinessOperations[readinessOperationID] = context
             let result: Any?
             do {
+                if identifier == FloorpNativeWebExtensionCatalog.darkReader.identifier,
+                   case .coldLifecycle = mode,
+                   !didLoadBackgroundContent {
+                    // Construct the extension page before waking the background
+                    // to preserve iOS 26's Gestures ordering, but let that wake
+                    // settle before starting a second WebKit navigation.
+                    try await loadBackgroundContent(
+                        in: context,
+                        identifier: identifier,
+                        timeoutNanoseconds: try remainingTimeout()
+                    )
+                    didLoadBackgroundContent = true
+#if DEBUG || TESTING
+                    backgroundLoadCompletedBeforeReadinessNavigationHookForTesting?(
+                        identifier,
+                        attempt,
+                        readinessSurface.webView
+                    )
+#endif
+                }
                 try await probe.load(
                     readinessURL,
                     in: readinessSurface.webView,
@@ -4757,9 +4805,19 @@ final class FloorpNativeWebExtensionHost: NSObject {
                     retiredBackgroundReadinessSurfaces.append(readinessSurface)
                 } else {
                     // A delivered WebKit error has completed its callback. It
-                    // may be retryable, but retaining that completed attempt
-                    // would exhaust WebContent resources across later retries.
+                    // may be retryable, so use only the bounded teardown grace
+                    // rather than retaining every attempt until process exit.
                     probe.invalidate()
+                    FloorpNativeWebExtensionDeferredWebViewRelease.retain(
+                        readinessSurface.webView
+                    )
+#if DEBUG || TESTING
+                    backgroundReadinessSurfaceDeferredReleaseHookForTesting?(
+                        identifier,
+                        attempt,
+                        readinessSurface.webView
+                    )
+#endif
                 }
                 activeBackgroundReadinessOperations.removeValue(
                     forKey: readinessOperationID
@@ -4813,6 +4871,16 @@ final class FloorpNativeWebExtensionHost: NSObject {
             }
 
             probe.invalidate()
+            FloorpNativeWebExtensionDeferredWebViewRelease.retain(
+                readinessSurface.webView
+            )
+#if DEBUG || TESTING
+            backgroundReadinessSurfaceDeferredReleaseHookForTesting?(
+                identifier,
+                attempt,
+                readinessSurface.webView
+            )
+#endif
             activeBackgroundReadinessOperations.removeValue(forKey: readinessOperationID)
             await Task.yield()
             await Task.yield()

--- a/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
+++ b/firefox-ios/firefox-ios-tests/Tests/ClientTests/Coordinators/FloorpNativeWebExtensionIntegrationTests.swift
@@ -125,7 +125,7 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
             FloorpNativeWebExtensionHost.coldBackgroundReadinessTimeoutForTesting(
                 identifier: FloorpNativeWebExtensionCatalog.darkReader.identifier
             ),
-            30_000_000_000
+            60_000_000_000
         )
         XCTAssertEqual(
             FloorpNativeWebExtensionHost.coldBackgroundReadinessTimeoutForTesting(
@@ -2568,6 +2568,7 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
 #endif
     }
 
+    // swiftlint:disable:next function_body_length
     func testDarkReaderReadinessRecoversOnceFromDeliveredGesturesDeinitTransition() async throws {
 #if DEBUG || TESTING
         let profileFixture = try makeIsolatedHostProfile(prefix: "darkreader_gestures_recovery")
@@ -2589,12 +2590,38 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
             ]
         )
         var attemptedSurfaces = [Int]()
-        var createdSurfaceCount = 0
+        var createdSurfaces = [Int: WKWebView]()
+        var lifecycleEvents = [String]()
+        var backgroundCompletionAttempts = [Int]()
+        var deferredReleaseAttempts = [Int]()
         var grantedSupplementalBudgets = [UInt64]()
         var successfulResponseCount = 0
-        host.backgroundReadinessSurfaceCreatedHookForTesting = { hookIdentifier, _, _ in
+        host.backgroundReadinessSurfaceCreatedHookForTesting = { hookIdentifier, attempt, webView in
             guard hookIdentifier == item.identifier else { return }
-            createdSurfaceCount += 1
+            XCTAssertNil(createdSurfaces[attempt])
+            XCTAssertNil(webView.url)
+            createdSurfaces[attempt] = webView
+            lifecycleEvents.append("surface-\(attempt)")
+        }
+        host.backgroundLoadCompletedBeforeReadinessNavigationHookForTesting = { hookIdentifier, attempt, webView in
+            guard hookIdentifier == item.identifier else { return }
+            XCTAssertTrue(webView === createdSurfaces[attempt])
+            XCTAssertNil(webView.url)
+            backgroundCompletionAttempts.append(attempt)
+            lifecycleEvents.append("background-\(attempt)")
+        }
+        host.backgroundReadinessSurfaceDeferredReleaseHookForTesting = { hookIdentifier, attempt, webView in
+            guard hookIdentifier == item.identifier else { return }
+            XCTAssertTrue(webView === createdSurfaces[attempt])
+            XCTAssertTrue(
+                FloorpNativeWebExtensionDeferredWebViewRelease.isRetainedForTesting(webView)
+            )
+            XCTAssertFalse(
+                FloorpNativeWebExtensionProcessLifetimeWebViewRegistry
+                    .isPermanentlyRetained(webView)
+            )
+            deferredReleaseAttempts.append(attempt)
+            lifecycleEvents.append("release-\(attempt)")
         }
         host.supplementalReadinessRetryGrantedHookForTesting = { hookIdentifier, _, budget in
             guard hookIdentifier == item.identifier else { return }
@@ -2602,7 +2629,9 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         }
         host.backgroundReadinessTransientFailureHookForTesting = { hookIdentifier, attempt in
             guard hookIdentifier == item.identifier else { return nil }
+            XCTAssertEqual(createdSurfaces[attempt]?.url?.path, "/floorp-readiness.html")
             attemptedSurfaces.append(attempt)
+            lifecycleEvents.append("readiness-\(attempt)")
             return attempt == 1 ? gesturesDeinitTransition : nil
         }
         host.backgroundReadinessResponseHookForTesting = { hookIdentifier, _ in
@@ -2615,6 +2644,8 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         }
         defer {
             host.backgroundReadinessSurfaceCreatedHookForTesting = nil
+            host.backgroundLoadCompletedBeforeReadinessNavigationHookForTesting = nil
+            host.backgroundReadinessSurfaceDeferredReleaseHookForTesting = nil
             host.supplementalReadinessRetryGrantedHookForTesting = nil
             host.backgroundReadinessTransientFailureHookForTesting = nil
             host.backgroundReadinessResponseHookForTesting = nil
@@ -2623,15 +2654,32 @@ final class FloorpNativeWebExtensionIntegrationTests: XCTestCase {
         try await host.installBundledExtension(identifier: item.identifier)
 
         XCTAssertEqual(attemptedSurfaces, [1, 2])
-        XCTAssertEqual(createdSurfaceCount, 2)
+        XCTAssertEqual(createdSurfaces.keys.sorted(), [1, 2])
+        XCTAssertEqual(backgroundCompletionAttempts, [1])
+        XCTAssertEqual(deferredReleaseAttempts, [1, 2])
+        XCTAssertEqual(
+            lifecycleEvents,
+            [
+                "surface-1",
+                "background-1",
+                "readiness-1",
+                "release-1",
+                "surface-2",
+                "readiness-2",
+                "release-2"
+            ]
+        )
         XCTAssertEqual(grantedSupplementalBudgets, [15_000_000_000])
         XCTAssertEqual(successfulResponseCount, 1)
         let context = try XCTUnwrap(host.installedContext(identifier: item.identifier))
+        XCTAssertFalse(host.hasUnfinishedWebKitOperationForTesting(context))
         XCTAssertTrue(
             context.errors.isEmpty,
             context.errors.map(\.localizedDescription).joined(separator: "\n")
         )
         host.backgroundReadinessSurfaceCreatedHookForTesting = nil
+        host.backgroundLoadCompletedBeforeReadinessNavigationHookForTesting = nil
+        host.backgroundReadinessSurfaceDeferredReleaseHookForTesting = nil
         host.supplementalReadinessRetryGrantedHookForTesting = nil
         host.backgroundReadinessTransientFailureHookForTesting = nil
         host.backgroundReadinessResponseHookForTesting = nil

--- a/scripts/ci/tests/test_floorp_webextension_os_matrix_contract.py
+++ b/scripts/ci/tests/test_floorp_webextension_os_matrix_contract.py
@@ -583,7 +583,15 @@ class FloorpWebExtensionOSMatrixContractTests(unittest.TestCase):
         modern_tests = (
             (
                 "ClientTests/FloorpNativeWebExtensionIntegrationTests/"
+                "testDarkReaderReadinessRecoversOnceFromDeliveredGesturesDeinitTransition"
+            ),
+            (
+                "ClientTests/FloorpNativeWebExtensionIntegrationTests/"
                 "testMainMenuSelectsDarkReaderFromTwoActionPickerAndPresentsInteractivePopup"
+            ),
+            (
+                "ClientTests/FloorpDarkReaderWebKitAcceptanceTests/"
+                "testOfficialDarkReaderAppliesThemeAndRendersInteractivePopup"
             ),
             (
                 "ClientTests/FloorpNativeWebExtensionIntegrationTests/"
@@ -596,15 +604,17 @@ class FloorpWebExtensionOSMatrixContractTests(unittest.TestCase):
         )
 
         self.assertEqual(minimum.count("run_test \\\n"), 4)
-        self.assertEqual(modern.count("run_test \\\n"), 3)
+        self.assertEqual(modern.count("run_test \\\n"), 5)
         selected_pattern = r'"(ClientTests/[^"\n]+)"'
         self.assertEqual(set(re.findall(selected_pattern, minimum)), set(minimum_tests))
         self.assertEqual(set(re.findall(selected_pattern, modern)), set(modern_tests))
         self.assertEqual(minimum.count("UBOL"), 1)
         self.assertNotIn("FLOORP_UBOL_RELEASE_GATE", minimum)
-        self.assertIn(
-            "FLOORP_DARKREADER_RELEASE_GATE background-resume-popup", minimum
+        darkreader_release_marker = (
+            "FLOORP_DARKREADER_RELEASE_GATE background-resume-popup"
         )
+        self.assertEqual(minimum.count(darkreader_release_marker), 1)
+        self.assertEqual(modern.count(darkreader_release_marker), 1)
         self.assertIn("FLOORP_UBOL_RELEASE_GATE report", modern)
         self.assertIn(
             "TEST_RUNNER_FLOORP_RUN_UBOL_DNR_DIAGNOSTICS=1", acceptance
@@ -930,6 +940,8 @@ class FloorpWebExtensionOSMatrixContractTests(unittest.TestCase):
             "records the reclaimed space before",
             "obtaining iOS 26.0 with the same download mechanism",
             "iOS 26.2 build-support runtime remains installed",
+            "Dark Reader cold-readiness ordering and recovery",
+            "official Dark Reader acceptance",
             "opt-in official uBlock",
             "Origin Lite acceptance.",
             "use `test-without-building` rather than rebuilding",


### PR DESCRIPTION
## :scroll: Tickets

Jira: N/A (Floorp project change)

[GitHub issue #178](https://github.com/Floorp-Projects/floorp-ios/issues/178)

## :bulb: Description

Dark Reader's cold installation could start its hidden readiness-page navigation while WebKit was still waking the extension background page in the same WebContent process. Under iOS 26 CI load, that race could outlive WebKit's navigation activity and make the Page Action popup fail with `GesturePhaseQueue.InvalidTransition`.

This change:

- creates the lifecycle-owned readiness surface before the background wake, but defers its navigation until the background load callback has completed;
- gives Dark Reader's complete cold-readiness sequence a 60-second outer budget while keeping the page navigation capped at 30 seconds and interactive probes at 15 seconds;
- accepts navigation delegate callbacks only for the exact `WKNavigation` started by the readiness probe;
- keeps timed-out or cancelled callbacks retained for process lifetime, while completed callbacks receive only the existing bounded two-second teardown grace;
- adds lifecycle ordering and release assertions to the existing iOS 26 regression test;
- runs the recovery test and official Dark Reader acceptance test in the exact iOS 26.0 WebExtension matrix.

The uBlock Origin Lite order and 240-second cold budget are unchanged. Its production-host and official release acceptance tests remain required after the new Dark Reader gates.

Related prior work: PR #174 and PR #175.

## Verification

- iOS 26.0 targeted readiness tests: 2/2 passed
- iOS 26.0 Dark Reader focused regression and Page Action tests: 10/10 passed
- official Dark Reader WebKit acceptance: 3 independent runs passed; each reached `FLOORP_DARKREADER_RELEASE_GATE background-resume-popup`
- iOS 26.0 uBlock Origin Lite readiness and production-host tests: 4/4 passed
- official uBlock Origin Lite WebKit acceptance: passed and reached `FLOORP_UBOL_RELEASE_GATE report`
- unsafe WebKit/Page Action diagnostic signatures: 0 across the focused logs
- Python contracts: CI 324/324, staging 131/131, release 217/217, Native WebExtensions 182/182
- bundled extension provenance/license verification, Floorp branding checks, actionlint, SwiftLint, and `git diff --check`: passed

## :movie_camera: Demos

N/A — this changes WebKit lifecycle ordering rather than visual layout. The production-host Page Action and official popup acceptance tests exercise the user-visible path.

## :pencil: Checklist

- [x] I filled in the ticket numbers and a description of my work
- [x] I updated the PR name to follow our [PR naming guidelines](https://github.com/mozilla-mobile/firefox-ios/wiki/Pull-Request-Naming-Guide)
- [x] I ensured unit tests pass and wrote tests for new code
- [x] Accessibility is not affected; this change introduces no new UI or interaction surface
- [x] Telemetry is not affected; this change adds or modifies no telemetry
- [x] Localization is not affected; this change adds or modifies no user-facing strings
- [x] I updated the WebExtension CI documentation and documented the lifecycle constraints in code
