### PR TITLE
Fail fast on missing default browser capability

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -210,9 +210,9 @@ Adding Push later requires restoring that target where needed, production entitl
 
 ### Managed browser entitlements
 
-Apple has assigned `com.apple.developer.web-browser` to `app.floorp.Floorp`. `FloorpReleaseApplication.entitlements` declares it as `true`, allowing eligible signed builds to appear in iOS’s Default Browser App settings. `FloorpReleaseInfo.plist` already registers the required `http` and `https` URL schemes.
+Apple has assigned `com.apple.developer.web-browser` to `app.floorp.Floorp`. `FloorpReleaseApplication.entitlements` declares it as `true`, allowing eligible signed builds to appear in iOS’s Default Browser App settings. `FloorpReleaseInfo.plist` already registers the required `http` and `https` URL schemes. The approved capability must also be enabled on the exact registered App ID: immediately before dispatch, the release bridge resolves the exact iOS bundle ID and refuses `POST /v1/ciBuildRuns` unless its live capability list contains exactly one `DEFAULT_WEB_BROWSER` entry.
 
-The capability is managed. Before producing a distribution archive, let Xcode refresh the automatically managed provisioning profile for Team `DV2U35YBHT`, then verify the signed archive contains `com.apple.developer.web-browser = true`.
+The capability is managed. Xcode-managed development and distribution profiles do not appear in the Developer account, so a visible pre-existing profile is not an authoritative preflight requirement. Once the App ID capability is enabled, the next Xcode Cloud run sees the latest configuration and automatically includes the additional entitlement in a new profile. Verify the resulting signed archive contains `com.apple.developer.web-browser = true`.
 
 The Floorp release entitlement continues to omit `com.apple.developer.browser.app-installation`, which is for installing alternative-distribution apps from a website. Add it only if Floorp deliberately adopts that distribution path and Apple approves the request.
 
@@ -304,7 +304,7 @@ The shared `Floorp` scheme now archives with `FloorpRelease` in Xcode Cloud. The
 1. In Signing & Capabilities, explicitly confirm the main `app.floorp.Floorp` bundle ID once before initial setup because the project derives it from an `.xcconfig` file. Register extension IDs only when those targets return to the release.
 2. Connect `Floorp-Projects/Floorp-iOS` to Xcode Cloud from Xcode's Report navigator. A GitHub organization owner must authorize the first connection.
 3. Keep `Floorp TestFlight Manual` manually started in Xcode Cloud, but start public-release candidates only through the GitHub Actions bridge. A direct App Store Connect start does not produce the source-bound release receipt and is not eligible for submission. Release builds use a protected immutable `floorp-catalog-<40-character merged SHA>` lightweight tag whose ref points directly at the exact reviewed `main` commit; annotated tags are rejected by the source-identity gate. Never delete or retarget a candidate tag after creating it, including when its build fails. Xcode Cloud supplies the tag/ref/commit values embedded by the pre-build script; the bridge and retained receipt remain responsible for resolving the live App Store Connect tag reference and proving that it points to that commit. A local `refs/tags/*` ref is not assumed in Xcode Cloud's detached checkout.
-4. Use `.github/workflows/floorp-xcode-cloud-testflight.yml`. It verifies the immutable tag and exact-source CI acceptance, validates the workflow repository and product against App Store Connect app `6796708699` / bundle `app.floorp.Floorp`, snapshots the current maximum build number, and starts the tagged run through `POST /v1/ciBuildRuns`.
+4. Use `.github/workflows/floorp-xcode-cloud-testflight.yml`. It verifies the immutable tag and exact-source CI acceptance, validates the workflow repository and product against App Store Connect app `6796708699` / bundle `app.floorp.Floorp`, snapshots the current maximum build number, then re-resolves the exact registered iOS bundle ID and its sparse capability list. A missing or ambiguous `DEFAULT_WEB_BROWSER` capability blocks the bridge before it starts the tagged run through `POST /v1/ciBuildRuns`.
 5. The bridge always waits for `COMPLETE` / `SUCCEEDED`, rechecks the exact source commit and workflow, and requires exactly one nonpaginated run-to-build linkage. The linked build must be a new, larger build number for Floorp `0.3.0` on iOS, `VALID`, `APP_STORE_ELIGIBLE`, unexpired, non-exempt-encryption false, and minimum OS `18.4`.
 6. The bridge downloads the unique `ARCHIVE` and `ARCHIVE_EXPORT` resources from the same successful archive action through the authenticated App Store Connect API. It verifies the recorded resource IDs, types, sizes, and SHA-256 values, safely materializes the `.xcarchive` and `.ipa`, and emits `floorp-xcode-cloud-artifact-manifest.json`. Retain that manifest together with `floorp-xcode-cloud-build-receipt.json`. The workflow also materializes a notes-only App Review payload from the receipt using the full 40-character commit URL rather than the tag name; it rejects placeholders, a missing immutable public source URL or GPL disclosure, and content over 4,000 bytes.
 7. Before any external-beta write, `submit-floorp-external-beta.sh` snapshots the receipt once, then re-reads the run, run-to-build linkage, build, and group. It uses that same private receipt snapshot for both reviewed-note generation and source/build validation, and requires the supplied notes-only payload to match it exactly. The selected group must be external and belong to the same app. Contact fields must be complete; demo credentials are required only when App Store Connect reports `demoAccountRequired=true`. The client never creates groups or writes contact/demo credentials.
@@ -430,8 +430,10 @@ scripts/release/validate-floorp-release-evidence.py \
 ```
 
 `scripts/release/app-store-connect-api.py` is the only App Store Connect
-surface. Its read allowlist covers the required workflow, repository, and Git
-reference GETs and its write allowlist is
+surface. Its read allowlist covers the required workflow, repository, Git
+reference, and exact filtered bundle-ID/capability GETs. The two signing
+preflight routes require fixed sparse fields and reject broad or additional
+queries; no provisioning-profile content is requested or logged. Its write allowlist is
 exactly `POST /v1/ciBuildRuns`, `POST /v1/betaBuildLocalizations`,
 `PATCH /v1/betaBuildLocalizations/{id}`, `PATCH /v1/betaAppReviewDetails/{id}`,
 `POST /v1/betaAppReviewSubmissions`, and
@@ -458,4 +460,6 @@ Actions, uploads the signed archive.
 - [Including TestFlight notes](https://developer.apple.com/documentation/xcode/including-notes-for-testers-with-a-beta-release-of-your-app)
 - [Preparing an app to be the default browser](https://developer.apple.com/documentation/xcode/preparing-your-app-to-be-the-default-browser)
 - [Requesting managed capabilities](https://developer.apple.com/help/account/capabilities/capability-requests/)
+- [Provisioning with managed capabilities](https://developer.apple.com/help/account/reference/provisioning-with-managed-capabilities)
+- [Edit, download, or delete provisioning profiles](https://developer.apple.com/help/account/provisioning-profiles/edit-download-or-delete-profiles)
 - [`com.apple.developer.browser.app-installation`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.browser.app-installation)

--- a/scripts/release/app-store-connect-api.py
+++ b/scripts/release/app-store-connect-api.py
@@ -11,6 +11,8 @@ made and issues zero requests.
 Read allowlist (GET):
   /v1/apps, /v1/apps/{id}, /v1/apps/{id}/builds, /v1/builds,
   /v1/builds/{id},
+  /v1/bundleIds (exact identifier/platform/sparse-field query only),
+  /v1/bundleIds/{id}/bundleIdCapabilities (exact sparse-field query only),
   /v1/preReleaseVersions/{id},
   /v1/ciProducts, /v1/ciProducts/{id}, /v1/ciWorkflows,
   /v1/ciBuildRuns/{id}, /v1/ciBuildRuns/{id}/actions,
@@ -90,6 +92,9 @@ READ_ROUTES = [
     r"^/v1/betaAppReviewSubmissions$",
 ]
 
+BUNDLE_ID_FIELDS = "identifier,platform"
+BUNDLE_ID_CAPABILITY_FIELDS = "capabilityType"
+
 WRITE_ROUTES = {
     ("POST", r"^/v1/ciBuildRuns$"),
     ("POST", r"^/v1/betaBuildLocalizations$"),
@@ -109,11 +114,43 @@ class CredentialError(Exception):
 
 
 def route_allowed(method: str, path: str) -> bool:
-    path = path.split("?", 1)[0]
     if method == "GET":
-        return any(re.fullmatch(pattern, path) for pattern in READ_ROUTES)
+        parsed = urllib.parse.urlsplit(path)
+        if parsed.scheme or parsed.netloc or parsed.fragment:
+            return False
+        resource = parsed.path
+        query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+        if resource == "/v1/bundleIds":
+            identifier = query.get("filter[identifier]")
+            return (
+                set(query) == {
+                    "fields[bundleIds]",
+                    "filter[identifier]",
+                    "filter[platform]",
+                    "limit",
+                }
+                and query.get("fields[bundleIds]") == [BUNDLE_ID_FIELDS]
+                and query.get("filter[platform]") == ["IOS"]
+                and query.get("limit") == ["200"]
+                and isinstance(identifier, list)
+                and len(identifier) == 1
+                and re.fullmatch(r"[A-Za-z0-9.-]+", identifier[0]) is not None
+            )
+        capability_route = re.fullmatch(
+            r"/v1/bundleIds/([A-Za-z0-9._-]+)/bundleIdCapabilities", resource
+        )
+        if capability_route:
+            if capability_route.group(1) in {".", ".."}:
+                return False
+            return (
+                set(query) == {"fields[bundleIdCapabilities]"}
+                and query.get("fields[bundleIdCapabilities]")
+                == [BUNDLE_ID_CAPABILITY_FIELDS]
+            )
+        return any(re.fullmatch(pattern, resource) for pattern in READ_ROUTES)
+    resource = path.split("?", 1)[0]
     if method in ("POST", "PATCH"):
-        return any(method == allowed_method and re.fullmatch(pattern, path)
+        return any(method == allowed_method and re.fullmatch(pattern, resource)
                    for allowed_method, pattern in WRITE_ROUTES)
     return False
 

--- a/scripts/release/tests/test_app_store_connect_api.py
+++ b/scripts/release/tests/test_app_store_connect_api.py
@@ -111,8 +111,67 @@ class AllowlistTests(unittest.TestCase):
             "/v1/betaBuildLocalizations",
             "/v1/apps/abc/builds",
             "/v1/apps/abc",
+            (
+                "/v1/bundleIds?filter[identifier]=app.floorp.Floorp"
+                "&filter[platform]=IOS&fields[bundleIds]=identifier,platform"
+                "&limit=200"
+            ),
+            (
+                "/v1/bundleIds/3MC2Q46999/bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType"
+            ),
         ]:
             self.assertTrue(asc.route_allowed("GET", path), path)
+
+    def test_signing_preflight_reads_require_exact_sparse_queries(self):
+        denied = [
+            "/v1/bundleIds",
+            "/v1/bundleIds?filter[identifier]=app.floorp.Floorp",
+            (
+                "/v1/bundleIds?filter[identifier]=app.floorp.Floorp"
+                "&filter[platform]=UNIVERSAL"
+                "&fields[bundleIds]=identifier,platform&limit=200"
+            ),
+            (
+                "/v1/bundleIds?filter[identifier]=app.floorp.Floorp"
+                "&filter[platform]=IOS&fields[bundleIds]=identifier,name,platform"
+                "&limit=200"
+            ),
+            (
+                "/v1/bundleIds?filter[identifier]=app.floorp.Floorp"
+                "&filter[platform]=IOS&fields[bundleIds]=identifier,platform"
+                "&include=profiles&fields[profiles]=profileContent&limit=200"
+            ),
+            (
+                "/v1/bundleIds?filter[identifier]=app.floorp.Floorp"
+                "&filter[identifier]=other.bundle&filter[platform]=IOS"
+                "&fields[bundleIds]=identifier,platform&limit=200"
+            ),
+            (
+                "/v1/bundleIds/3MC2Q46999/bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType,settings"
+            ),
+            (
+                "/v1/bundleIds/3MC2Q46999/bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType&limit=200"
+            ),
+            "/v1/bundleIds/3MC2Q46999/bundleIdCapabilities",
+            (
+                "/v1/bundleIds/./bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType"
+            ),
+            (
+                "/v1/bundleIds/../bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType"
+            ),
+            (
+                "/v1/bundleIds/invalid%2Fid/bundleIdCapabilities"
+                "?fields[bundleIdCapabilities]=capabilityType"
+            ),
+        ]
+        for path in denied:
+            with self.subTest(path=path):
+                self.assertFalse(asc.route_allowed("GET", path))
 
     def test_write_allowlist_is_exact(self):
         allowed = [

--- a/scripts/release/tests/test_trigger_xcode_cloud.py
+++ b/scripts/release/tests/test_trigger_xcode_cloud.py
@@ -24,6 +24,14 @@ WORKFLOW_ID = "workflow-1"
 PRODUCT_ID = "product-1"
 REPOSITORY_ID = "repository-1"
 REFERENCE_ID = "reference-main"
+BUNDLE_RESOURCE_ID = "bundle-id-1"
+DEFAULT_BROWSER_CAPABILITY_ID = "capability-default-browser"
+LIVE_CAPABILITIES_WITHOUT_DEFAULT_BROWSER = [
+    "IN_APP_PURCHASE",
+    "WEB_BROWSER_PUBLIC_KEY_CREDENTIALS_REQUESTS",
+    "MULTIPATH",
+    "APP_GROUPS",
+]
 WORKFLOW_NAME = "Floorp TestFlight Manual"
 REPOSITORY_URL = "https://github.com/Floorp-Projects/floorp-ios.git"
 APP_ID = "6796708699"
@@ -101,11 +109,57 @@ def references_response(rows=None):
     }
 
 
+def bundle_ids_response(rows=None):
+    return {
+        "data": rows
+        if rows is not None
+        else [
+            {
+                "type": "bundleIds",
+                "id": BUNDLE_RESOURCE_ID,
+                "attributes": {"identifier": BUNDLE_ID, "platform": "UNIVERSAL"},
+            }
+        ],
+        "links": {"next": None},
+    }
+
+
+def capabilities_response(capability_types=None):
+    if capability_types is None:
+        capability_types = LIVE_CAPABILITIES_WITHOUT_DEFAULT_BROWSER + [
+            "DEFAULT_WEB_BROWSER"
+        ]
+    return {
+        "data": [
+            {
+                "type": "bundleIdCapabilities",
+                "id": (
+                    DEFAULT_BROWSER_CAPABILITY_ID
+                    if capability_type == "DEFAULT_WEB_BROWSER"
+                    else f"capability-{index}"
+                ),
+                "attributes": {"capabilityType": capability_type},
+            }
+            for index, capability_type in enumerate(capability_types)
+        ],
+        "links": {"next": None},
+    }
+
+
 class FakeAPI:
-    def __init__(self, workflow=None, references=None, product=None):
+    def __init__(
+        self,
+        workflow=None,
+        references=None,
+        product=None,
+        bundle_ids=None,
+        capabilities=None,
+    ):
         self.workflow = workflow or workflow_response()
         self.references = references or references_response()
         self.product = product or product_response()
+        self.bundle_ids = bundle_ids or bundle_ids_response()
+        self.capabilities = capabilities or capabilities_response()
         self.calls = []
 
     def __call__(self, method, path, body=None):
@@ -118,6 +172,12 @@ class FakeAPI:
             return self.references
         if path == f"/v1/scmRepositories/{REPOSITORY_ID}":
             return {"data": workflow_response()["included"][0]}
+        if path.startswith("/v1/bundleIds?"):
+            return self.bundle_ids
+        if path.startswith(
+            f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities?"
+        ):
+            return self.capabilities
         raise AssertionError(f"unexpected API request: {method} {path}")
 
 
@@ -193,6 +253,105 @@ class TriggerContractTests(unittest.TestCase):
                 APP_ID,
                 BUNDLE_ID,
             )
+
+    def test_signing_preflight_requires_exact_ios_bundle_and_default_browser_capability(self):
+        api = FakeAPI()
+
+        result = trigger.verify_distribution_signing_capability(api, BUNDLE_ID)
+
+        self.assertEqual(
+            result,
+            {
+                "bundle_id_resource_id": BUNDLE_RESOURCE_ID,
+                "bundle_id_platform": "UNIVERSAL",
+                "capability_id": DEFAULT_BROWSER_CAPABILITY_ID,
+                "capability_type": "DEFAULT_WEB_BROWSER",
+            },
+        )
+        self.assertEqual(
+            [(method, path) for method, path, _ in api.calls],
+            [
+                (
+                    "GET",
+                    "/v1/bundleIds"
+                    "?filter[identifier]=app.floorp.Floorp"
+                    "&filter[platform]=IOS"
+                    "&fields[bundleIds]=identifier,platform"
+                    "&limit=200",
+                ),
+                (
+                    "GET",
+                    f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities"
+                    "?fields[bundleIdCapabilities]=capabilityType",
+                ),
+            ],
+        )
+
+    def test_signing_preflight_rejects_missing_or_duplicate_bundle_id(self):
+        duplicate = bundle_ids_response()["data"] + [
+            {
+                "type": "bundleIds",
+                "id": "bundle-id-2",
+                "attributes": {"identifier": BUNDLE_ID, "platform": "UNIVERSAL"},
+            }
+        ]
+        for response, count in (
+            (bundle_ids_response([]), 0),
+            (bundle_ids_response(duplicate), 2),
+        ):
+            with self.subTest(count=count):
+                with self.assertRaisesRegex(
+                    ValueError, f"exactly one registered iOS bundle ID.*found {count}"
+                ):
+                    trigger.verify_distribution_signing_capability(
+                        FakeAPI(bundle_ids=response), BUNDLE_ID
+                    )
+
+    def test_signing_preflight_rejects_wrong_identity_and_platform(self):
+        for attributes, message in (
+            ({"identifier": "other.bundle", "platform": "UNIVERSAL"}, "identifier"),
+            ({"identifier": BUNDLE_ID, "platform": "MAC_OS"}, "iOS-compatible"),
+            ({"identifier": BUNDLE_ID, "platform": "UNKNOWN"}, "iOS-compatible"),
+        ):
+            response = bundle_ids_response()
+            response["data"][0]["attributes"] = attributes
+            with self.subTest(attributes=attributes):
+                with self.assertRaisesRegex(ValueError, message):
+                    trigger.verify_distribution_signing_capability(
+                        FakeAPI(bundle_ids=response), BUNDLE_ID
+                    )
+
+    def test_signing_preflight_rejects_missing_or_duplicate_required_capability(self):
+        duplicate = capabilities_response(
+            ["DEFAULT_WEB_BROWSER", "DEFAULT_WEB_BROWSER"]
+        )
+        duplicate["data"][1]["id"] = "capability-default-browser-2"
+        for response, count in (
+            (capabilities_response(LIVE_CAPABILITIES_WITHOUT_DEFAULT_BROWSER), 0),
+            (duplicate, 2),
+        ):
+            with self.subTest(count=count):
+                with self.assertRaisesRegex(
+                    ValueError, f"DEFAULT_WEB_BROWSER capability; found {count}"
+                ):
+                    trigger.verify_distribution_signing_capability(
+                        FakeAPI(capabilities=response), BUNDLE_ID
+                    )
+
+    def test_signing_preflight_rejects_paginated_state(self):
+        bundle_response = bundle_ids_response()
+        bundle_response["links"]["next"] = "https://api.appstoreconnect.apple.com/v1/next"
+        capability_response = capabilities_response()
+        capability_response["links"]["next"] = (
+            "https://api.appstoreconnect.apple.com/v1/next"
+        )
+        for api in (
+            FakeAPI(bundle_ids=bundle_response),
+            FakeAPI(capabilities=capability_response),
+        ):
+            with self.subTest(calls=api.calls):
+                with self.assertRaisesRegex(ValueError, "paginated"):
+                    trigger.verify_distribution_signing_capability(api, BUNDLE_ID)
 
     def test_resolve_branch_rejects_deleted_or_duplicate_references(self):
         api = FakeAPI(
@@ -367,6 +526,12 @@ class TriggerContractTests(unittest.TestCase):
                     return product_response()
                 if path == "/v1/builds?filter[app]=6796708699&sort=-version&limit=200":
                     return {"data": [], "links": {"next": None}}
+                if path.startswith("/v1/bundleIds?"):
+                    return bundle_ids_response()
+                if path.startswith(
+                    f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities?"
+                ):
+                    return capabilities_response()
                 if path.startswith(
                     f"/v1/scmRepositories/{REPOSITORY_ID}/gitReferences"
                 ):
@@ -421,7 +586,15 @@ class TriggerContractTests(unittest.TestCase):
             trigger.load_client = original_load_client
 
         self.assertEqual(report["run"]["id"], "run-1")
+        self.assertEqual(
+            report["signing_preflight"]["capability_type"],
+            "DEFAULT_WEB_BROWSER",
+        )
         self.assertTrue(all(method == "GET" for method, _, _ in fake_client.reads))
+        self.assertIn(
+            f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities",
+            fake_client.reads[-1][1],
+        )
         self.assertEqual(len(fake_client.writes), 1)
         method, path, token, encoded, intended, prior, guard = fake_client.writes[0]
         self.assertEqual((method, path, token), ("POST", "/v1/ciBuildRuns", "jwt"))
@@ -433,6 +606,77 @@ class TriggerContractTests(unittest.TestCase):
         self.assertEqual(
             json.loads(encoded), trigger.build_request(WORKFLOW_ID, REFERENCE_ID)
         )
+
+    def test_run_missing_default_browser_capability_never_dispatches(self):
+        class FakeClient:
+            def __init__(self):
+                self.writes = []
+
+            @staticmethod
+            def load_credentials(arguments):
+                return "issuer", "key", Path("/unused/AuthKey.p8")
+
+            @staticmethod
+            def make_jwt(*arguments):
+                return "jwt"
+
+            @staticmethod
+            def canonical_state_sha256(value):
+                return "f" * 64
+
+            @staticmethod
+            def api_call(method, path, token):
+                if path.startswith(f"/v1/ciWorkflows/{WORKFLOW_ID}"):
+                    return workflow_response()
+                if path.startswith(f"/v1/ciProducts/{PRODUCT_ID}"):
+                    return product_response()
+                if path.startswith(
+                    f"/v1/scmRepositories/{REPOSITORY_ID}/gitReferences"
+                ):
+                    return references_response()
+                if path == f"/v1/builds?filter[app]={APP_ID}&sort=-version&limit=200":
+                    return {"data": [], "links": {"next": None}}
+                if path.startswith("/v1/bundleIds?"):
+                    return bundle_ids_response()
+                if path.startswith(
+                    f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities?"
+                ):
+                    return capabilities_response(
+                        LIVE_CAPABILITIES_WITHOUT_DEFAULT_BROWSER
+                    )
+                raise AssertionError(f"unexpected read: {method} {path}")
+
+            def guarded_write(self, *arguments):
+                self.writes.append(arguments)
+                raise AssertionError("Xcode Cloud dispatch must remain unreachable")
+
+        fake_client = FakeClient()
+        original_load_client = trigger.load_client
+        trigger.load_client = lambda: fake_client
+        try:
+            with self.assertRaisesRegex(ValueError, "DEFAULT_WEB_BROWSER"):
+                trigger.run(
+                    SimpleNamespace(
+                        authorize_mutation=True,
+                        expected_head="a" * 40,
+                        branch="main",
+                        source_tag=None,
+                        wait=False,
+                        workflow_id=WORKFLOW_ID,
+                        expected_workflow_name=WORKFLOW_NAME,
+                        expected_repository=REPOSITORY_URL,
+                        team_id="team-1",
+                        app_id=APP_ID,
+                        expected_bundle_id=BUNDLE_ID,
+                        expected_marketing_version="0.3.0",
+                        expected_platform="IOS",
+                        expected_min_os_version="18.4",
+                    )
+                )
+        finally:
+            trigger.load_client = original_load_client
+
+        self.assertEqual(fake_client.writes, [])
 
     def test_waited_run_returns_exact_source_bound_new_build_receipt(self):
         class FakeClient:
@@ -505,6 +749,12 @@ class TriggerContractTests(unittest.TestCase):
                         }],
                         "links": {"next": None},
                     }
+                if path.startswith("/v1/bundleIds?"):
+                    return bundle_ids_response()
+                if path.startswith(
+                    f"/v1/bundleIds/{BUNDLE_RESOURCE_ID}/bundleIdCapabilities?"
+                ):
+                    return capabilities_response()
                 if path == "/v1/ciBuildRuns/run-1?include=workflow":
                     return {
                         "data": {

--- a/scripts/release/trigger-xcode-cloud.py
+++ b/scripts/release/trigger-xcode-cloud.py
@@ -24,6 +24,8 @@ from typing import Any, Callable
 
 CLIENT_PATH = Path(__file__).with_name("app-store-connect-api.py")
 RECEIPT_PATH = Path(__file__).with_name("floorp_xcode_cloud_build_receipt.py")
+REQUIRED_SIGNING_CAPABILITY = "DEFAULT_WEB_BROWSER"
+IOS_BUNDLE_ID_PLATFORMS = {"IOS", "UNIVERSAL"}
 
 
 def load_client():
@@ -199,6 +201,71 @@ def resolve_tag(
     return resolve_source_reference(api, repository_id, tag, "tag")
 
 
+def verify_distribution_signing_capability(
+    api: Callable[..., dict[str, Any]], expected_bundle_id: str
+) -> dict[str, str]:
+    receipt_validator = load_receipt_validator()
+    identifier = urllib.parse.quote(expected_bundle_id, safe="")
+    bundle_response = api(
+        "GET",
+        "/v1/bundleIds"
+        f"?filter[identifier]={identifier}"
+        "&filter[platform]=IOS"
+        "&fields[bundleIds]=identifier,platform"
+        "&limit=200",
+    )
+    bundle_ids = receipt_validator.collection_rows(
+        bundle_response, "bundleIds", "Floorp distribution bundle ID"
+    )
+    if len(bundle_ids) != 1:
+        raise ValueError(
+            "expected exactly one registered iOS bundle ID for "
+            f"{expected_bundle_id!r}, found {len(bundle_ids)}"
+        )
+    bundle_id = bundle_ids[0]
+    attributes = bundle_id.get("attributes")
+    if not isinstance(attributes, dict):
+        raise ValueError("Floorp distribution bundle ID has no attributes")
+    if attributes.get("identifier") != expected_bundle_id:
+        raise ValueError("Floorp distribution bundle ID identifier does not match")
+    platform = attributes.get("platform")
+    if not isinstance(platform, str) or platform not in IOS_BUNDLE_ID_PLATFORMS:
+        raise ValueError("Floorp distribution bundle ID is not iOS-compatible")
+
+    bundle_resource_id = bundle_id["id"]
+    capability_response = api(
+        "GET",
+        f"/v1/bundleIds/{bundle_resource_id}/bundleIdCapabilities"
+        "?fields[bundleIdCapabilities]=capabilityType",
+    )
+    capabilities = receipt_validator.collection_rows(
+        capability_response,
+        "bundleIdCapabilities",
+        "Floorp distribution bundle ID capabilities",
+    )
+    matches = []
+    for capability in capabilities:
+        capability_attributes = capability.get("attributes")
+        if not isinstance(capability_attributes, dict):
+            raise ValueError("Floorp bundle ID capability has no attributes")
+        capability_type = capability_attributes.get("capabilityType")
+        if not isinstance(capability_type, str) or not capability_type:
+            raise ValueError("Floorp bundle ID capability type is invalid")
+        if capability_type == REQUIRED_SIGNING_CAPABILITY:
+            matches.append(capability)
+    if len(matches) != 1:
+        raise ValueError(
+            f"App ID {expected_bundle_id!r} must have exactly one enabled "
+            f"{REQUIRED_SIGNING_CAPABILITY} capability; found {len(matches)}"
+        )
+    return {
+        "bundle_id_resource_id": bundle_resource_id,
+        "bundle_id_platform": platform,
+        "capability_id": matches[0]["id"],
+        "capability_type": REQUIRED_SIGNING_CAPABILITY,
+    }
+
+
 def build_request(workflow_id: str, reference_id: str) -> dict[str, Any]:
     return {
         "data": {
@@ -289,6 +356,9 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
         f"/v1/ciWorkflows/{arguments.workflow_id}?include=product,repository"
     )
     prior_state = client.canonical_state_sha256(workflow_response)
+    signing_preflight = verify_distribution_signing_capability(
+        api, arguments.expected_bundle_id
+    )
     token = client.make_jwt(issuer_id, key_id, private_key, int(time.time()))
     start_response = client.guarded_write(
         "POST",
@@ -409,6 +479,7 @@ def run(arguments: argparse.Namespace) -> dict[str, Any]:
             "reference_id": reference_id,
             "expected_head": arguments.expected_head,
         },
+        "signing_preflight": signing_preflight,
         "run": final_resource,
         "receipt": receipt,
         "build_url": (


### PR DESCRIPTION
## Summary

- resolve the exact Floorp bundle ID immediately before Xcode Cloud dispatch
- require exactly one enabled `DEFAULT_WEB_BROWSER` capability before `POST /v1/ciBuildRuns`
- restrict the two new App Store Connect reads to exact sparse queries and never request provisioning-profile content
- document Xcode Cloud managed-profile behavior and the release preflight

## Why

The source-bound Floorp build reached archive but export failed because `app.floorp.Floorp` requests `com.apple.developer.web-browser` while the live App ID does not have `DEFAULT_WEB_BROWSER` enabled. This gate turns that late signing failure into a safe pre-dispatch failure.

## Test Plan

- `python3 -m unittest scripts.release.tests.test_app_store_connect_api scripts.release.tests.test_trigger_xcode_cloud` (62 tests)
- `python3 -m unittest discover -s scripts/release/tests -p 'test_*.py'` (224 tests)
- branding, Python syntax, and diff checks
- read-only live API probe confirms current state is rejected before any build mutation
