### PR TITLE
fix(release): take the cloud-archive build number from the exported IPA

### DIFF
--- a/scripts/release/collect-floorp-release-evidence.sh
+++ b/scripts/release/collect-floorp-release-evidence.sh
@@ -199,6 +199,7 @@ if [[ ! -f "$PLIST" || -L "$PLIST" ]]; then
 fi
 MARKETING_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$PLIST")"
 BUILD_NUMBER="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$PLIST")"
+ARCHIVE_BUILD_NUMBER="$BUILD_NUMBER"
 BUNDLE_ID="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$PLIST")"
 if ! ARCHIVE_SOURCE_SHA="$(
     /usr/libexec/PlistBuddy -c 'Print :MozFloorpSourceSHA' "$PLIST"
@@ -450,6 +451,11 @@ PYEOF
         echo "Could not read signed IPA entitlements: $IPA" >&2
         exit 2
     fi
+    if [[ "$CLOUD_ARCHIVE" -eq 1 ]]; then
+        # Xcode Cloud renumbers CFBundleVersion during the distribution export,
+        # so the exported IPA is authoritative for the release build number.
+        BUILD_NUMBER="$IPA_BUILD_NUMBER"
+    fi
 fi
 
 FINAL_ARCHIVE_SHA256="$(python3 "$SCRIPT_DIR/floorp_archive_tree.py" "$ARCHIVE")"
@@ -486,7 +492,8 @@ python3 - \
     "$EXPORT_STATUS" \
     "$ARCHIVE_ONLY" \
     "$IPA_MARKETING_VERSION" \
-    "$IPA_BUILD_NUMBER" <<'PYEOF'
+    "$IPA_BUILD_NUMBER" \
+    "$ARCHIVE_BUILD_NUMBER" <<'PYEOF'
 import json
 import os
 import sys
@@ -498,6 +505,7 @@ from pathlib import Path
     archive_team_id, archive, archive_sha256, ipa, ipa_sha256, signing_identity,
     entitlements_json, dsym_entries, asc_build_id, ci_run_url, xcresult_path,
     export_status, archive_only, ipa_marketing_version, ipa_build_number,
+    archive_build_number,
 ) = sys.argv[1:]
 
 is_archive_only = archive_only == "1"
@@ -517,7 +525,7 @@ evidence = {
     "signing_identity": signing_identity or None,
     "archive_info": {
         "marketing_version": marketing_version,
-        "build_number": build_number,
+        "build_number": archive_build_number,
         "bundle_id": bundle_id,
         "team_id": archive_team_id,
     },

--- a/scripts/release/validate-floorp-release-evidence.py
+++ b/scripts/release/validate-floorp-release-evidence.py
@@ -1443,10 +1443,11 @@ def validate_release_evidence(
         evidence["marketing_version"] == archive_info["marketing_version"],
         "marketing version differs from archive Info.plist",
     )
-    check(
-        evidence["build_number"] == archive_info["build_number"],
-        "build number differs from archive Info.plist",
-    )
+    if artifact_kind != "cloud-archive":
+        check(
+            evidence["build_number"] == archive_info["build_number"],
+            "build number differs from archive Info.plist",
+        )
     check(
         evidence["bundle_id"] == archive_info["bundle_id"],
         "bundle ID differs from archive Info.plist",
@@ -1481,10 +1482,19 @@ def validate_release_evidence(
             ipa_info["marketing_version"] == archive_info["marketing_version"],
             "mixed build IDs: IPA marketing version differs from archive",
         )
-        check(
-            ipa_info["build_number"] == archive_info["build_number"],
-            "mixed build IDs: IPA build number differs from archive",
-        )
+        if artifact_kind == "cloud-archive":
+            # Xcode Cloud renumbers CFBundleVersion during the distribution
+            # export, so the exported IPA is authoritative for the release
+            # build number while the archive keeps its pre-export value.
+            check(
+                evidence["build_number"] == ipa_info["build_number"],
+                "build number differs from the exported IPA",
+            )
+        else:
+            check(
+                ipa_info["build_number"] == archive_info["build_number"],
+                "mixed build IDs: IPA build number differs from archive",
+            )
 
     dsyms = evidence["dsym_inventory"]
     check(bool(dsyms), "dSYM inventory is empty")


### PR DESCRIPTION
## Problem

With the `cloud-archive` binding in place (PR #183), the deploy reached the evidence checks but was rejected:

```
REJECT: build number does not match its external expected value
Collected release evidence for 0.3.0 (4)
```

Xcode Cloud renumbers `CFBundleVersion` **during the distribution export**: build 111's `.xcarchive` carries `4` while the exported IPA and App Store Connect both report `111`. The collector recorded the archive value as the release build number, so it could never match the App Store Connect build number the bridge passes as expected.

## Fix

- The collector records the pre-export archive build number in `archive_info.build_number` and uses the exported IPA build number as the release `build_number`.
- The `cloud-archive` validator accepts the pre-export archive value in the archive metadata, requires the release build number to equal the exported IPA build number, and keeps the marketing-version agreement. local-export and archive-only evidence are unchanged.

## Verification

- `python3 -m unittest discover -s scripts/release/tests` -> 228 OK
- `python3 -m unittest discover -s scripts/ci/tests` -> 325 OK
- `bash -n` collector, workflow YAML parses, `git diff --check` clean
